### PR TITLE
Stop generation on model end token

### DIFF
--- a/cactus/engine/engine.h
+++ b/cactus/engine/engine.h
@@ -152,6 +152,7 @@ public:
     virtual uint32_t get_bos_token() const = 0;
     virtual uint32_t get_eos_token() const = 0;
     virtual bool has_chat_template() const { return has_chat_template_; }
+    std::string get_default_stop_sequence() const;
 
     virtual bool load_vocabulary_with_config(const std::string& vocab_file, const std::string& merges_file, const std::string& config_file) = 0;
     

--- a/cactus/engine/engine_tokenizer.cpp
+++ b/cactus/engine/engine_tokenizer.cpp
@@ -66,6 +66,19 @@ void Tokenizer::detect_model_type(const std::string& config_path) {
     file.close();
 }
 
+std::string Tokenizer::get_default_stop_sequence() const {
+    switch (model_type_) {
+        case ModelType::GEMMA:
+            return "<end_of_turn>";
+        case ModelType::QWEN:
+        case ModelType::LFM2:
+        case ModelType::SMOL:
+            return "<|im_end|>";
+        default:
+            return "<|im_end|>";
+    }
+}
+
 std::vector<uint32_t> Tokenizer::apply_chat_template(const std::vector<ChatMessage>& messages, bool add_generation_prompt) const {
     std::string formatted_prompt = format_chat_prompt(messages, add_generation_prompt);
     return encode(formatted_prompt);

--- a/cactus/ffi/cactus_transcribe.cpp
+++ b/cactus/ffi/cactus_transcribe.cpp
@@ -150,8 +150,8 @@ int cactus_transcribe(
         float temperature, top_p, confidence_threshold;
         size_t top_k, max_tokens, tool_rag_top_k;
         std::vector<std::string> stop_sequences;
-        bool force_tools;
-        parse_options_json(options_json ? options_json : "", temperature, top_p, top_k, max_tokens, stop_sequences, force_tools, tool_rag_top_k, confidence_threshold);
+        bool force_tools, include_stop_sequences;
+        parse_options_json(options_json ? options_json : "", temperature, top_p, top_k, max_tokens, stop_sequences, force_tools, tool_rag_top_k, confidence_threshold, include_stop_sequences);
 
         std::vector<float> mel_bins;
         if (audio_file_path == nullptr) {

--- a/cactus/ffi/cactus_utils.h
+++ b/cactus/ffi/cactus_utils.h
@@ -299,7 +299,8 @@ inline void parse_options_json(const std::string& json,
                                std::vector<std::string>& stop_sequences,
                                bool& force_tools,
                                size_t& tool_rag_top_k,
-                               float& confidence_threshold) {
+                               float& confidence_threshold,
+                               bool& include_stop_sequences) {
     temperature = 0.0f;
     top_p = 0.0f;
     top_k = 0;
@@ -307,6 +308,7 @@ inline void parse_options_json(const std::string& json,
     force_tools = false;
     tool_rag_top_k = 2;  // 0 = disabled, N = select top N relevant tools
     confidence_threshold = 0.7f;  // trigger cloud handoff when confidence < this value
+    include_stop_sequences = false;
     stop_sequences.clear();
 
     if (json.empty()) return;
@@ -352,6 +354,13 @@ inline void parse_options_json(const std::string& json,
     if (pos != std::string::npos) {
         pos = json.find(':', pos) + 1;
         confidence_threshold = std::stof(json.substr(pos));
+    }
+
+    pos = json.find("\"include_stop_sequences\"");
+    if (pos != std::string::npos) {
+        pos = json.find(':', pos) + 1;
+        while (pos < json.length() && std::isspace(json[pos])) pos++;
+        include_stop_sequences = (json.substr(pos, 4) == "true");
     }
 
     pos = json.find("\"stop_sequences\"");

--- a/python/README.md
+++ b/python/README.md
@@ -61,6 +61,7 @@ Run chat completion. Returns JSON string with response and metrics.
 | `top_k` | `int` | Top-k sampling |
 | `max_tokens` | `int` | Maximum tokens to generate |
 | `stop_sequences` | `list` | Stop sequences |
+| `include_stop_sequences` | `bool` | Include matched stop sequences in output (default: `False`) |
 | `force_tools` | `bool` | Constrain output to tool call format |
 | `tool_rag_top_k` | `int` | Select top-k relevant tools via Tool RAG (default: 2, 0 = use all tools) |
 | `confidence_threshold` | `float` | Minimum confidence for local generation (default: 0.7, triggers cloud_handoff when below) |

--- a/python/src/cactus.py
+++ b/python/src/cactus.py
@@ -218,6 +218,7 @@ def cactus_complete(
     top_k=None,
     max_tokens=None,
     stop_sequences=None,
+    include_stop_sequences=None,
     force_tools=False,
     tool_rag_top_k=None,
     confidence_threshold=None,
@@ -235,6 +236,7 @@ def cactus_complete(
         top_k: Top-k sampling
         max_tokens: Maximum tokens to generate
         stop_sequences: List of stop sequences
+        include_stop_sequences: Include matched stop sequences in output (default: False)
         force_tools: Constrain output to tool call format
         tool_rag_top_k: Select top-k relevant tools via Tool RAG (default: 2, 0 = disabled)
         confidence_threshold: Minimum confidence for local generation (default: 0.7, triggers cloud_handoff when below)
@@ -285,6 +287,8 @@ def cactus_complete(
         options["max_tokens"] = max_tokens
     if stop_sequences is not None:
         options["stop_sequences"] = stop_sequences
+    if include_stop_sequences is not None:
+        options["include_stop_sequences"] = include_stop_sequences
     if force_tools:
         options["force_tools"] = True
     if tool_rag_top_k is not None:


### PR DESCRIPTION
## Description
Ensures models stop generating once their end-of-turn token is reached. This prevents cases where models emit a stop token but continue generating additional text afterward. The stop token is suppressed from the final output by default, while still allowing users to override stopping behavior via custom stop words if needed.

## Type of Change
- [X] Bug fix
- [X] New feature
- [ ] Performance improvement
- [ ] Documentation update

## Testing
- [ ] Tests pass locally (VLM MULTI-TURN TEST fails with & without changes)
- [X] Tested on ARM hardware
- [ ] Benchmarked performance impact

## Checklist
- [X] All commits are signed-off (DCO)
- [X] Code follows project style
- [X] Comments added where necessary
- [X] Documentation updated if needed