### PR TITLE
Fix Flutter Documentation

### DIFF
--- a/flutter/README.md
+++ b/flutter/README.md
@@ -137,6 +137,8 @@ class _ChatScreenState extends State<ChatScreen> {
   }
 }
 
+```
+
 ## Core APIs
 
 ### CactusLM (Language Model)


### PR DESCRIPTION
This PR fixes a simple code formatting bug in the flutter library docs. This error was caused by missing backticks. 

### Before

<img width="602" height="732" alt="image" src="https://github.com/user-attachments/assets/1300ea1a-244b-4054-a609-0ea598a280d2" />


### After

<img width="602" height="732" alt="image" src="https://github.com/user-attachments/assets/383a7d5a-530b-4c28-9a43-bb7c0587833b" />
