### PR TITLE
fix: handle spaces in paths when running shell commands

### DIFF
--- a/python/src/cli.py
+++ b/python/src/cli.py
@@ -5,7 +5,6 @@ import argparse
 import re
 import subprocess
 import shutil
-import shlex
 import platform
 from pathlib import Path
 
@@ -46,11 +45,18 @@ def check_command(cmd):
 
 
 def run_command(cmd, cwd=None, check=True):
-    """Run a shell command and optionally exit on failure."""
-    # If cmd is a string (single command/script path), quote it to handle spaces
+    """Run a script or command and optionally exit on failure.
+
+    Args:
+        cmd: Script path (str) or command list. String paths are executed
+             directly without shell interpretation to handle spaces safely.
+        cwd: Working directory for the command.
+        check: If True, exit on non-zero return code.
+    """
+    # Convert string paths to list to avoid shell=True and handle spaces safely
     if isinstance(cmd, str):
-        cmd = shlex.quote(cmd)
-    result = subprocess.run(cmd, cwd=cwd, shell=isinstance(cmd, str))
+        cmd = [cmd]
+    result = subprocess.run(cmd, cwd=cwd)
     if check and result.returncode != 0:
         sys.exit(result.returncode)
     return result


### PR DESCRIPTION
Fixes #379

## Problem

The `cactus build` command fails when the repo is cloned into a directory path containing spaces (e.g., `/Users/name/Programming Projects/cactus`).

**Error:**
```
/bin/sh: /Users/name/Programming: No such file or directory
Build failed
```

The issue is in `run_command()` which passes string paths to `subprocess.run()` with `shell=True`, causing the shell to interpret spaces as argument separators.

## Solution

Changed `run_command()` to use `shell=False` (the default) by converting string paths to a list. This avoids shell interpretation entirely and handles paths with spaces correctly.

**Before:**
```python
result = subprocess.run(cmd, cwd=cwd, shell=isinstance(cmd, str))
```

**After:**
```python
if isinstance(cmd, str):
    cmd = [cmd]
result = subprocess.run(cmd, cwd=cwd)  # shell=False by default
```

## Why this approach?

- **Cross-platform**: Works on both Unix and Windows (unlike `shlex.quote()` which uses single quotes that break on Windows)
- **Secure**: Avoids shell injection risks by not using `shell=True`
- **Robust**: Handles paths with spaces without any quoting complexity
- **Respects shebangs**: Scripts with `#!/bin/bash` are executed with the correct interpreter

## Testing

Tested with a repo cloned to a path containing spaces:
```
/Users/.../Programming Projects/Hackathons/Cactus AI x Google Deepmind 2026/Resources/...
```

`cactus build --python` now completes successfully.