### PR TITLE
M4airbenchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ graph.hard_reset();
 | Device | LFM2.5-1.2B<br>(1k-Prefill/100-Decode) | LFM2.5-VL-1.6B<br>(256px-Latency & Decode) | Whisper-Small-244m<br>(30s-audio-Latency & Decode)
 |--------|--------|--------|----------|
 | Mac M4 Pro | 582tps/77tps (76MB RAM) | 0.2s/76tps (87MB RAM) | 0.1s/119tps (73MB RAM) |
-| iPad/Mac M4 Air | 379tps/46tps (30MB RAM) | 1.47s/46tps (53MB RAM) | 1.21s/100tp (122MB RAM) |
+| iPad/Mac M4 | 379tps/46tps (30MB RAM) | 0.2s/46tps (53MB RAM) | 0.2s/100tp (122MB RAM) |
 | iPhone 17 Pro | 300tps/33tps (108MB RAM)| 0.3s/33tps (156MB RAM) | 0.3s/114tps (177MB RAM)|
 | Galaxy S25 Ultra | 226tps/36tps (1.2GB RAM) | 2.6s/33tps (2GB RAM) | 2.3s/90tps (363MB RAM) |
 | Pixel 10 Pro | - | - | - |


### PR DESCRIPTION
Added benchmarks for the following device:

Device: MacBook Air (13-inch, 2025)
Chip: Apple M4
Memory: 16 GB
