### PR TITLE
tests: align qwen int8 weights path

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Use any of the (270m, 350m, 360m, 600m, 750m, 1B, 1.2B, 1.7B activated params):
 python3 tools/convert_hf.py google/gemma-3-270m-it weights/gemma3-270m/ --precision INT8
 python3 tools/convert_hf.py LiquidAI/LFM2-350M weights/lfm2-350m/ --precision INT8
 python3 tools/convert_hf.py HuggingFaceTB/SmolLM2-360m-Instruct weights/smollm2-360m/ --precision INT8
-python3 tools/convert_hf.py Qwen/Qwen3-0.6B weights/qwen3-600m/ --precision INT8 
+python3 tools/convert_hf.py Qwen/Qwen3-0.6B weights/qwen3-600m-i8/ --precision INT8
 python3 tools/convert_hf.py LiquidAI/LFM2-700M weights/lfm2-700m/ --precision INT8
 python3 tools/convert_hf.py google/gemma-3-1b-it weights/gemma3-1b/ --precision INT8
 python3 tools/convert_hf.py LiquidAI/LFM2-1.2B weights/lfm2-1.2B/ --precision INT8

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -6,23 +6,23 @@ echo "============================"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 
-WEIGHTS_DIR="$PROJECT_ROOT/weights/qwen3-600m"
+WEIGHTS_DIR="$PROJECT_ROOT/weights/qwen3-600m-i8"
 if [ ! -d "$WEIGHTS_DIR" ] || [ ! -f "$WEIGHTS_DIR/config.txt" ]; then
     echo ""
     echo "Qwen weights not found. Generating weights..."
     echo "============================================="
     cd "$PROJECT_ROOT"
     if command -v python3 &> /dev/null; then
-        echo "Running: python3 tools/convert_hf.py Qwen/Qwen3-0.6B weights/qwen3-600m/ --precision INT8"
-        if python3 tools/convert_hf.py Qwen/Qwen3-0.6B weights/qwen3-600m/ --precision INT8; then
+        echo "Running: python3 tools/convert_hf.py Qwen/Qwen3-0.6B weights/qwen3-600m-i8/ --precision INT8"
+        if python3 tools/convert_hf.py Qwen/Qwen3-0.6B weights/qwen3-600m-i8/ --precision INT8; then
             echo "Successfully generated Qwen weights"
         else
             echo "Warning: Failed to generate Qwen weights. Tests may fail."
-            echo "Please run manually: python3 tools/convert_hf.py Qwen/Qwen3-0.6B weights/qwen3-600m/ --precision INT8"
+            echo "Please run manually: python3 tools/convert_hf.py Qwen/Qwen3-0.6B weights/qwen3-600m-i8/ --precision INT8"
         fi
     else
         echo "Warning: Python3 not found. Cannot generate weights automatically."
-        echo "Please run manually: python3 tools/convert_hf.py Qwen/Qwen3-0.6B weights/qwen3-600m/ --precision INT8"
+        echo "Please run manually: python3 tools/convert_hf.py Qwen/Qwen3-0.6B weights/qwen3-600m-i8/ --precision INT8"
     fi
 else
     echo ""

--- a/tests/test_engine.cpp
+++ b/tests/test_engine.cpp
@@ -8,7 +8,7 @@
 #include <thread>
 #include <atomic>
 
-const char* g_model_path = "../../weights/qwen3-600m";
+const char* g_model_path = "../../weights/qwen3-600m-i8";
 
 const char* g_options = R"({
         "max_tokens": 256,


### PR DESCRIPTION
## Summary
- update the C++ test harness
- adjust the test runner to generate weights in the same directory
- sync the README instructions so documentation matches the tooling

Fixes #189