### PR TITLE
docs: Benchmark M1 and iPhone 16 (#296)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,9 @@ graph.hard_reset();
 | Device | LFM2-350m<br>(1k-Prefill/100-Decode) | LFM2-VL-450m<br>(256px-Latency & Decode) | Moonshine-Base-67m<br>(30s-audio-Latency & Decode)
 |--------|--------|--------|----------|
 | iPad/Mac M2 | 998tps/101tps (334MB RAM) | 0.2s/109tps (146MB RAM) | 0.3s/395tps (201MB RAM) |
-| iPad/Mac M1 | - | - | - |
-| iPhone 16 | 764tps/93tps (329MB RAM) | 0.4s/73tps (308MB RAM) | 0.7s/65tps (329MB RAM) |
+| iPad/Mac M1 | 641tps/79tps (33MB RAM) | 0.3s/82tps (75MB RAM) | 0.7s/281tps (39MB RAM) |
+| iPhone 16 | 781tps/98tps (329MB RAM) | 0.2s/96tps (439MB RAM) | 0.5s/518tps (75MB RAM) |
+| iPhone 13 Mini | - | - | - |
 | Galaxy A56 | - | - | - |
 | Pixel 6a | 218tps/44tps (395MB RAM)| 2.5s/36tps (631MB RAM) | 1.5s/189tps (111MB RAM)|
 | Nothing CMF | - | - | - |


### PR DESCRIPTION
- Added the following benchmarks on the M1 Mac Mini and iPhone 16:

| Device | LFM2-350m<br>(1k-Prefill/100-Decode) | LFM2-VL-450m<br>(256px-Latency & Decode) | Moonshine-Base-67m<br>(30s-audio-Latency & Decode)
|--------|--------|--------|----------|
| iPad/Mac M1 | 641tps/79tps (33MB RAM) | 0.3s/82tps (75MB RAM) | 0.7s/281tps (39MB RAM) |
| iPhone 16 | 781tps/98tps (329MB RAM) | 0.2s/96tps (439MB RAM) | 0.5s/518tps (75MB RAM) |