### PR TITLE
Add language parameter support for Whisper transcription

### DIFF
--- a/python/src/cactus.py
+++ b/python/src/cactus.py
@@ -580,20 +580,29 @@ def cactus_rag_query(model, query, top_k=5):
     return json.loads(buf.value.decode("utf-8", errors="ignore"))
 
 
-def cactus_stream_transcribe_start(model, options=None):
+def cactus_stream_transcribe_start(model, options=None, language="en"):
     """
     Initialize streaming transcription session.
 
     Args:
         model: Whisper model handle from cactus_init
-        options: Optional JSON string with options
+        options: Optional dict or JSON string with options
+        language: Language code (default: "en"). Examples: es, fr, de, zh, ja
 
     Returns:
         Stream handle for use with other stream_transcribe functions.
     """
+    if options is None:
+        options = {}
+    elif isinstance(options, str):
+        options = json.loads(options)
+
+    options["language"] = language
+    options_json = json.dumps(options)
+
     return _lib.cactus_stream_transcribe_start(
         model,
-        options.encode() if options else None
+        options_json.encode()
     )
 
 

--- a/python/src/cli.py
+++ b/python/src/cli.py
@@ -930,6 +930,8 @@ def cmd_transcribe(args):
     cmd_args = [str(asr_binary), str(weights_dir)]
     if audio_file:
         cmd_args.append(audio_file)
+    if hasattr(args, 'language') and args.language:
+        cmd_args.extend(['--language', args.language])
 
     os.execv(str(asr_binary), cmd_args)
 
@@ -1540,6 +1542,8 @@ def create_parser():
                                    help=f'HuggingFace model ID (default: {DEFAULT_ASR_MODEL_ID})')
     transcribe_parser.add_argument('--file', dest='audio_file', default=None,
                                    help='Audio file to transcribe (WAV format). Omit for live microphone.')
+    transcribe_parser.add_argument('--language', default='en',
+                                   help='Language code for transcription (default: en). Examples: es, fr, de, zh, ja')
     transcribe_parser.add_argument('--precision', choices=['INT4', 'INT8', 'FP16'], default='INT8',
                                    help='Quantization precision (default: INT8)')
     transcribe_parser.add_argument('--cache-dir', help='Cache directory for HuggingFace models')


### PR DESCRIPTION
## Summary
Adds language parameter support for Whisper transcription in both streaming and file modes.

## Changes
- Stream API: `cactus_stream_transcribe_start(model, language="es")`
- CLI: `cactus transcribe --language es --file audio.wav`
- Cloud fallback: Language passed to cloud API for accurate transcription
- DRY: Shared prompt builder for consistent language handling

## Testing
- ✅ Live streaming with custom language
- ✅ File transcription with custom language
- ✅ Cloud handoff preserves language
- ✅ Backward compatible (defaults to 'en')

## Implementation
- Non-breaking: Defaults to English
- Whisper-only: Moonshine gets empty prompt as before
- 85 net lines changed across 4 files