### PR TITLE
kotlin: expose forceTools in CompletionOptions

### DIFF
--- a/android/Cactus.android.kt
+++ b/android/Cactus.android.kt
@@ -357,6 +357,7 @@ private fun CompletionOptions.toJson(): String = JSONObject().apply {
     put("max_tokens", maxTokens)
     put("stop", JSONArray(stopSequences))
     put("confidence_threshold", confidenceThreshold)
+    put("force_tools", forceTools)
 }.toString()
 
 private fun JSONObject.toCompletionResult(): CompletionResult {

--- a/android/Cactus.common.kt
+++ b/android/Cactus.common.kt
@@ -75,7 +75,8 @@ data class CompletionOptions(
     val topK: Int = 40,
     val maxTokens: Int = 512,
     val stopSequences: List<String> = emptyList(),
-    val confidenceThreshold: Float = 0f
+    val confidenceThreshold: Float = 0f,
+    val forceTools: Boolean = false
 )
 
 data class CompletionResult(

--- a/android/Cactus.ios.kt
+++ b/android/Cactus.ios.kt
@@ -379,6 +379,7 @@ actual class Cactus private constructor(private var handle: COpaquePointer?) : A
             put("max_tokens", options.maxTokens)
             putJsonArray("stop") { options.stopSequences.forEach { add(it) } }
             put("confidence_threshold", options.confidenceThreshold)
+            put("force_tools", options.forceTools)
         }.toString()
     }
 


### PR DESCRIPTION
Adds forceTools to CompletionOptions and serializes it as force_tools in the options JSON. Already supported by the C FFI.