### PR TITLE
Added Galaxy S24+ token/sec score to benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Gemma 1B INT8:
 - iPhone 13 Pro: ~30 toks/sec 
 - Galaxy S21: ~14 toks/sec 
 - Google Pixel 6a: ~14 toks/sec 
+- Galaxy S24 plus: ~20 toks/sec 
 
 SmollLM 135m INT8: 
 - iPhone 13 Pro: ~180 toks/sec


### PR DESCRIPTION
Added benchmark results for the Galaxy S24+ (`~20 toks/sec`) to the README's benchmark section for "Gemma 1B INT8".

*Testing Details:*

- Ran the app on a Galaxy S24+.  
- Observed consistent performance of ~20 tokens/sec

