### PR TITLE
Add flutter gitignore

### DIFF
--- a/flutter/.gitignore
+++ b/flutter/.gitignore
@@ -1,0 +1,2 @@
+.dart_tool
+lib/src/types.g.dart

--- a/flutter/.gitignore
+++ b/flutter/.gitignore
@@ -1,2 +1,3 @@
 .dart_tool
 lib/src/types.g.dart
+pubspec.lock


### PR DESCRIPTION
Hey,
I've just installed the flutter development on my machine. The first thing I noticed, was that lots of files were to be staged because the Flutter library does not have a `.gitignore` file. 

![Screenshot 2025-04-28 at 17 46 46](https://github.com/user-attachments/assets/f82e3ce0-07f5-4abf-9741-365e9344530b)

This PR adds a `.gitignore` file containing the automatically generated files/directories `lib/src/types.g.dart` and `.dart_tool`, as well as the `pubspec.lock` file, which is excluded from version control to provide flexibility to end-users of the library. The generated files are excluded, because they often cause merge conflicts and are usually not necessary in the source control.
