### PR TITLE
Refactor tool formatting in tokenizer and utils

### DIFF
--- a/cactus/engine/engine_tokenizer.cpp
+++ b/cactus/engine/engine_tokenizer.cpp
@@ -114,13 +114,16 @@ std::string Tokenizer::format_qwen_style(const std::vector<ChatMessage>& message
             }
         }
 
-        result += "You have access to the following tools:\n";
-        result += "[\n";
+        result += "# Tools\n\n";
+        result += "You may call one or more functions to assist with the user query.\n\n";
+        result += "You are provided with function signatures within <tools></tools> XML tags:\n";
+        result += "<tools>\n";
         result += tools_json;
-        result += "\n]\n\n";
-        result += "When you need to call a tool, respond with a JSON object in this exact format:\n";
-        result += "{\"function_call\": {\"name\": \"function_name\", \"arguments\": {\"arg1\": \"value1\"}}}\n";
-        result += "You can call multiple tools by using multiple function_call JSON objects.";
+        result += "\n</tools>\n\n";
+        result += "For each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\n";
+        result += "<tool_call>\n";
+        result += "{\"name\": <function-name>, \"arguments\": <args-json-object>}\n";
+        result += "</tool_call>";
         result += "<|im_end|>\n";
 
         for (const auto& msg : messages) {

--- a/cactus/ffi/cactus_utils.h
+++ b/cactus/ffi/cactus_utils.h
@@ -284,7 +284,7 @@ inline std::string format_tools_for_prompt(const std::vector<ToolFunction>& tool
     if (tools.empty()) return "";
     std::string formatted_tools_json;
     for (size_t i = 0; i < tools.size(); i++) {
-        if (i > 0) formatted_tools_json += ",\n";
+        if (i > 0) formatted_tools_json += "\n";
         formatted_tools_json += "{\"type\":\"function\",\"function\":{\"name\":\""
                               + tools[i].name
                               + "\",\"description\":\""


### PR DESCRIPTION
- Updated the format of tool descriptions in the Tokenizer class to use XML tags to match official Qwen docs and training data.
- Changed the JSON formatting in cactus_utils.h to match Qwen official training data.

These changes massively improve tool calling performance in my benchmarks.