### PR TITLE
fixed lfm2 vlm lmhead issue that came in with hf 5.0.0

### DIFF
--- a/cactus/models/model_lfm2vl.cpp
+++ b/cactus/models/model_lfm2vl.cpp
@@ -102,7 +102,7 @@ void Lfm2VlModel::load_weights_to_graph(CactusGraph* gb) {
         return primary_path.string();
     };
 
-    try { // these guys are not present in lfm2.5, so in lieu of adding a config option detecting that i just try catch them
+    try { 
         projector_weights_.layer_norm_weight = gb->mmap_weights(resolve_weight("projector_layer_norm.weights"));
         projector_weights_.layer_norm_bias = gb->mmap_weights(resolve_weight("projector_layer_norm.bias.weights"));
     } catch (const std::exception&) {


### PR DESCRIPTION
Had a problem with LFM2-VLM, where the model would not output anything. The breaking change was introduced at commit addad5d where the Trnasformers version was changed. To replicate run

deactivate
cactus clean
source setup
cactus test --reconvert


The fix was manually hard coding the tying of embeddings and lm head for lfm2 vlm model

also fixed a seemingly unrelated problem that somehow just now appeared where the lfm2.5 vlm doesn't have a layernorm for their projector so it wouldn't even load the model. Not sure why this wasn't a problem before 