### PR TITLE
Tie-embed-conversion-fix

### DIFF
--- a/python/src/converter.py
+++ b/python/src/converter.py
@@ -152,6 +152,8 @@ def convert_hf_model_weights(model, output_dir, precision='INT8', args=None):
             if dst.exists():
                 dst.unlink()
             os.link(src, dst)
+        else:
+            print(f"Warning: tie_word_embeddings is True but {src} not found")
         if embedding_found:
             for name in OUTPUT_NAMES:
                 if name in state_dict:


### PR DESCRIPTION
Renamed ambiguous configs in hf conversion and added checks for both root_config and config to retrieve tie embeddings in accordance with the new Transformers 5.0+ api.

Uses hard links to tie LM head to the embedding weights, eliminating all redundant/wasteful storage use