### PR TITLE
add --image flag to cactus run for vision models

### DIFF
--- a/python/src/cli.py
+++ b/python/src/cli.py
@@ -787,11 +787,21 @@ def cmd_run(args):
         print_color(RED, f"Error: Chat binary not found at {chat_binary}")
         return 1
 
+    image_path = getattr(args, 'image', None)
+    if image_path:
+        image_path = str(Path(image_path).resolve())
+        if not Path(image_path).exists():
+            print_color(RED, f"Error: Image not found at {image_path}")
+            return 1
+
     os.system('clear' if platform.system() != 'Windows' else 'cls')
     print_color(GREEN, f"Starting Cactus Chat with model: {model_id}")
     print()
 
-    os.execv(str(chat_binary), [str(chat_binary), str(weights_dir)])
+    exec_args = [str(chat_binary), str(weights_dir)]
+    if image_path:
+        exec_args.append(image_path)
+    os.execv(str(chat_binary), exec_args)
 
 
 DEFAULT_ASR_MODEL_ID = "openai/whisper-small"
@@ -1494,6 +1504,7 @@ def create_parser():
     Optional flags:
     --precision INT4|INT8|FP16         default: INT8
     --token <token>                    HF token (for gated models)
+    --image <path>                     image for vision models (VLM)
     --reconvert                        force model weights reconversion from source
 
   -----------------------------------------------------------------
@@ -1623,6 +1634,7 @@ def create_parser():
     run_parser.add_argument('--token', help='HuggingFace API token')
     run_parser.add_argument('--no-cloud-tele', action='store_true',
                             help='Disable cloud telemetry (write to cache only)')
+    run_parser.add_argument('--image', help='Path to image for vision models')
     run_parser.add_argument('--reconvert', action='store_true',
                             help='Download original model and convert (instead of using pre-converted from Cactus-Compute)')
 

--- a/tests/chat.cpp
+++ b/tests/chat.cpp
@@ -172,14 +172,16 @@ std::string unescape_json(const std::string& s) {
 }
 
 int main(int argc, char* argv[]) {
-    if (argc != 2) {
+    if (argc < 2 || argc > 3) {
         std::cerr << colored("Error: ", Color::RED + Color::BOLD) << "Missing model path\n";
-        std::cerr << "Usage: " << argv[0] << " <model_path>\n";
+        std::cerr << "Usage: " << argv[0] << " <model_path> [image_path]\n";
         std::cerr << "Example: " << argv[0] << " weights/lfm2-1.2B\n";
+        std::cerr << "Example: " << argv[0] << " weights/LFM2-VL-450M photo.png\n";
         return 1;
     }
 
     const char* model_path = argv[1];
+    const char* image_path = (argc == 3) ? argv[2] : nullptr;
 
     std::cout << "\n" << colored("Loading model from ", Color::YELLOW)
               << colored(model_path, Color::CYAN) << colored("...", Color::YELLOW) << "\n";
@@ -192,6 +194,10 @@ int main(int argc, char* argv[]) {
     }
 
     std::cout << colored("Model loaded successfully!\n", Color::GREEN + Color::BOLD);
+
+    if (image_path) {
+        std::cout << colored("Image: ", Color::YELLOW) << colored(image_path, Color::CYAN) << "\n";
+    }
 
     print_header();
 
@@ -228,7 +234,11 @@ int main(int argc, char* argv[]) {
             if (i > 0) messages_json << ",";
             if (i % 2 == 0) {
                 messages_json << "{\"role\":\"user\",\"content\":\""
-                             << escape_json(history[i]) << "\"}";
+                             << escape_json(history[i]) << "\"";
+                if (image_path && i == 0) {
+                    messages_json << ",\"images\":[\"" << escape_json(image_path) << "\"]";
+                }
+                messages_json << "}";
             } else {
                 messages_json << "{\"role\":\"assistant\",\"content\":\""
                              << escape_json(history[i]) << "\"}";


### PR DESCRIPTION
## Summary
- Adds `--image <path>` optional flag to `cactus run` for vision models
- CLI validates the image path exists before launching the chat binary
- Chat binary accepts optional image path and attaches it to the first user message via the existing `"images"` JSON field

## Usage
```bash
cactus run LiquidAI/LFM2-VL-450M --image photo.png
```

Resolves #367