### PR TITLE
Improve error handling in BPE tokenizer

### DIFF
--- a/cactus/engine/engine_bpe.cpp
+++ b/cactus/engine/engine_bpe.cpp
@@ -210,14 +210,14 @@ bool BPETokenizer::load_vocabulary_with_config(const std::string& vocab_file, co
                         uint32_t token_id = static_cast<uint32_t>(std::stoul(id_str));
                         special_tokens_[token_content] = token_id;
                     } catch (...) {
-                        
+                        std::cerr << "Warning: Failed to parse token ID '" << id_str << "' for special token '" << token_content << "'" << std::endl;
                     }
                 }
                 pos = cont_quote2 + 1;
             }
         }
     } catch (...) {
-        
+        std::cerr << "Warning: Failed to parse tokenizer.json for special tokens" << std::endl;
     }
 
     std::string template_path = dir + "/chat_template.jinja2";


### PR DESCRIPTION
## Description
Adds descriptive error logging to empty catch blocks in the BPE tokenizer (`engine_bpe.cpp`). Previously, parsing errors in `tokenizer.json` were silently ignored, making it difficult to diagnose issues with malformed tokenizer configurations.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Documentation update

## Changes
- Add warning message when token ID parsing fails, including details about which token caused the failure
- Add warning message when general `tokenizer.json` parsing fails
- Follows existing error handling pattern in the engine layer using `std::cerr` for non-fatal warnings

## Testing
- [x] Tests pass locally
- [ ] Tested on ARM hardware (low-risk change - error path only)
- [x] Benchmarked performance impact (none - only affects error paths)

## Checklist
- [x] All commits are signed-off (DCO)
- [x] Code follows project style
- [x] Comments added where necessary
- [ ] Documentation updated if needed (not applicable)