### PR TITLE
docs: Add Rust SDK to community bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Example response from Gemma3-270m-INT8
 - [Flutter SDK](https://github.com/cactus-compute/cactus-flutter)
 - [React Native SDK](https://github.com/cactus-compute/cactus-react-native)
 - [Swift SDK](https://github.com/mhayes853/swift-cactus)
+- [Rust SDK](https://github.com/mrsarac/cactus-rs)
 
 ## Try demo apps
 


### PR DESCRIPTION
## Summary

Adds [cactus-rs](https://github.com/mrsarac/cactus-rs) to the SDK list in README.

## What is cactus-rs?

Safe, idiomatic Rust bindings for Cactus with:

- 🚀 LLM chat completion (sync + streaming)
- 🎤 Whisper audio transcription
- 🧮 Text/image/audio embeddings
- 🔍 Vector index for semantic search
- ⚡ Metal GPU acceleration

## Usage

```toml
[dependencies]
cactus = { git = "https://github.com/mrsarac/cactus-rs" }
```

```rust
use cactus::{Model, Message, GenerateOptions};

let model = Model::from_gguf("path/to/model")?;
let messages = vec![Message::user("Hello!")];
let response = model.complete(&messages, GenerateOptions::default())?;
```

Related issue: #269