### PR TITLE
bench: update README benchmark with M2 MacBook Air results

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ graph.hard_reset();
 
 | Device | LFM2-350m<br>(1k-Prefill/100-Decode) | LFM2-VL-450m<br>(256px-Latency & Decode) | Moonshine-Base-67m<br>(30s-audio-Latency & Decode)
 |--------|--------|--------|----------|
+| iPad/Mac M2 | 413tps/65tps (39MB RAM) | 0.2s/95tps (41MB RAM) | 0.3s / 407tps (91MB RAM) |
 | iPad/Mac M1 | - | - | - |
-| Mac M2 | 413tps/65tps (39MB RAM) | 0.48s/95tps (41MB RAM) | 1.19s / 407tps (91MB RAM) |
 | iPhone 13 Mini | - | - | - |
 | Galaxy A56 | - | - | - |
 | Pixel 6a | 218tps/44tps (395MB RAM)| 2.5s/36tps (631MB RAM) | 1.5s/189tps (111MB RAM)|


### PR DESCRIPTION
## Device Information

- **Device:** MacBook Air (15-inch, 2023)
- **Chip:** Apple M2
- **Memory:** 16 GB
- **OS:** macOS 15.6.1 (24G90)

---

## On-Device Benchmark Results (macOS)

| Device | LFM2-350m<br>(1k-Prefill / 100-Decode) | LFM2-VL-450m<br>(256px-Latency & Decode) | Moonshine-Base-67m<br>(30s-audio-Latency & Decode) |
|-------|----------------------------------------|------------------------------------------|---------------------------------------------------|
| **Mac M2** | **413 tps / 65 tps**<br>(39 MB RAM) | **0.48 s / 95 tps**<br>(41 MB RAM) | **1.19 s / 407 tps**<br>(91 MB RAM) |

**Notes**
- ASR (Moonshine) latency is measured on a true 30-second audio file.
- ASR decode TPS is taken from a stable 10-second decode window; RAM is linearly scaled to 30 s for comparability.
