### PR TITLE
Update cpp.md to Reflect Correct CMake Build Path

### DIFF
--- a/docs/cpp.md
+++ b/docs/cpp.md
@@ -8,7 +8,7 @@ A GGML-based C++ library for running Large Language Models (LLMs) and Vision Lan
 
 ```bash
 git clone https://github.com/your-org/cactus.git
-cd cactus
+cd cactus/cactus
 mkdir build && cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release
 make -j$(nproc)


### PR DESCRIPTION
When git clone the repo, users need to `cd cactus/cactus` to build the C++ core library with CMake, since the **root cactus directory** does not contain any CMakeLists.txt file.