### PR TITLE
Implement FP16 sum reduction operation

### DIFF
--- a/cactus/graph/graph_ops.cpp
+++ b/cactus/graph/graph_ops.cpp
@@ -61,7 +61,8 @@ void compute_reduce_node(GraphNode& node, const std::vector<std::unique_ptr<Grap
                     int64_t result = cactus_sum_all_int8(input_buffer.data_as<int8_t>(), input_buffer.total_size);
                     node.output_buffer.data_as<int8_t>()[0] = static_cast<int8_t>(std::max(static_cast<int64_t>(-128), std::min(static_cast<int64_t>(127), result)));
                 } else if (input_buffer.precision == Precision::FP16) {
-                    throw std::runtime_error("FP16 sum not yet implemented");
+                    double result = cactus_sum_all_f16(input_buffer.data_as<__fp16>(), input_buffer.total_size);
+                    node.output_buffer.data_as<__fp16>()[0] = static_cast<__fp16>(result);
                 } else {
                     double result = cactus_sum_all_f32(input_buffer.data_as<float>(), input_buffer.total_size);
                     node.output_buffer.data_as<float>()[0] = static_cast<float>(result);

--- a/cactus/kernel/kernel.h
+++ b/cactus/kernel/kernel.h
@@ -118,6 +118,7 @@ void cactus_transpose_f32(const float* source, float* destination, const size_t*
 
 int64_t cactus_sum_all_int8(const int8_t* data, size_t num_elements);
 void cactus_sum_axis_int8(const int8_t* input, int8_t* output, size_t outer_size, size_t axis_size, size_t inner_size);
+double cactus_sum_all_f16(const __fp16* data, size_t num_elements);
 double cactus_sum_all_f32(const float* data, size_t num_elements);
 void cactus_sum_axis_f32(const float* input, float* output, size_t outer_size, size_t axis_size, size_t inner_size);
 

--- a/cactus/kernel/kernel_reduce.cpp
+++ b/cactus/kernel/kernel_reduce.cpp
@@ -511,7 +511,7 @@ void cactus_sum_axis_f32(const float* input, float* output, size_t outer_size, s
         });
 }
 
-double cactus_mean_all_f16(const __fp16* data, size_t num_elements) {
+double cactus_sum_all_f16(const __fp16* data, size_t num_elements) {
     return CactusThreading::parallel_reduce(
         num_elements, CactusThreading::Thresholds::ALL_REDUCE,
         [&](size_t start_idx, size_t end_idx) -> double {
@@ -540,7 +540,12 @@ double cactus_mean_all_f16(const __fp16* data, size_t num_elements) {
         },
         0.0,
         [](double a, double b) { return a + b; }
-    ) / static_cast<double>(num_elements);
+    );
+}
+
+double cactus_mean_all_f16(const __fp16* data, size_t num_elements) {
+    double sum = cactus_sum_all_f16(data, num_elements);
+    return sum / static_cast<double>(num_elements);
 }
 
 void cactus_mean_axis_f16(const __fp16* input, __fp16* output, size_t outer_size, size_t axis_size, size_t inner_size) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,7 +47,7 @@ else()
     message(STATUS "SDL2 not found; microphone tests will be skipped")
 endif()
 
-file(GLOB TEST_SOURCES "test_en*.cpp")
+file(GLOB TEST_SOURCES "test_*.cpp")
 list(REMOVE_ITEM TEST_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/test_utils.cpp")
 
 foreach(TEST_FILE ${TEST_SOURCES})

--- a/tests/test_graph.cpp
+++ b/tests/test_graph.cpp
@@ -242,6 +242,26 @@ bool test_reduction_operations() {
            fixture.verify_output(sum_axis1, {6, 15});
 }
 
+bool test_fp16_reduction_operations() {
+    CactusGraph graph;
+    
+    size_t input_a = graph.input({2, 3}, Precision::FP16);
+    size_t sum_all = graph.sum(input_a, -1);
+    
+    std::vector<__fp16> input_data = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+    graph.set_input(input_a, input_data.data(), Precision::FP16);
+    graph.execute();
+    
+    __fp16* output = static_cast<__fp16*>(graph.get_output(sum_all));
+    double result = static_cast<double>(output[0]);
+    double expected = 21.0;
+    
+    bool success = std::abs(result - expected) < 0.1f; // FP16 has lower precision
+    
+    graph.hard_reset();
+    return success;
+}
+
 bool test_mean_operations() {
     TestUtils::Int8TestFixture fixture("Mean Operations");
     
@@ -779,6 +799,7 @@ int main() {
     runner.run_test("Scalar Subtract/Divide", test_scalar_subtract_divide());
     runner.run_test("Scalar Math Functions", test_scalar_math_functions());
     runner.run_test("Reduction Operations", test_reduction_operations());
+    runner.run_test("FP16 Reduction Operations", test_fp16_reduction_operations());
     runner.run_test("Mean Operations", test_mean_operations());
     runner.run_test("Variance Operations", test_variance_operations());
     runner.run_test("Min/Max Operations", test_min_max_operations());

--- a/tests/test_kernel.cpp
+++ b/tests/test_kernel.cpp
@@ -97,6 +97,7 @@ bool test_neon_matrix_multiply_correctness() {
 }
 
 bool test_neon_reduction_correctness() {
+    // Test INT8 sum
     std::vector<int8_t> input = {1, 2, 3, 4, 5, 6, 7, 8};
     
     int64_t sum_result = cactus_sum_all_int8(input.data(), input.size());
@@ -110,6 +111,23 @@ bool test_neon_reduction_correctness() {
     double expected_mean = 4.5; 
     
     if (std::abs(mean_result - expected_mean) > 1e-6) {
+        return false;
+    }
+    
+    // Test FP16 sum
+    std::vector<__fp16> input_f16 = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f};
+    double sum_result_f16 = cactus_sum_all_f16(input_f16.data(), input_f16.size());
+    double expected_sum_f16 = 36.0;
+    
+    if (std::abs(sum_result_f16 - expected_sum_f16) > 1e-3) {
+        return false;
+    }
+    
+    // Test FP16 mean (which uses sum internally)
+    double mean_result_f16 = cactus_mean_all_f16(input_f16.data(), input_f16.size());
+    double expected_mean_f16 = 4.5;
+    
+    if (std::abs(mean_result_f16 - expected_mean_f16) > 1e-3) {
         return false;
     }
     


### PR DESCRIPTION
## Description
Implements FP16 sum reduction operation that was previously throwing "not yet implemented" errors. The implementation uses ARM NEON SIMD optimization with parallel reduction for multi-threaded performance.

## Type of Change
- [x] New feature
- [x] Bug fix (fixes missing implementation)

## Changes Made
- Added `cactus_sum_all_f16()` function in `kernel_reduce.cpp` with ARM NEON SIMD optimization
- Updated `cactus_mean_all_f16()` to use the new sum function for consistency
- Replaced runtime error in `graph_ops.cpp` with working implementation
- Added comprehensive tests for FP16 sum in both kernel and graph test suites
- Fixed CMakeLists.txt to build all test executables (was only building test_en*.cpp)

## Testing
- [x] Tests pass locally
- [x] Tested on ARM hardware (Apple Silicon)
- [x] Verified FP16 sum works correctly through graph API
- [x] Verified FP16 sum works correctly at kernel level
- [x] All existing tests still pass

## Performance
The implementation follows the same optimized pattern as FP32 sum:
- Uses ARM NEON SIMD with `float16x8_t` vectors (8 elements per vector)
- Parallel reduction for multi-threaded performance
- Consistent with existing INT8 and FP32 implementations

## Checklist
- [x] All commits are signed-off (DCO)
- [x] Code follows project style
- [x] Comments added where necessary
- [x] Tests added for new functionality