### PR TITLE
fix cpp path typos build errors

### DIFF
--- a/cpp/example/CMakeLists.txt
+++ b/cpp/example/CMakeLists.txt
@@ -13,7 +13,7 @@ include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-add_subdirectory(../../cactus ${CMAKE_BINARY_DIR}/cactus_core_build)
+add_subdirectory(../../cpp ${CMAKE_BINARY_DIR}/cactus_core_build)
 
 # Create separate executables for each example
 add_executable(cactus_vlm main_vlm.cpp)

--- a/cpp/example/build.sh
+++ b/cpp/example/build.sh
@@ -1,8 +1,10 @@
 mkdir -p build
 cd build
 cmake ..
+
+echo "Building the project..."
 make
 
-ln -sf ../../../cactus/ggml-llama.metallib default.metallib
+ln -sf ../../../cpp/ggml-llama.metallib default.metallib
 
 ./cactus_llm chat

--- a/cpp/example/main_conversation_ffi.cpp
+++ b/cpp/example/main_conversation_ffi.cpp
@@ -5,8 +5,8 @@
 #include <chrono>
 
 #include "utils.h"
-#include "../../cactus/cactus_ffi.h"
-#include "../../cactus/json.hpp"
+#include "../../cpp/cactus_ffi.h"
+#include "../../cpp/json.hpp"
 using json = nlohmann::ordered_json;
 
 std::chrono::high_resolution_clock::time_point first_token_time;

--- a/cpp/example/main_embed.cpp
+++ b/cpp/example/main_embed.cpp
@@ -7,7 +7,7 @@
 #include <algorithm>
 
 #include "utils.h"
-#include "../../cactus/cactus.h"
+#include "../../cpp/cactus.h"
 
 float cosineSimilarity(const std::vector<float>& a, const std::vector<float>& b) {
     if (a.size() != b.size()) {

--- a/cpp/example/main_llm.cpp
+++ b/cpp/example/main_llm.cpp
@@ -10,10 +10,10 @@
 #include <iomanip>
 
 #include "utils.h"
-#include "../../cactus/cactus.h"
+#include "../../cpp/cactus.h"
 
 // Include nlohmann json for proper JSON handling
-#include "../../cactus/json.hpp"
+#include "../../cpp/json.hpp"
 using json = nlohmann::ordered_json;
 
 struct GenerationResult {

--- a/cpp/example/main_tts.cpp
+++ b/cpp/example/main_tts.cpp
@@ -8,7 +8,7 @@
 #include <thread>
 
 #include "utils.h"
-#include "../../cactus/cactus.h"
+#include "../../cpp/cactus.h"
 
 void writeWavFile(const std::string& filename, const std::vector<float>& audio_data, int sample_rate = 24000) {
     std::ofstream file(filename, std::ios::binary);

--- a/cpp/example/main_vlm.cpp
+++ b/cpp/example/main_vlm.cpp
@@ -5,7 +5,7 @@
 #include <ctime>
 
 #include "utils.h"
-#include "../../cactus/cactus.h"
+#include "../../cpp/cactus.h"
 
 int main(int argc, char **argv) {
     const std::string model_filename = "SmolVLM-256M.gguf";

--- a/cpp/example/main_vlm_ffi.cpp
+++ b/cpp/example/main_vlm_ffi.cpp
@@ -5,7 +5,7 @@
 #include <ctime>
 
 #include "utils.h"
-#include "../../cactus/cactus_ffi.h"
+#include "../../cpp/cactus_ffi.h"
 
 bool prompt_and_respond_ffi(cactus_context_handle_t handle, const std::string& prompt, const std::vector<std::string>& media_paths = {}, int max_tokens = 50) {
     std::cout << "\n" << std::string(80, '=') << std::endl;


### PR DESCRIPTION
Fixes a few typos in file path for includes (possibly due to recent code reorg) that lead to build errors. The cpp examples now build and run as intended (tested on M4 Mac, Sequoia 15.5)