### PR TITLE
fix: resolve completionWithTools type casting crash

### DIFF
--- a/cactus/ffi/cactus_utils.h
+++ b/cactus/ffi/cactus_utils.h
@@ -434,10 +434,10 @@ inline void parse_function_calls_from_response(const std::string& response_text,
 
     while ((tool_start_pos = regular_response.find(TOOL_CALL_START, tool_start_pos)) != std::string::npos) {
         size_t content_start = tool_start_pos + TOOL_CALL_START.length();
-        size_t tool_end_pos = response_text.find(TOOL_CALL_END, content_start);
+        size_t tool_end_pos = regular_response.find(TOOL_CALL_END, content_start);
 
         if (tool_end_pos != std::string::npos) {
-            std::string tool_content = response_text.substr(content_start, tool_end_pos - content_start);
+            std::string tool_content = regular_response.substr(content_start, tool_end_pos - content_start);
 
             if (tool_content.size() > 2 && tool_content[0] == '[' && tool_content[tool_content.size()-1] == ']') {
                 tool_content = tool_content.substr(1, tool_content.size() - 2); 
@@ -495,7 +495,8 @@ inline void parse_function_calls_from_response(const std::string& response_text,
             }
 
             regular_response.erase(tool_start_pos, tool_end_pos + TOOL_CALL_END.length() - tool_start_pos);
-            tool_start_pos = tool_end_pos + TOOL_CALL_END.length();
+            // Don't advance tool_start_pos after erase - the string has shifted
+            // and the next tool call (if any) will now be at tool_start_pos
         } else {
             break;
         }

--- a/flutter/cactus.dart
+++ b/flutter/cactus.dart
@@ -452,11 +452,23 @@ class CompletionResult {
   });
 
   factory CompletionResult.fromJson(Map<String, dynamic> json) {
+    List<Map<String, dynamic>>? parsedFunctionCalls;
+    if (json['function_calls'] != null && json['function_calls'] is List) {
+      try {
+        parsedFunctionCalls = (json['function_calls'] as List)
+            .whereType<Map<String, dynamic>>()
+            .toList();
+        if (parsedFunctionCalls.isEmpty) {
+          parsedFunctionCalls = null;
+        }
+      } catch (_) {
+        parsedFunctionCalls = null;
+      }
+    }
+
     return CompletionResult(
-      text: json['text'] ?? '',
-      functionCalls: json['function_calls'] != null
-          ? List<Map<String, dynamic>>.from(json['function_calls'])
-          : null,
+      text: json['text'] ?? json['response'] ?? '',
+      functionCalls: parsedFunctionCalls,
       promptTokens: json['prompt_tokens'] ?? 0,
       completionTokens: json['completion_tokens'] ?? 0,
       timeToFirstToken: (json['time_to_first_token'] ?? 0.0).toDouble(),


### PR DESCRIPTION
## Description
Fixes the `completionWithTools` crash reported in #135 where users experienced type casting errors and "toDartString on nullptr" when using function/tool calling in Flutter.

## Root Cause
Two bugs in LFM2-style function call parsing in `cactus_utils.h`:

1. **Wrong variable used for string operations** - The parser used `response_text` (original, unmodified input) instead of `regular_response` (working copy) for `find()` and `substr()`. When previous parsers (Gemma, Qwen) had already modified the working string, position indices became mismatched, producing corrupted JSON.

2. **Incorrect loop position advancement** - After erasing parsed content, the loop advanced past the erased position using an invalidated index, potentially skipping subsequent tool calls.

## Changes
- `cactus/ffi/cactus_utils.h`: Fixed variable references in LFM2 parsing (lines 437, 440) and removed incorrect position advancement after erase
- `flutter/cactus.dart`: Added defensive parsing in `CompletionResult.fromJson()` using `whereType<>()` to gracefully handle malformed function_calls arrays

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation update

## Testing
- [x] Tests pass locally (all 53+ C++ tests: kernel, kv_cache, index, threading, engine, graph)
- [x] Tested on ARM hardware (Apple Silicon)
- [ ] Benchmarked performance impact (N/A - bug fix only)

## Checklist
- [x] All commits are signed-off (DCO)
- [x] Code follows project style
- [x] Comments added where necessary
- [ ] Documentation updated if needed (N/A)

Fixes #135