### PR TITLE
 Added optional image for cactus run (#367)

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ git clone https://github.com/cactus-compute/cactus && cd cactus && source ./setu
 | Command | Description |
 |---------|-------------|
 | `cactus auth` | Setup Cactus cloud fallback (optional) (`--status`, `--clear`) |
-| `cactus run [model]` | Opens playground (auto downloads model) |
+| `cactus run [model]` | Opens playground (auto downloads model), optional `--image <path>` for VLM chat |
 | `cactus download [model]` | Downloads model to `./weights` |
 | `cactus convert [model] [dir]` | Converts model, supports LoRA merging (`--lora <path>`) |
 | `cactus build` | Builds for ARM (`--apple` or `--android`) |
@@ -161,6 +161,19 @@ git clone https://github.com/cactus-compute/cactus && cd cactus && source ./setu
 | `cactus transcribe [model]` | Transcribe audio file (`--file`) or live microphone |
 | `cactus clean` | Removes build artifacts |
 | `cactus --help` | Shows all commands and flags (always run this) |
+
+### Optional image input for `cactus run`
+
+Use `--image` to attach a local image to chat when running a vision model.
+
+```bash
+cactus run LiquidAI/LFM2-VL-450M --image /absolute/path/to/image.png
+```
+
+- The image is attached to the first user message in the chat session.
+- Supported vision models include `LiquidAI/LFM2-VL-450M` and `LiquidAI/LFM2.5-VL-1.6B`.
+- If the selected model does not support vision, Cactus prints a warning and continues in text-only mode.
+- If the image path does not exist, `cactus run` exits with an error.
 
 ## Using in your apps 
 

--- a/cactus/engine/engine_image.cpp
+++ b/cactus/engine/engine_image.cpp
@@ -307,10 +307,6 @@ Siglip2Preprocessor::PreprocessedImage Siglip2Preprocessor::preprocess_from_memo
         auto [grid_target_width, grid_target_height] = get_grid_layout(height, width);
         grid_cols = grid_target_width / config_.tile_size;
         grid_rows = grid_target_height / config_.tile_size;
-        printf("[debug] grid_target_width=%d grid_target_height=%d grid_cols=%d grid_rows=%d\n",
-               grid_target_width, grid_target_height, grid_cols, grid_rows);
-    
-
         std::vector<float> resized_grid = resize_image(
             source_data, width, height, grid_target_width, grid_target_height, expected_channels);
 
@@ -599,5 +595,4 @@ Siglip2Preprocessor::PreprocessedImage Siglip2Preprocessor::pad_patches(
 
 } // namespace engine
 } // namespace cactus
-
 

--- a/cactus/engine/engine_model.cpp
+++ b/cactus/engine/engine_model.cpp
@@ -509,6 +509,18 @@ bool Config::from_json(const std::string& config_path) {
         else if (key == "partial_rotary_factor") partial_rotary_factor = std::stof(value);
     }
 
+    const bool has_vision_support =
+        use_image_tokens ||
+        vision_num_layers > 0 ||
+        vision_embed_dim > 0 ||
+        vision_hidden_dim > 0 ||
+        visual_tokens_per_img > 0;
+
+    // Backward compatibility: some legacy VLM configs still ship with model_variant=default.
+    if (model_type == ModelType::LFM2 && model_variant == ModelVariant::DEFAULT && has_vision_support) {
+        model_variant = ModelVariant::VLM;
+    }
+
     if (model_type == ModelType::GEMMA) {
         default_temperature = 1.0f;
         default_top_p = 0.95f;

--- a/cactus/engine/engine_tokenizer.cpp
+++ b/cactus/engine/engine_tokenizer.cpp
@@ -41,25 +41,55 @@ void Tokenizer::detect_model_type(const std::string& config_path) {
     file.clear();
     file.seekg(0);
 
-    while (std::getline(file, line)) {
-        size_t pos2 = line.find("model_variant");
-        if (pos2 != std::string::npos) {
-            std::transform(line.begin(), line.end(), line.begin(), ::tolower);
+    bool has_vision_support = false;
 
-            if (line.find("vlm") != std::string::npos) {
+    while (std::getline(file, line)) {
+        std::string lower = line;
+        std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+
+        size_t eq_pos = lower.find('=');
+        if (eq_pos == std::string::npos) continue;
+
+        std::string key = lower.substr(0, eq_pos);
+        std::string value = lower.substr(eq_pos + 1);
+
+        key.erase(0, key.find_first_not_of(" \t"));
+        key.erase(key.find_last_not_of(" \t") + 1);
+        value.erase(0, value.find_first_not_of(" \t"));
+        value.erase(value.find_last_not_of(" \t") + 1);
+
+        if (key == "model_variant") {
+            if (value == "vlm") {
                 model_variant_ = ModelVariant::VLM;
-                break;
-            } else if (line.find("extract") != std::string::npos) {
+            } else if (value == "extract") {
                 model_variant_ = ModelVariant::EXTRACT;
-                break;
-            } else if (line.find("rag") != std::string::npos) {
+            } else if (value == "rag") {
                 model_variant_ = ModelVariant::RAG;
-                break;
             } else {
                 model_variant_ = ModelVariant::DEFAULT;
             }
+            continue;
+        }
+
+        if (key == "use_image_tokens") {
+            has_vision_support = (value == "true" || value == "1");
+            continue;
+        }
+
+        if (key == "vision_num_layers" || key == "vision_embed_dim" ||
+            key == "vision_hidden_dim" || key == "visual_tokens_per_img") {
+            try {
+                has_vision_support = has_vision_support || (std::stoul(value) > 0);
+            } catch (...) {
+            }
         }
     }
+
+    // Backward compatibility: infer VL model type from vision fields when model_variant is not set.
+    if (model_type_ == ModelType::LFM2 && model_variant_ == ModelVariant::DEFAULT && has_vision_support) {
+        model_variant_ = ModelVariant::VLM;
+    }
+
     file.close();
 }
 
@@ -88,7 +118,7 @@ std::string Tokenizer::format_chat_prompt(const std::vector<ChatMessage>& messag
             break;
         }
     }
-    if (model_type_ == ModelType::LFM2 && has_images) {
+    if (model_type_ == ModelType::LFM2 && has_images && model_variant_ == ModelVariant::VLM) {
         return format_lfm2_vl_style(messages, add_generation_prompt, tools_json);
     }
     

--- a/cactus/ffi/cactus_complete.cpp
+++ b/cactus/ffi/cactus_complete.cpp
@@ -246,7 +246,22 @@ int cactus_complete(
 
         std::vector<uint32_t> tokens_to_process;
 
-        bool has_images = !image_paths.empty();
+        const auto& model_config = handle->model->get_config();
+        const bool model_supports_images =
+            model_config.model_variant == Config::ModelVariant::VLM ||
+            model_config.use_image_tokens ||
+            model_config.vision_num_layers > 0 ||
+            model_config.vision_embed_dim > 0 ||
+            model_config.vision_hidden_dim > 0 ||
+            model_config.visual_tokens_per_img > 0;
+        if (!image_paths.empty() && !model_supports_images) {
+            CACTUS_LOG_WARN("complete", "Ignoring image inputs for non-VLM model");
+        }
+        const std::vector<std::string> no_images;
+        const std::vector<std::string>& active_image_paths =
+            model_supports_images ? image_paths : no_images;
+
+        bool has_images = !active_image_paths.empty();
         bool is_prefix = !has_images &&
                          (current_prompt_tokens.size() >= handle->processed_tokens.size()) &&
                          std::equal(handle->processed_tokens.begin(), handle->processed_tokens.end(), current_prompt_tokens.begin());
@@ -268,7 +283,7 @@ int cactus_complete(
         double time_to_first_token = 0.0;
         float first_token_entropy = 0.0f;
 
-        uint32_t next_token = generate_first_token(handle, tokens_to_process, image_paths,
+        uint32_t next_token = generate_first_token(handle, tokens_to_process, active_image_paths,
                                                     temperature, top_p, top_k, &first_token_entropy);
 
         handle->processed_tokens = current_prompt_tokens;

--- a/cactus/models/model_siglip2.cpp
+++ b/cactus/models/model_siglip2.cpp
@@ -66,35 +66,35 @@ void Siglip2VisionModel::load_weights_to_graph(CactusGraph* gb) {
     vision_weight_nodes_.patch_embedding_bias = gb->mmap_weights(base + "vision_patch_embedding.bias.weights");
     vision_weight_nodes_.position_embedding = gb->mmap_weights(base + "vision_position_embedding.weights");
 
-    if (!use_npu_encoder_) {
-        vision_weight_nodes_.vision_layers.resize(config_.vision_num_layers);
+    // Keep CPU vision weights available even when ANE loads successfully.
+    // This enables safe runtime fallback when ANE shape constraints are not met.
+    vision_weight_nodes_.vision_layers.resize(config_.vision_num_layers);
 
-        vision_weight_nodes_.post_layernorm_weight = gb->mmap_weights(base + "vision_post_layernorm.weights");
-        vision_weight_nodes_.post_layernorm_bias = gb->mmap_weights(base + "vision_post_layernorm.bias.weights");
+    vision_weight_nodes_.post_layernorm_weight = gb->mmap_weights(base + "vision_post_layernorm.weights");
+    vision_weight_nodes_.post_layernorm_bias = gb->mmap_weights(base + "vision_post_layernorm.bias.weights");
 
-        for (uint32_t i = 0; i < vision_weight_nodes_.vision_layers.size(); ++i) {
-            auto& layer = vision_weight_nodes_.vision_layers[i];
-            std::string prefix = base + "vision_layer_" + std::to_string(i) + "_";
+    for (uint32_t i = 0; i < vision_weight_nodes_.vision_layers.size(); ++i) {
+        auto& layer = vision_weight_nodes_.vision_layers[i];
+        std::string prefix = base + "vision_layer_" + std::to_string(i) + "_";
 
-            layer.attn_q_weight = gb->mmap_weights(prefix + "self_attn_q.weights");
-            layer.attn_q_bias = gb->mmap_weights(prefix + "self_attn_q.bias.weights");
-            layer.attn_k_weight = gb->mmap_weights(prefix + "self_attn_k.weights");
-            layer.attn_k_bias = gb->mmap_weights(prefix + "self_attn_k.bias.weights");
-            layer.attn_v_weight = gb->mmap_weights(prefix + "self_attn_v.weights");
-            layer.attn_v_bias = gb->mmap_weights(prefix + "self_attn_v.bias.weights");
-            layer.attn_output_weight = gb->mmap_weights(prefix + "self_attn_out.weights");
-            layer.attn_output_bias = gb->mmap_weights(prefix + "self_attn_out.bias.weights");
+        layer.attn_q_weight = gb->mmap_weights(prefix + "self_attn_q.weights");
+        layer.attn_q_bias = gb->mmap_weights(prefix + "self_attn_q.bias.weights");
+        layer.attn_k_weight = gb->mmap_weights(prefix + "self_attn_k.weights");
+        layer.attn_k_bias = gb->mmap_weights(prefix + "self_attn_k.bias.weights");
+        layer.attn_v_weight = gb->mmap_weights(prefix + "self_attn_v.weights");
+        layer.attn_v_bias = gb->mmap_weights(prefix + "self_attn_v.bias.weights");
+        layer.attn_output_weight = gb->mmap_weights(prefix + "self_attn_out.weights");
+        layer.attn_output_bias = gb->mmap_weights(prefix + "self_attn_out.bias.weights");
 
-            layer.layer_norm1_weight = gb->mmap_weights(prefix + "layer_norm1.weights");
-            layer.layer_norm1_bias = gb->mmap_weights(prefix + "layer_norm1.bias.weights");
-            layer.layer_norm2_weight = gb->mmap_weights(prefix + "layer_norm2.weights");
-            layer.layer_norm2_bias = gb->mmap_weights(prefix + "layer_norm2.bias.weights");
+        layer.layer_norm1_weight = gb->mmap_weights(prefix + "layer_norm1.weights");
+        layer.layer_norm1_bias = gb->mmap_weights(prefix + "layer_norm1.bias.weights");
+        layer.layer_norm2_weight = gb->mmap_weights(prefix + "layer_norm2.weights");
+        layer.layer_norm2_bias = gb->mmap_weights(prefix + "layer_norm2.bias.weights");
 
-            layer.mlp_fc1_weight = gb->mmap_weights(prefix + "ffn_fc1.weights");
-            layer.mlp_fc1_bias = gb->mmap_weights(prefix + "ffn_fc1.bias.weights");
-            layer.mlp_fc2_weight = gb->mmap_weights(prefix + "ffn_fc2.weights");
-            layer.mlp_fc2_bias = gb->mmap_weights(prefix + "ffn_fc2.bias.weights");
-        }
+        layer.mlp_fc1_weight = gb->mmap_weights(prefix + "ffn_fc1.weights");
+        layer.mlp_fc1_bias = gb->mmap_weights(prefix + "ffn_fc1.bias.weights");
+        layer.mlp_fc2_weight = gb->mmap_weights(prefix + "ffn_fc2.weights");
+        layer.mlp_fc2_bias = gb->mmap_weights(prefix + "ffn_fc2.bias.weights");
     }
 }
 
@@ -238,14 +238,36 @@ size_t Siglip2VisionModel::forward_vision(
     const Siglip2Preprocessor::PreprocessedImage& preprocessed_image,
     ComputeBackend backend) {
 
-    if (use_npu_encoder_ && npu_encoder_ && npu_encoder_->is_available()) {
-        // NPU path: build patch embeddings + position embeddings on CPU, then run transformer on NPU
-        auto embedding_result = build_vision_embeddings(gb, preprocessed_image, backend);
+    (void)backend;
+    const ComputeBackend cpu_backend = ComputeBackend::CPU;
 
-        size_t total_patches = 0;
-        for (const auto& shape : preprocessed_image.spatial_shapes) {
-            total_patches += shape.first * shape.second;
+    size_t total_patches = 0;
+    for (const auto& shape : preprocessed_image.spatial_shapes) {
+        total_patches += shape.first * shape.second;
+    }
+
+    bool try_npu = use_npu_encoder_ && npu_encoder_ && npu_encoder_->is_available();
+    if (try_npu) {
+        const std::vector<int> npu_input_shape = npu_encoder_->get_input_shape();
+        if (npu_input_shape.size() >= 2) {
+            const int expected_tokens = npu_input_shape[0];
+            const int expected_hidden = npu_input_shape[1];
+            const bool tokens_ok = (expected_tokens <= 0) || (static_cast<int>(total_patches) == expected_tokens);
+            const bool hidden_ok = (expected_hidden <= 0) || (static_cast<int>(config_.vision_embed_dim) == expected_hidden);
+
+            if (!tokens_ok || !hidden_ok) {
+                CACTUS_LOG_WARN("npu",
+                    "Vision NPU shape mismatch (expected [" << expected_tokens << ", " << expected_hidden
+                    << "], got [" << total_patches << ", " << config_.vision_embed_dim
+                    << "]); falling back to CPU vision path");
+                try_npu = false;
+            }
         }
+    }
+
+    if (try_npu) {
+        // NPU path: build patch embeddings + position embeddings on CPU, then run transformer on NPU
+        auto embedding_result = build_vision_embeddings(gb, preprocessed_image, cpu_backend);
 
         gb->execute();
 
@@ -293,12 +315,14 @@ size_t Siglip2VisionModel::forward_vision(
                 return vision_output;
             }
         }
-
-        throw std::runtime_error("NPU encoder failed");
+        CACTUS_LOG_WARN("npu", "NPU vision encoder failed for shape [" << total_patches
+                            << ", " << config_.vision_embed_dim
+                            << "]; falling back to CPU vision path");
+        gb->soft_reset();
     }
 
     // CPU path: full forward pass through transformer layers
-    auto embedding_result = build_vision_embeddings(gb, preprocessed_image, backend);
+    auto embedding_result = build_vision_embeddings(gb, preprocessed_image, cpu_backend);
 
     auto concat_nodes = [&](const std::vector<size_t>& nodes) {
         if (nodes.empty()) {
@@ -318,7 +342,7 @@ size_t Siglip2VisionModel::forward_vision(
         size_t hidden_states = embedding_result.tile_embeddings[tile_idx];
 
         for (uint32_t layer_idx = 0; layer_idx < config_.vision_num_layers; ++layer_idx) {
-            hidden_states = build_vision_transformer_layer(gb, hidden_states, layer_idx, backend);
+            hidden_states = build_vision_transformer_layer(gb, hidden_states, layer_idx, cpu_backend);
         }
 
         hidden_states = gb->layernorm(hidden_states,

--- a/python/src/cli.py
+++ b/python/src/cli.py
@@ -52,6 +52,40 @@ def run_command(cmd, cwd=None, check=True):
     return result
 
 
+def model_supports_images(weights_dir):
+    """Return True if local model config indicates image/VLM support."""
+    config_path = Path(weights_dir) / "config.txt"
+    if not config_path.exists():
+        return False
+
+    config = {}
+    try:
+        with open(config_path, 'r') as f:
+            for line in f:
+                line = line.strip()
+                if not line or '=' not in line:
+                    continue
+                key, value = line.split('=', 1)
+                config[key.strip().lower()] = value.strip().lower()
+    except Exception:
+        return False
+
+    if config.get('model_variant') == 'vlm':
+        return True
+
+    for key in ('vision_num_layers', 'vision_embed_dim', 'vision_hidden_dim', 'vision_image_size'):
+        value = config.get(key)
+        if not value:
+            continue
+        try:
+            if int(float(value)) > 0:
+                return True
+        except ValueError:
+            continue
+
+    return False
+
+
 def ensure_vad_weights(model_id, weights_dir, precision='INT8'):
     """Bundle Silero VAD weights into <weights_dir>/vad/ for whisper/moonshine models."""
     is_asr = 'whisper' in model_id.lower() or 'moonshine' in model_id.lower()
@@ -672,6 +706,14 @@ def cmd_run(args):
         os.environ["CACTUS_CLOUD_API_KEY"] = api_key
 
     model_id = args.model_id
+    image_path = getattr(args, 'image', None)
+
+    resolved_image = None
+    if image_path:
+        resolved_image = Path(image_path).expanduser().resolve()
+        if not resolved_image.exists():
+            print_color(RED, f"Error: image file not found: {resolved_image}")
+            return 1
 
     if getattr(args, 'no_cloud_tele', False):
         os.environ["CACTUS_NO_CLOUD_TELE"] = "1"
@@ -691,6 +733,10 @@ def cmd_run(args):
             return download_result
         weights_dir = get_weights_dir(model_id)
 
+    if resolved_image and not model_supports_images(weights_dir):
+        print_color(YELLOW, f"Warning: model at {weights_dir} does not support images; ignoring --image")
+        resolved_image = None
+
     chat_binary = PROJECT_ROOT / "tests" / "build" / "chat"
 
     if not chat_binary.exists():
@@ -699,9 +745,15 @@ def cmd_run(args):
 
     os.system('clear' if platform.system() != 'Windows' else 'cls')
     print_color(GREEN, f"Starting Cactus Chat with model: {model_id}")
+    if resolved_image:
+        print_color(GREEN, f"Using image: {resolved_image}")
     print()
 
-    os.execv(str(chat_binary), [str(chat_binary), str(weights_dir)])
+    exec_args = [str(chat_binary), str(weights_dir)]
+    if resolved_image:
+        exec_args.append(str(resolved_image))
+
+    os.execv(str(chat_binary), exec_args)
 
 
 DEFAULT_ASR_MODEL_ID = "openai/whisper-small"
@@ -1401,6 +1453,7 @@ def create_parser():
                                        auto downloads and spins up
 
     Optional flags:
+    --image <path>                     optional image for VLM chat (first user turn)
     --precision INT4|INT8|FP16         default: INT8
     --token <token>                    HF token (for gated models)
     --reconvert                        force model weights reconversion from source
@@ -1532,6 +1585,8 @@ def create_parser():
     run_parser.add_argument('--token', help='HuggingFace API token')
     run_parser.add_argument('--no-cloud-tele', action='store_true',
                             help='Disable cloud telemetry (write to cache only)')
+    run_parser.add_argument('--image',
+                            help='Optional image path for VLM chat (attached to first user message)')
     run_parser.add_argument('--reconvert', action='store_true',
                             help='Download original model and convert (instead of using pre-converted from Cactus-Compute)')
 

--- a/tests/chat.cpp
+++ b/tests/chat.cpp
@@ -9,6 +9,10 @@
 #include <iomanip>
 #include <chrono>
 #include <thread>
+#include <filesystem>
+#include <fstream>
+#include <algorithm>
+#include <cctype>
 
 constexpr int MAX_TOKENS = 512;
 constexpr size_t MAX_BYTES_PER_TOKEN = 64;
@@ -171,15 +175,71 @@ std::string unescape_json(const std::string& s) {
     return result;
 }
 
+bool model_supports_images(const std::string& model_path) {
+    std::filesystem::path config_path = std::filesystem::path(model_path) / "config.txt";
+    std::ifstream config_file(config_path);
+    if (!config_file.is_open()) {
+        return false;
+    }
+
+    std::string line;
+    while (std::getline(config_file, line)) {
+        auto eq_pos = line.find('=');
+        if (eq_pos == std::string::npos) {
+            continue;
+        }
+
+        std::string key = line.substr(0, eq_pos);
+        std::string value = line.substr(eq_pos + 1);
+        std::transform(key.begin(), key.end(), key.begin(), [](unsigned char c) {
+            return static_cast<char>(std::tolower(c));
+        });
+        std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
+            return static_cast<char>(std::tolower(c));
+        });
+
+        if (key == "model_variant" && value == "vlm") {
+            return true;
+        }
+
+        if (key == "vision_num_layers" || key == "vision_embed_dim" ||
+            key == "vision_hidden_dim" || key == "vision_image_size") {
+            try {
+                if (std::stof(value) > 0.0f) {
+                    return true;
+                }
+            } catch (...) {
+                continue;
+            }
+        }
+    }
+
+    return false;
+}
+
 int main(int argc, char* argv[]) {
-    if (argc != 2) {
-        std::cerr << colored("Error: ", Color::RED + Color::BOLD) << "Missing model path\n";
-        std::cerr << "Usage: " << argv[0] << " <model_path>\n";
-        std::cerr << "Example: " << argv[0] << " weights/lfm2-1.2B\n";
+    if (argc < 2 || argc > 3) {
+        std::cerr << colored("Error: ", Color::RED + Color::BOLD) << "Invalid arguments\n";
+        std::cerr << "Usage: " << argv[0] << " <model_path> [image_path]\n";
+        std::cerr << "Example: " << argv[0] << " weights/lfm2-vl-450m ./image.jpg\n";
         return 1;
     }
 
     const char* model_path = argv[1];
+    std::string image_path;
+    if (argc == 3) {
+        image_path = std::filesystem::absolute(argv[2]).string();
+        if (!std::filesystem::exists(image_path)) {
+            std::cerr << colored("Error: ", Color::RED + Color::BOLD)
+                      << "Image file not found: " << image_path << "\n";
+            return 1;
+        }
+        if (!model_supports_images(model_path)) {
+            std::cout << colored("Warning: ", Color::YELLOW + Color::BOLD)
+                      << "Model does not support image inputs; ignoring image.\n";
+            image_path.clear();
+        }
+    }
 
     std::cout << "\n" << colored("Loading model from ", Color::YELLOW)
               << colored(model_path, Color::CYAN) << colored("...", Color::YELLOW) << "\n";
@@ -192,6 +252,10 @@ int main(int argc, char* argv[]) {
     }
 
     std::cout << colored("Model loaded successfully!\n", Color::GREEN + Color::BOLD);
+    if (!image_path.empty()) {
+        std::cout << colored("Using image: ", Color::YELLOW)
+                  << colored(image_path, Color::CYAN) << "\n";
+    }
 
     print_header();
 
@@ -228,7 +292,11 @@ int main(int argc, char* argv[]) {
             if (i > 0) messages_json << ",";
             if (i % 2 == 0) {
                 messages_json << "{\"role\":\"user\",\"content\":\""
-                             << escape_json(history[i]) << "\"}";
+                             << escape_json(history[i]) << "\"";
+                if (!image_path.empty() && i == 0) {
+                    messages_json << ",\"images\":[\"" << escape_json(image_path) << "\"]";
+                }
+                messages_json << "}";
             } else {
                 messages_json << "{\"role\":\"assistant\",\"content\":\""
                              << escape_json(history[i]) << "\"}";


### PR DESCRIPTION
## Summary
Adds optional image input to `cactus run` and stabilizes VLM fallback when the ANE vision path fails.

## Changes
- **CLI:** `cactus run --image <path>` support (`python/src/cli.py`)
- **Chat app:** accepts an optional image and attaches it to the first user turn (`tests/chat.cpp`)
- **Non-vision models:** warn and ignore image input (`python/src/cli.py`, `tests/chat.cpp`, `cactus/ffi/cactus_complete.cpp`)
- **Model loading:** improved VLM detection for legacy configs that include vision fields (`cactus/engine/engine_model.cpp`, `cactus/engine/engine_tokenizer.cpp`)
- **SigLIP2:** hardened ANE shape-mismatch fallback to CPU path to avoid crashes (`cactus/models/model_siglip2.cpp`)
- **Docs:** README updated with `--image` usage (`README.md`)

resolves #367 