### PR TITLE
docs: update cactus test command description for transcribe models (#297)

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ git clone https://github.com/cactus-compute/cactus && cd cactus && source ./setu
 | `cactus download [model]` | Downloads model to `./weights` |
 | `cactus convert [model] [dir]` | Converts model, supports LoRA merging (`--lora <path>`) |
 | `cactus build` | Builds for ARM (`--apple` or `--android`) |
-| `cactus test` | Runs tests (`--ios` / `--android`, `--model [name/path]`), `--precision` |
+| `cactus test` | Runs tests (`--ios` / `--android`, `--model [name/path]`, `--transcribe_model [name/path]`), `--precision` |
 | `cactus transcribe [model]` | Transcribe audio file (`--file`) or live microphone |
 | `cactus clean` | Removes build artifacts |
 | `cactus --help` | Shows all commands and flags (always run this) |


### PR DESCRIPTION
Updated the `cactus test` command description in the `README.md` file to include `--transcribe_model` for greater clarity on how to select transcribe models when testing.