### PR TITLE
Added warmups and increased iterations for performance testing

### DIFF
--- a/tests/test_performance.cpp
+++ b/tests/test_performance.cpp
@@ -970,7 +970,6 @@ bool test_engine_operations_performance(TestUtils::TestRunner& runner) {
 
 bool test_gather_operations_performance(TestUtils::TestRunner& runner) {
     BenchmarkConfig config;
-    config.iterations = 10;
     // INT8 for storage, FP16 for computation
     benchmark_gather_ops<int8_t>(runner, config);
     benchmark_gather_ops<__fp16>(runner, config);


### PR DESCRIPTION
This PR adds warmup runs and increases the default number of iterations that test_performance runs an operation for. This is to warm up caches, avoid initialization overhead and smooth out potential timing spikes. Overall, this change drastically reduces the variance in reported timings/bandwidths (see below). I also tried a higher number of iterations (100) and other optimizations (increasing process priority) but these didn't yield any better results.


**Tested moonshine-base on M1 Mac Mini for 10 runs. These are results for the MatMul 1024³ CPU operation**

- no warmups, 1 iteration
4.309ms, 498.37 GFLOPS
4.816ms, 445.91 GFLOPS
5.322ms, 403.51 GFLOPS
4.270ms, 502.92 GFLOPS
4.186ms, 513.02 GFLOPS
4.591ms, 467.76 GFLOPS
4.567ms, 470.22 GFLOPS
4.431ms, 484.65 GFLOPS
4.859ms, 441.96 GFLOPS
4.586ms, 468.27 GFLOPS
Mean: 4.5996 ms, 469.06 GFLOPS
Std dev: 0.330 ms, 32.94 GFLOPS

- 5 warmups, 10 iterations
3.585ms, 599.00 GFLOPS
3.374ms, 636.39 GFLOPS
3.362ms, 638.68 GFLOPS
3.422ms, 627.52 GFLOPS
3.524ms, 609.44 GFLOPS
3.604ms, 595.88 GFLOPS
3.468ms, 619.28 GFLOPS
3.448ms, 622.78 GFLOPS
3.354ms, 640.24 GFLOPS
3.471ms, 618.75 GFLOPS
Mean: 3.461 ms, 620.80 GFLOPS
Std dev: 0.0885 ms, 15.71 GFLOPS