### PR TITLE
Add Raspberry Pi 5 benchmark (LFM-450M)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ graph.hard_reset();
 | Galaxy A56 | - | - | - |
 | Pixel 6a | 218/44 tps | 2.5s & 36 tps | 1.5s & 189 tps |
 | Nothing CMF | - | - | - |
-| Raspberry Pi 5 | - | 17 tps | - |
+| Raspberry Pi 5 | - | 0.23 & 17 tps | - |
 
  ## Supported Models                                                                                                                                                     
                                                                                                                                                                           


### PR DESCRIPTION
### Benchmark Results for Raspberry Pi 5

I've added the benchmark results for the **LFM-VL-450M** model.

- **LFM-VL-450M:** 17 tps (Success)
- **LFM-350M:** Failed (Device shutdown/rebooted during test due to power/thermal limits)
- **Moonshine:** Failed (Download error: `pytorch_model.bin` not found)