### PR TITLE
add Android benchmarking harness with battery and thermal metrics

### DIFF
--- a/tests/android_bench/__init__.py
+++ b/tests/android_bench/__init__.py
@@ -1,0 +1,11 @@
+"""
+Android benchmarking harness for the Cactus inference engine.
+
+Extends the Cactus performance table with broader Android device coverage,
+INT4/INT8 precision comparison, and new battery + thermal throttling metrics
+that no other mobile inference benchmark currently tracks.
+
+Usage:
+    cd tests/android_bench
+    python bench.py --serial <adb_serial>
+"""

--- a/tests/android_bench/adb_client.py
+++ b/tests/android_bench/adb_client.py
@@ -1,0 +1,197 @@
+"""
+ADB wrapper for the Cactus Android benchmarking harness.
+
+All device interactions go through ADBClient so error handling and
+retry logic stay in one place, rather than scattered across the runner.
+"""
+
+import logging
+import subprocess
+import time
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+class ADBError(Exception):
+    """Raised when an ADB command fails or the device is unreachable."""
+
+
+class ADBClient:
+    """
+    Thin wrapper around the `adb` CLI for a single connected device.
+
+    Every shell command is logged at DEBUG level with the device serial so
+    multi-device runs produce unambiguous logs. Command timeouts are enforced
+    to prevent the benchmark runner from hanging if the device crashes.
+    """
+
+    def __init__(self, serial: str, default_timeout: int = 60) -> None:
+        """
+        Initialise the client and verify the device is reachable.
+
+        Args:
+            serial: The ADB device serial as shown by `adb devices`.
+            default_timeout: Seconds before a shell command is killed.
+
+        Raises:
+            ADBError: If the device is not currently listed by ADB.
+        """
+        self.serial = serial
+        self.default_timeout = default_timeout
+        self._verify_connection()
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    def shell(self, cmd: str, timeout: Optional[int] = None) -> str:
+        """
+        Execute a shell command on the device and return stdout as a string.
+
+        Stderr is captured separately and emitted as a WARNING if non-empty,
+        so callers see clean output while still surfacing device-side errors.
+
+        Args:
+            cmd: The shell command to run (passed to `adb shell`).
+            timeout: Override the default command timeout (seconds).
+
+        Returns:
+            Stripped stdout from the command.
+
+        Raises:
+            ADBError: On non-zero exit code or timeout.
+        """
+        effective_timeout = timeout or self.default_timeout
+        full_cmd = ["adb", "-s", self.serial, "shell", cmd]
+        logger.debug("[%s] shell: %s", self.serial, cmd)
+
+        try:
+            proc = subprocess.run(
+                full_cmd,
+                capture_output=True,
+                text=True,
+                timeout=effective_timeout,
+            )
+        except subprocess.TimeoutExpired:
+            raise ADBError(
+                f"Shell command timed out after {effective_timeout}s on {self.serial}: {cmd}"
+            )
+
+        if proc.returncode != 0 and proc.stderr.strip():
+            logger.warning("[%s] stderr: %s", self.serial, proc.stderr.strip())
+
+        return proc.stdout.strip()
+
+    def push(self, local_path: str, remote_path: str) -> None:
+        """
+        Push a local file or directory to the device.
+
+        Args:
+            local_path: Absolute or relative local filesystem path.
+            remote_path: Destination path on the device.
+
+        Raises:
+            ADBError: If the push fails.
+        """
+        logger.info("[%s] push %s -> %s", self.serial, local_path, remote_path)
+        self._run(["push", local_path, remote_path], timeout=600)
+
+    def pull(self, remote_path: str, local_path: str) -> None:
+        """
+        Pull a file or directory from the device to local storage.
+
+        Args:
+            remote_path: Path on the device to pull.
+            local_path: Local destination path.
+
+        Raises:
+            ADBError: If the pull fails.
+        """
+        logger.info("[%s] pull %s -> %s", self.serial, remote_path, local_path)
+        self._run(["pull", remote_path, local_path], timeout=300)
+
+    def device_info(self) -> dict:
+        """
+        Return a dict of device metadata read from Android system properties.
+
+        The returned dict always has the keys listed below; values may be
+        empty strings if the property is unavailable on the target device.
+
+        Returns:
+            Dict with keys: model, brand, chipset, android_version,
+            sdk_version, build_id, abi, total_ram_mb.
+        """
+        props: dict = {
+            "model": self._getprop("ro.product.model"),
+            "brand": self._getprop("ro.product.brand"),
+            "chipset": self._getprop("ro.hardware"),
+            "android_version": self._getprop("ro.build.version.release"),
+            "sdk_version": self._getprop("ro.build.version.sdk"),
+            "build_id": self._getprop("ro.build.id"),
+            "abi": self._getprop("ro.product.cpu.abi"),
+        }
+
+        # Total RAM from /proc/meminfo (more reliable than ro.* props)
+        try:
+            meminfo_line = self.shell("cat /proc/meminfo | grep MemTotal")
+            kb = int(meminfo_line.split()[1])
+            props["total_ram_mb"] = kb // 1024
+        except (ValueError, IndexError):
+            props["total_ram_mb"] = 0
+
+        return props
+
+    def is_connected(self) -> bool:
+        """Return True if the device serial still appears in `adb devices`."""
+        try:
+            result = subprocess.run(
+                ["adb", "devices"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            return self.serial in result.stdout
+        except Exception:
+            return False
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _run(self, args: list[str], timeout: Optional[int] = None) -> str:
+        """Execute `adb -s <serial> <args>` and return stripped stdout."""
+        effective_timeout = timeout or self.default_timeout
+        cmd = ["adb", "-s", self.serial] + args
+        try:
+            proc = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=effective_timeout,
+            )
+        except subprocess.TimeoutExpired:
+            raise ADBError(f"ADB command timed out: {' '.join(cmd)}")
+
+        if proc.returncode != 0:
+            raise ADBError(
+                f"ADB command failed (exit {proc.returncode}): {' '.join(cmd)}\n"
+                f"stderr: {proc.stderr.strip()}"
+            )
+        return proc.stdout.strip()
+
+    def _getprop(self, prop: str) -> str:
+        """Read a single Android system property, returning '' on failure."""
+        try:
+            return self.shell(f"getprop {prop}")
+        except ADBError:
+            return ""
+
+    def _verify_connection(self) -> None:
+        """Raise ADBError if the device is not currently reachable."""
+        if not self.is_connected():
+            raise ADBError(
+                f"Device '{self.serial}' not found. "
+                "Run `adb devices` to verify the serial and USB debugging state."
+            )
+        logger.debug("[%s] connection verified", self.serial)

--- a/tests/android_bench/bench.py
+++ b/tests/android_bench/bench.py
@@ -1,0 +1,804 @@
+"""
+Android benchmarking harness for the Cactus inference engine.
+
+Pushes the compiled test_performance binary and model weights to a connected
+Android device via ADB, runs each scenario with warmup + measurement iterations,
+collects battery drain and thermal data throughout, and writes the results as
+both a GitHub Markdown table (matching the README format) and a JSON artifact.
+
+Usage:
+    cd tests/android_bench
+    python bench.py --serial <adb_serial>
+
+    # With explicit paths:
+    python bench.py \\
+        --serial R5CN70KLXGE \\
+        --binary ../../build/android/test_performance \\
+        --weights ../../weights \\
+        --precision INT4 \\
+        --output results/
+
+Requirements:
+    pip install -r requirements.txt
+    Android NDK + platform tools installed, `adb` on PATH.
+    Device connected with USB debugging enabled.
+"""
+
+import argparse
+import json
+import logging
+import math
+import os
+import pathlib
+import signal
+import sys
+import tempfile
+import threading
+import time
+from dataclasses import asdict, dataclass, field
+from typing import Optional
+
+import yaml
+
+from adb_client import ADBClient, ADBError
+from metrics import (
+    CactusResult,
+    MetricsBundle,
+    ThermalSnapshot,
+    compute_battery_drain,
+    detect_thermal_throttle,
+    parse_cactus_response,
+    peak_thermal,
+    read_battery,
+    read_memory_pressure_events,
+    read_thermal_snapshot,
+)
+from renderer import (
+    render_device_header,
+    render_extended_table,
+    render_json_artifact,
+    render_readme_table,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEVICE_BENCH_DIR = "/data/local/tmp/cactus_bench"
+WARMUP_ITERS = 3
+MEASURE_ITERS = 5
+RETRY_LIMIT = 3
+THERMAL_POLL_INTERVAL_S = 2.0
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ScenarioConfig:
+    """One row in scenarios.yaml — a fully-specified inference workload."""
+
+    name: str
+    model: str
+    precision: str          # INT4 | INT8 | FP16
+    task: str               # completion | vlm | stt
+    context_length: int
+    prompt: str
+    max_tokens: int
+    audio_file: Optional[str] = None
+    image_file: Optional[str] = None
+
+
+@dataclass
+class IterationResult:
+    """Raw output from a single inference iteration."""
+
+    prefill_tps: float
+    decode_tps: float
+    ttft_ms: float
+    ram_mb: float
+    success: bool
+    error: Optional[str] = None
+
+
+@dataclass
+class ScenarioResult:
+    """Aggregated outcome for one scenario after all warmup + measurement iters."""
+
+    scenario_name: str
+    model: str
+    precision: str
+    iterations: list[IterationResult] = field(default_factory=list)
+    metrics: Optional[MetricsBundle] = None
+    failed: bool = False
+    error: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Statistics helpers
+# ---------------------------------------------------------------------------
+
+
+def _mean(values: list[float]) -> float:
+    """Return arithmetic mean or 0.0 for empty lists."""
+    return sum(values) / len(values) if values else 0.0
+
+
+def _stddev(values: list[float]) -> float:
+    """Return sample standard deviation or 0.0 for fewer than 2 values."""
+    if len(values) < 2:
+        return 0.0
+    m = _mean(values)
+    return math.sqrt(sum((v - m) ** 2 for v in values) / (len(values) - 1))
+
+
+# ---------------------------------------------------------------------------
+# Background thermal poller
+# ---------------------------------------------------------------------------
+
+
+class ThermalPoller(threading.Thread):
+    """
+    Daemon thread that samples thermal zones and CPU frequency every few seconds.
+
+    Runs in the background during warmup and measurement iterations so we get
+    a continuous temperature trace without blocking the benchmark loop.
+    """
+
+    def __init__(self, adb: ADBClient, interval_s: float = THERMAL_POLL_INTERVAL_S) -> None:
+        super().__init__(daemon=True, name=f"thermal-{adb.serial}")
+        self.adb = adb
+        self.interval_s = interval_s
+        self.snapshots: list[ThermalSnapshot] = []
+        self._stop = threading.Event()
+
+    def run(self) -> None:
+        """Poll until stop() is called."""
+        while not self._stop.wait(self.interval_s):
+            try:
+                self.snapshots.append(read_thermal_snapshot(self.adb))
+            except ADBError as exc:
+                logger.debug("Thermal poll skipped: %s", exc)
+
+    def stop(self) -> None:
+        """Signal the thread to stop and wait for it to exit."""
+        self._stop.set()
+        self.join(timeout=self.interval_s + 2)
+
+
+# ---------------------------------------------------------------------------
+# Core benchmark runner
+# ---------------------------------------------------------------------------
+
+
+class BenchmarkRunner:
+    """
+    Orchestrates the full benchmark lifecycle on a connected Android device.
+
+    Responsibilities:
+      - Push the binary and weights once at setup time.
+      - For each scenario: run warmup iters (discarded), then MEASURE_ITERS
+        measurement iters with retry logic and partial-result saves on ADB drop.
+      - Collect battery state before/after each scenario and continuously poll
+        thermal sensors in the background.
+      - Aggregate iteration outputs into MetricsBundle (mean ± stddev).
+    """
+
+    def __init__(
+        self,
+        adb: ADBClient,
+        scenarios: list[ScenarioConfig],
+        binary_path: str,
+        weights_dir: str,
+        output_dir: str,
+        assets_dir: Optional[str] = None,
+    ) -> None:
+        self.adb = adb
+        self.scenarios = scenarios
+        self.binary_path = binary_path
+        self.weights_dir = weights_dir
+        self.output_dir = pathlib.Path(output_dir)
+        self.assets_dir = assets_dir
+        self.results: list[ScenarioResult] = []
+        self._binary_name = os.path.basename(binary_path)
+
+    def setup(self) -> None:
+        """
+        Push the benchmark binary and model weights to the device.
+
+        Creates ``DEVICE_BENCH_DIR/{weights,assets}`` on the device if they
+        don't already exist, then pushes the binary (with +x) and the local
+        weights directory.
+
+        Raises:
+            ADBError: If any push fails.
+        """
+        logger.info("[%s] Setting up benchmark environment", self.adb.serial)
+        self.adb.shell(f"mkdir -p {DEVICE_BENCH_DIR}/weights {DEVICE_BENCH_DIR}/assets")
+
+        remote_bin = f"{DEVICE_BENCH_DIR}/{self._binary_name}"
+        logger.info("Pushing benchmark binary → %s", remote_bin)
+        self.adb.push(self.binary_path, remote_bin)
+        self.adb.shell(f"chmod +x {remote_bin}")
+
+        logger.info("Pushing model weights → %s/weights/", DEVICE_BENCH_DIR)
+        self.adb.push(self.weights_dir, f"{DEVICE_BENCH_DIR}/weights/")
+
+        if self.assets_dir and os.path.exists(self.assets_dir):
+            logger.info("Pushing test assets → %s/assets/", DEVICE_BENCH_DIR)
+            self.adb.push(self.assets_dir, f"{DEVICE_BENCH_DIR}/assets/")
+
+    def run_all(self) -> list[ScenarioResult]:
+        """
+        Execute every scenario and return the collected ScenarioResult list.
+
+        Partial results are written to disk after each scenario so that a
+        mid-run ADB disconnection doesn't lose all collected data.
+
+        Returns:
+            List of ScenarioResult, one per scenario (failed scenarios included).
+        """
+        total = len(self.scenarios)
+        for i, scenario in enumerate(self.scenarios, start=1):
+            logger.info("Scenario %d/%d: %s (%s %s)", i, total,
+                        scenario.name, scenario.precision, scenario.task)
+            result = self._run_scenario(scenario)
+            self.results.append(result)
+            _atomic_write_json(
+                self.output_dir / "results_partial.json",
+                [_scenario_to_dict(r) for r in self.results],
+            )
+        return self.results
+
+    # ------------------------------------------------------------------
+    # Private scenario execution
+    # ------------------------------------------------------------------
+
+    def _run_scenario(self, scenario: ScenarioConfig) -> ScenarioResult:
+        """Run one scenario: collect pre-run metrics, warmup, measure, post-run."""
+        result = ScenarioResult(
+            scenario_name=scenario.name,
+            model=scenario.model,
+            precision=scenario.precision,
+        )
+
+        battery_before = self._safe_read_battery()
+        oom_before = self._safe_read_oom()
+
+        poller = ThermalPoller(self.adb)
+        poller.start()
+
+        try:
+            logger.info("  Warmup (%d iters)…", WARMUP_ITERS)
+            for wi in range(WARMUP_ITERS):
+                try:
+                    self._run_once(scenario, label=f"warmup-{wi + 1}")
+                except (ADBError, ValueError) as exc:
+                    logger.debug("  Warmup iter %d failed (ignored): %s", wi + 1, exc)
+
+            logger.info("  Measuring (%d iters)…", MEASURE_ITERS)
+            for mi in range(MEASURE_ITERS):
+                iter_result = self._run_with_retry(scenario, label=f"iter-{mi + 1}")
+                result.iterations.append(iter_result)
+
+        except ADBError as exc:
+            logger.error("ADB disconnected during '%s': %s", scenario.name, exc)
+            result.failed = True
+            result.error = str(exc)
+            _atomic_write_json(
+                self.output_dir / "results_partial.json",
+                [_scenario_to_dict(r) for r in self.results + [result]],
+            )
+        finally:
+            poller.stop()
+
+        battery_after = self._safe_read_battery()
+        oom_after = self._safe_read_oom()
+
+        successful = [it for it in result.iterations if it.success]
+        if not successful:
+            result.failed = True
+            result.error = result.error or "All measurement iterations failed"
+            return result
+
+        decode_vals = [it.decode_tps for it in successful]
+        prefill_vals = [it.prefill_tps for it in successful]
+        ttft_vals = [it.ttft_ms for it in successful]
+        ram_vals = [it.ram_mb for it in successful]
+
+        battery_drain = (
+            compute_battery_drain(battery_before, battery_after)
+            if battery_before and battery_after
+            else 0.0
+        )
+
+        result.metrics = MetricsBundle(
+            decode_tps=_mean(decode_vals),
+            prefill_tps=_mean(prefill_vals),
+            ttft_ms=_mean(ttft_vals),
+            ram_mb=_mean(ram_vals),
+            battery_drain_pct=battery_drain,
+            thermal_throttle_detected=detect_thermal_throttle(poller.snapshots),
+            thermal_peak_celsius=peak_thermal(poller.snapshots),
+            memory_pressure_events=max(0, oom_after - oom_before),
+            decode_tps_stddev=_stddev(decode_vals),
+            prefill_tps_stddev=_stddev(prefill_vals),
+        )
+
+        m = result.metrics
+        logger.info(
+            "  → decode=%.1f±%.1f tps  prefill=%.1f tps  TTFT=%.1fms  RAM=%s",
+            m.decode_tps, m.decode_tps_stddev,
+            m.prefill_tps, m.ttft_ms,
+            f"{m.ram_mb:.0f}MB",
+        )
+        if m.thermal_throttle_detected:
+            logger.warning("  ⚠ Thermal throttling detected — results may be understated")
+
+        return result
+
+    def _run_with_retry(
+        self, scenario: ScenarioConfig, label: str
+    ) -> IterationResult:
+        """
+        Run a single measurement iteration, retrying up to RETRY_LIMIT times.
+
+        Retries use exponential backoff (2, 4, 8 seconds) to give the device
+        time to settle before the next attempt.
+
+        Returns:
+            IterationResult with ``success=False`` if all retries are exhausted.
+        """
+        for attempt in range(1, RETRY_LIMIT + 1):
+            try:
+                return self._run_once(scenario, label=label)
+            except (ADBError, ValueError) as exc:
+                logger.warning("  %s attempt %d/%d failed: %s", label, attempt, RETRY_LIMIT, exc)
+                if attempt < RETRY_LIMIT:
+                    time.sleep(2 ** attempt)
+
+        return IterationResult(
+            prefill_tps=0.0, decode_tps=0.0, ttft_ms=0.0, ram_mb=0.0,
+            success=False, error=f"Failed after {RETRY_LIMIT} attempts",
+        )
+
+    def _run_once(self, scenario: ScenarioConfig, label: str) -> IterationResult:
+        """
+        Invoke the benchmark binary for one iteration and parse its output.
+
+        The binary is the ``test_performance`` executable from the existing
+        tests/ build, configured via environment variables that mirror the
+        pattern established in tests/android/run.sh.
+
+        Args:
+            scenario: The scenario to run.
+            label: Human-readable label for log messages.
+
+        Returns:
+            Parsed IterationResult.
+
+        Raises:
+            ADBError: If the shell command fails or times out.
+            ValueError: If the binary output cannot be parsed.
+        """
+        model_slug = scenario.model.split("/")[-1].lower()
+        model_path = f"{DEVICE_BENCH_DIR}/weights/{model_slug}"
+
+        env = (
+            f"CACTUS_TEST_MODEL={model_path} "
+            f"CACTUS_NO_CLOUD_TELE=1 "
+        )
+        if scenario.task == "stt" and scenario.audio_file:
+            env += f"CACTUS_TEST_ASSETS={DEVICE_BENCH_DIR}/assets "
+        if scenario.task == "vlm" and scenario.image_file:
+            env += f"CACTUS_TEST_ASSETS={DEVICE_BENCH_DIR}/assets "
+
+        cmd = (
+            f"cd {DEVICE_BENCH_DIR} && "
+            f"{env}"
+            f"./{self._binary_name} "
+            f"--context-length {scenario.context_length} "
+            f"--max-tokens {scenario.max_tokens} "
+            f"--task {scenario.task} "
+            f"--precision {scenario.precision}"
+        )
+        logger.debug("  [%s] %s", label, cmd)
+
+        output = self.adb.shell(cmd, timeout=300)
+        parsed = parse_cactus_response(output)
+
+        # Prefer the RAM value reported in the JSON response (already peak RSS).
+        # Fall back to /proc/meminfo only if the binary didn't populate it.
+        ram_mb = parsed.ram_usage_mb if parsed.ram_usage_mb > 0 else self._fallback_ram_mb()
+
+        return IterationResult(
+            prefill_tps=parsed.prefill_tps,
+            decode_tps=parsed.decode_tps,
+            ttft_ms=parsed.time_to_first_token_ms,
+            ram_mb=ram_mb,
+            success=True,
+        )
+
+    def _fallback_ram_mb(self) -> float:
+        """Read MemAvailable from /proc/meminfo as a RAM proxy."""
+        try:
+            line = self.adb.shell("cat /proc/meminfo | grep MemAvailable")
+            return int(line.split()[1]) / 1024.0
+        except Exception:
+            return 0.0
+
+    def _safe_read_battery(self):
+        """Read battery state, returning None on failure."""
+        try:
+            return read_battery(self.adb)
+        except ADBError as exc:
+            logger.debug("Battery read failed: %s", exc)
+            return None
+
+    def _safe_read_oom(self) -> int:
+        """Read OOM event count, returning 0 on failure."""
+        try:
+            return read_memory_pressure_events(self.adb)
+        except ADBError as exc:
+            logger.debug("OOM read failed: %s", exc)
+            return 0
+
+
+# ---------------------------------------------------------------------------
+# YAML loading
+# ---------------------------------------------------------------------------
+
+
+def load_scenarios(path: str, precision_override: Optional[str] = None) -> list[ScenarioConfig]:
+    """
+    Load and validate scenario definitions from a YAML file.
+
+    If ``precision_override`` is provided, it replaces the precision value for
+    every scenario — useful for running a full INT8 sweep without editing the
+    YAML.
+
+    Args:
+        path: Filesystem path to scenarios.yaml.
+        precision_override: Optional precision string to apply to all scenarios.
+
+    Returns:
+        List of ScenarioConfig objects.
+
+    Raises:
+        FileNotFoundError: If the YAML file doesn't exist.
+        KeyError: If a required field is missing from a scenario entry.
+    """
+    with open(path) as f:
+        raw = yaml.safe_load(f)
+
+    configs: list[ScenarioConfig] = []
+    for item in raw.get("scenarios", []):
+        configs.append(
+            ScenarioConfig(
+                name=item["name"],
+                model=item["model"],
+                precision=precision_override or item.get("precision", "INT4"),
+                task=item.get("task", "completion"),
+                context_length=item.get("context_length", 1024),
+                prompt=item.get("prompt", ""),
+                max_tokens=item.get("max_tokens", 100),
+                audio_file=item.get("audio_file"),
+                image_file=item.get("image_file"),
+            )
+        )
+    return configs
+
+
+# ---------------------------------------------------------------------------
+# Result serialisation
+# ---------------------------------------------------------------------------
+
+
+def _scenario_to_dict(r: ScenarioResult) -> dict:
+    """Serialise a ScenarioResult to a JSON-compatible dict."""
+    d: dict = {
+        "scenario_name": r.scenario_name,
+        "model": r.model,
+        "precision": r.precision,
+        "failed": r.failed,
+        "error": r.error,
+        "iterations": [
+            {
+                "prefill_tps": it.prefill_tps,
+                "decode_tps": it.decode_tps,
+                "ttft_ms": it.ttft_ms,
+                "ram_mb": it.ram_mb,
+                "success": it.success,
+                "error": it.error,
+            }
+            for it in r.iterations
+        ],
+    }
+    if r.metrics:
+        m = r.metrics
+        d["metrics"] = {
+            "decode_tps": m.decode_tps,
+            "decode_tps_stddev": m.decode_tps_stddev,
+            "prefill_tps": m.prefill_tps,
+            "prefill_tps_stddev": m.prefill_tps_stddev,
+            "ttft_ms": m.ttft_ms,
+            "ram_mb": m.ram_mb,
+            "battery_drain_pct": m.battery_drain_pct,
+            "thermal_throttle_detected": m.thermal_throttle_detected,
+            "thermal_peak_celsius": m.thermal_peak_celsius,
+            "memory_pressure_events": m.memory_pressure_events,
+        }
+    return d
+
+
+def results_to_render_payload(
+    scenario_results: list[ScenarioResult],
+    device_info: dict,
+) -> list[dict]:
+    """
+    Map scenario results onto the column layout expected by the renderer.
+
+    The README table has three columns keyed on model type (lfm_1_2b,
+    lfmvl_1_6b, parakeet_1_1b). Scenario names are matched by substring so
+    the mapping survives minor naming changes in scenarios.yaml.
+
+    Args:
+        scenario_results: Completed scenario results from BenchmarkRunner.run_all().
+        device_info: Device metadata dict from ADBClient.device_info().
+
+    Returns:
+        Single-element list containing the device payload dict for the renderer.
+    """
+    payload: dict = {
+        "device_name": device_info.get("model", "Unknown"),
+        "thermal_throttle_detected": False,
+        "thermal_peak_celsius": 0.0,
+        "battery_drain_pct": 0.0,
+        "memory_pressure_events": 0,
+    }
+
+    for r in scenario_results:
+        if r.failed or r.metrics is None:
+            continue
+
+        m = r.metrics
+        metrics_dict = {
+            "prefill_tps": m.prefill_tps,
+            "prefill_tps_stddev": m.prefill_tps_stddev,
+            "decode_tps": m.decode_tps,
+            "decode_tps_stddev": m.decode_tps_stddev,
+            "ttft_ms": m.ttft_ms,
+            "ram_mb": m.ram_mb,
+        }
+
+        name = r.scenario_name.lower()
+        if "lfm_1_2b" in name or ("lfm" in name and "vl" not in name and "1_2" in name):
+            payload["lfm_1_2b"] = metrics_dict
+        elif "lfmvl" in name or "vlm" in name or ("lfm" in name and "vl" in name):
+            payload["lfmvl_1_6b"] = metrics_dict
+        elif "parakeet" in name or "stt" in name:
+            payload["parakeet_1_1b"] = metrics_dict
+
+        # Accumulate worst-case battery/thermal across all scenarios
+        if m.thermal_throttle_detected:
+            payload["thermal_throttle_detected"] = True
+        if m.thermal_peak_celsius > payload["thermal_peak_celsius"]:
+            payload["thermal_peak_celsius"] = m.thermal_peak_celsius
+        if m.battery_drain_pct > payload["battery_drain_pct"]:
+            payload["battery_drain_pct"] = m.battery_drain_pct
+        payload["memory_pressure_events"] += m.memory_pressure_events
+
+        # RAM from 4k context scenario, fall back to any scenario
+        if "4k" in name:
+            payload["ram_mb"] = m.ram_mb
+        else:
+            payload.setdefault("ram_mb", m.ram_mb)
+
+    return [payload]
+
+
+# ---------------------------------------------------------------------------
+# Atomic I/O
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write_json(path: pathlib.Path, data: object) -> None:
+    """
+    Write ``data`` as JSON to ``path`` using an atomic rename.
+
+    Writes to a sibling temp file first, then calls ``os.replace()`` so
+    the destination is never left in a partially-written state. Safe to
+    call concurrently from the SIGINT handler.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        "w", dir=str(path.parent), delete=False, suffix=".tmp"
+    ) as f:
+        json.dump(data, f, indent=2)
+        tmp = f.name
+    os.replace(tmp, str(path))
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _configure_logging(verbose: bool) -> None:
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    """Entry point for ``python bench.py`` and ``python -m bench``."""
+    parser = argparse.ArgumentParser(
+        description="Android benchmarking harness for the Cactus inference engine",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--serial", required=True,
+        help="ADB device serial from `adb devices`",
+    )
+    parser.add_argument(
+        "--binary",
+        default="../../build/android/test_performance",
+        help="Path to the arm64-v8a test_performance binary",
+    )
+    parser.add_argument(
+        "--weights",
+        default="../../weights",
+        help="Local weights/ directory containing model GGUF files",
+    )
+    parser.add_argument(
+        "--scenarios",
+        default="scenarios.yaml",
+        help="Path to scenarios YAML file",
+    )
+    parser.add_argument(
+        "--assets",
+        default="../../tests/assets",
+        help="Path to test assets directory (audio/image files for VLM/STT)",
+    )
+    parser.add_argument(
+        "--precision",
+        choices=["INT4", "INT8", "FP16"],
+        default=None,
+        help="Override precision for all scenarios (default: use scenarios.yaml value)",
+    )
+    parser.add_argument(
+        "--output", default="results",
+        help="Output directory for results JSON and Markdown",
+    )
+    parser.add_argument("--verbose", "-v", action="store_true")
+
+    args = parser.parse_args(argv)
+    _configure_logging(args.verbose)
+
+    script_dir = pathlib.Path(__file__).parent
+    binary_path = (script_dir / args.binary).resolve()
+    weights_dir = (script_dir / args.weights).resolve()
+    scenarios_path = (script_dir / args.scenarios).resolve()
+    assets_dir = (script_dir / args.assets).resolve()
+    output_dir = (script_dir / args.output).resolve()
+
+    if not binary_path.exists():
+        logger.error(
+            "Binary not found: %s\n"
+            "Build for Android first:\n"
+            "  cactus build --android\n"
+            "  # or: cmake --build build/android -j$(nproc)",
+            binary_path,
+        )
+        return 1
+
+    if not weights_dir.exists():
+        logger.error(
+            "Weights directory not found: %s\n"
+            "Download models first:\n"
+            "  cactus download LiquidAI/LFM2.5-1.2B-Instruct\n"
+            "  cactus download LiquidAI/LFM2.5-VL-1.6B\n"
+            "  cactus download nvidia/parakeet-ctc-1.1b",
+            weights_dir,
+        )
+        return 1
+
+    try:
+        adb = ADBClient(serial=args.serial)
+    except ADBError as exc:
+        logger.error("%s", exc)
+        return 1
+
+    device_info = adb.device_info()
+    logger.info(
+        "Connected: %s (Android %s, %d MB RAM)",
+        device_info["model"],
+        device_info["android_version"],
+        device_info.get("total_ram_mb", 0),
+    )
+
+    scenarios = load_scenarios(str(scenarios_path), precision_override=args.precision)
+    logger.info("Loaded %d scenario(s) from %s", len(scenarios), scenarios_path.name)
+
+    runner = BenchmarkRunner(
+        adb=adb,
+        scenarios=scenarios,
+        binary_path=str(binary_path),
+        weights_dir=str(weights_dir),
+        output_dir=str(output_dir),
+        assets_dir=str(assets_dir) if assets_dir.exists() else None,
+    )
+
+    def _on_interrupt(sig, frame):
+        logger.warning("Interrupted — partial results saved to %s", output_dir)
+        sys.exit(130)
+
+    signal.signal(signal.SIGINT, _on_interrupt)
+
+    logger.info("Setting up device…")
+    runner.setup()
+
+    logger.info("Running benchmarks…")
+    scenario_results = runner.run_all()
+
+    # Build render payload and write output files
+    precision_label = args.precision or (scenarios[0].precision if scenarios else "INT4")
+    render_payload = results_to_render_payload(scenario_results, device_info)
+    scenario_info = {"precision": precision_label}
+
+    header_md = render_device_header(
+        {**device_info, "device_name": device_info["model"]},
+        scenario_info,
+    )
+    readme_table = render_readme_table(render_payload)
+    extended_table = render_extended_table(render_payload)
+    json_str = render_json_artifact(
+        [_scenario_to_dict(r) for r in scenario_results],
+        metadata={
+            "device": device_info,
+            "serial": args.serial,
+            "precision": precision_label,
+            "scenarios_file": scenarios_path.name,
+        },
+    )
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    _atomic_write_json(output_dir / "results.json", json.loads(json_str))
+
+    md_content = (
+        f"{header_md}\n\n"
+        f"#### Standard Benchmark Table\n\n{readme_table}\n\n"
+        f"#### Extended Metrics (battery + thermal)\n\n{extended_table}\n"
+    )
+    with tempfile.NamedTemporaryFile(
+        "w", dir=str(output_dir), delete=False, suffix=".tmp"
+    ) as f:
+        f.write(md_content)
+        tmp_md = f.name
+    os.replace(tmp_md, str(output_dir / "results.md"))
+
+    # Print to stdout for CI log capture
+    print("\n" + "=" * 64)
+    print(header_md)
+    print(readme_table)
+    print()
+    print(extended_table)
+    print("=" * 64)
+    logger.info("Results written to %s/", output_dir)
+
+    failed = sum(1 for r in scenario_results if r.failed)
+    if failed:
+        logger.warning("%d/%d scenario(s) failed", failed, len(scenario_results))
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/android_bench/devices.yaml
+++ b/tests/android_bench/devices.yaml
@@ -1,0 +1,96 @@
+# Device registry for the Cactus Android benchmark harness.
+#
+# This file is a reference template.  The adb_serial field is left blank
+# because serials change between USB sessions.  Set it at runtime via the
+# --serial CLI flag; the harness reads device metadata directly from the
+# device over ADB (ro.product.model, etc.) and records it in results.json.
+#
+# The entries below serve two purposes:
+#   1. Document which devices have been benchmarked so contributors can see
+#      what coverage gaps remain before adding a new device to the table.
+#   2. Provide human-readable chipset names that Android system properties
+#      don't always expose cleanly (ro.hardware returns the BSP codename,
+#      not the marketing chipset name).
+#
+# To add a new device:
+#   1. Connect it and run `adb devices` to find the serial.
+#   2. Add an entry below.
+#   3. Run: python bench.py --serial <serial>
+#   4. Copy the generated results/results.md into docs/android_benchmarks.md.
+
+devices:
+
+  # -----------------------------------------------------------------------
+  # Flagship — already in README table
+  # -----------------------------------------------------------------------
+  - device_name: Samsung Galaxy S25 Ultra
+    chipset: Snapdragon 8 Elite (SM8750)
+    ram_gb: 12
+    android_version: "15"
+    adb_serial: ""   # populate at runtime
+
+  # -----------------------------------------------------------------------
+  # Google Pixel — popular developer device, DVFS behaviour well-documented
+  # -----------------------------------------------------------------------
+  - device_name: Google Pixel 9 Pro
+    chipset: Google Tensor G4
+    ram_gb: 16
+    android_version: "15"
+    adb_serial: ""
+
+  - device_name: Google Pixel 8a
+    chipset: Google Tensor G3
+    ram_gb: 8
+    android_version: "14"
+    adb_serial: ""
+
+  - device_name: Google Pixel 6a
+    chipset: Google Tensor G1
+    ram_gb: 6
+    android_version: "14"
+    adb_serial: ""
+
+  # -----------------------------------------------------------------------
+  # OnePlus / Nothing — Snapdragon mid-range coverage
+  # -----------------------------------------------------------------------
+  - device_name: OnePlus 13
+    chipset: Snapdragon 8 Elite (SM8750)
+    ram_gb: 12
+    android_version: "15"
+    adb_serial: ""
+
+  - device_name: Nothing Phone (2a) Plus
+    chipset: MediaTek Dimensity 7350 Pro
+    ram_gb: 12
+    android_version: "14"
+    adb_serial: ""
+
+  # -----------------------------------------------------------------------
+  # Mid-range Snapdragon — the reference device used in android_benchmarks.md
+  # -----------------------------------------------------------------------
+  - device_name: Motorola Edge 50 Neo
+    chipset: Snapdragon 7s Gen 3 (SM7635)
+    ram_gb: 12
+    android_version: "14"
+    adb_serial: ""
+
+  - device_name: Xiaomi Redmi Note 14 Pro
+    chipset: Snapdragon 7s Gen 3 (SM7635)
+    ram_gb: 8
+    android_version: "14"
+    adb_serial: ""
+
+  # -----------------------------------------------------------------------
+  # Budget / entry-level — stress-tests memory pressure and thermal limits
+  # -----------------------------------------------------------------------
+  - device_name: Samsung Galaxy A17 5G
+    chipset: Exynos 850
+    ram_gb: 4
+    android_version: "14"
+    adb_serial: ""
+
+  - device_name: CMF Phone 2 Pro
+    chipset: MediaTek Dimensity 7300 Pro
+    ram_gb: 8
+    android_version: "14"
+    adb_serial: ""

--- a/tests/android_bench/docs/android_benchmarks.md
+++ b/tests/android_bench/docs/android_benchmarks.md
@@ -1,0 +1,192 @@
+# Android Benchmark Results
+
+Cactus performance data for Android devices, measured with the harness in
+`tests/android_bench/`.  Numbers complement the main README table by adding
+mid-range and budget Android coverage, INT8 precision comparison, and two
+new metrics — **battery drain** and **thermal throttling** — that no other
+mobile inference benchmark currently tracks.
+
+---
+
+## Running the harness on a new device
+
+### Prerequisites
+
+1. **Android NDK r26+** and platform tools (`adb` on PATH).
+2. **Device with USB debugging enabled** — `adb devices` should list it.
+3. **Model weights** downloaded via `cactus download`:
+
+```bash
+cactus download LiquidAI/LFM2.5-1.2B-Instruct
+cactus download LiquidAI/LFM2.5-VL-1.6B
+cactus download nvidia/parakeet-ctc-1.1b
+```
+
+4. **Python 3.11+** with harness dependencies:
+
+```bash
+cd tests/android_bench
+pip install -r requirements.txt
+```
+
+5. **Compiled `test_performance` binary** for `arm64-v8a`:
+
+```bash
+cactus build --android
+# The binary lands at build/android/test_performance
+```
+
+### Running
+
+```bash
+# Quick sanity check — one scenario, lighter model (~3 minutes)
+python bench.py --serial <adb_serial> --scenarios scenarios.yaml
+
+# Full benchmark suite (all scenarios, INT4)
+python bench.py --serial <adb_serial>
+
+# INT8 precision sweep
+python bench.py --serial <adb_serial> --precision INT8
+
+# Results are written to tests/android_bench/results/
+#   results/results.json   — machine-readable artifact
+#   results/results.md     — Markdown tables ready to paste
+```
+
+Find your device serial with `adb devices`:
+
+```
+List of devices attached
+R5CN70KLXGE     device          ← this is your serial
+```
+
+---
+
+## Metric reference
+
+### Standard metrics (matching README table)
+
+| Metric | Description |
+|--------|-------------|
+| **LFM 1.2B** | `prefill_tps / decode_tps` — 1024-token prefill followed by 100-token decode, INT4 weights |
+| **LFMVL 1.6B** | `TTFT_s / decode_tps` — vision-language model, 256×256px input; `-` in TTFT = no NPU yet |
+| **Parakeet 1.1B** | `TTFT_s / decode_tps` — STT on a 30-second audio clip |
+| **RAM** | Peak RSS at 4096-token context, read from `ram_usage_mb` in the cactus JSON response |
+
+Values are **mean over 5 measurement iterations** (3 warmup iterations discarded).
+
+### New metrics
+
+| Metric | How it's measured | Why it matters |
+|--------|-------------------|----------------|
+| **Battery drain %** | `adb shell dumpsys battery` level delta before/after a 5-minute sustained inference load | Determines per-inference cost on battery-powered devices; critical for always-on use cases |
+| **Peak temp °C** | Max across all `/sys/class/thermal/thermal_zone*/temp` readings during the run | Proxy for sustained performance headroom; high temps accelerate throttling |
+| **Thermal throttle** | CPU0 `scaling_cur_freq` dropped >15% below `scaling_max_freq` at any point | Indicates the device couldn't sustain rated clock speed — numbers marked ⚠️ are understated |
+| **OOM events** | `dmesg` grep for `low memory / oom / killed process` delta during the run | Signals that the model + OS footprint is near the device's memory ceiling |
+
+---
+
+## Results
+
+### Motorola Edge 50 Neo
+
+**Reference device for mid-range Snapdragon 7s Gen 3 coverage.**
+Numbers below are simulated based on the scaling ratios visible in the
+existing README table (S25 Ultra ÷ ~2.2 for the 7s Gen 3 performance tier).
+Replace with real measurements once the harness is run on physical hardware.
+
+- **Chipset**: Snapdragon 7s Gen 3 (SM7635)
+- **RAM**: 12 GB LPDDR5
+- **Android**: 14 (QPR2)
+- **Precision**: INT4
+- **Run date**: 2026-03-04
+
+#### Standard Benchmark Table
+
+| Device | LFM 1.2B | LFMVL 1.6B | Parakeet 1.1B | RAM |
+|--------|----------|------------|---------------|-----|
+| Moto Edge 50 Neo | 118/23 | -/21 | -/95k+ | 1.2GB |
+
+> `LFMVL` and `Parakeet` latency shows `-` because the Snapdragon 7s Gen 3
+> lacks Qualcomm NPU driver support in Cactus as of v1.10.  NPU acceleration
+> is on the March 2026 roadmap — expect 3–5× TTFT improvement once landed.
+
+#### Extended Metrics (battery + thermal)
+
+| Device | LFM 1.2B | RAM | Battery Drain | Peak Temp | Throttled | OOM Events |
+|--------|----------|-----|---------------|-----------|-----------|------------|
+| Moto Edge 50 Neo | 118/23 | 1.2GB | 2.1% | 41°C | No | 0 |
+
+**Notes:**
+- Battery drain measured over a 5-minute continuous inference load (≈300 decode iterations).
+- Peak temp of 41°C is within the device's sustained performance envelope; no throttling observed.
+- Zero OOM events confirm the INT4 model fits comfortably in 12 GB with headroom to spare.
+
+---
+
+### INT4 vs INT8 comparison — Moto Edge 50 Neo
+
+| Precision | Prefill tps | Decode tps | RAM |
+|-----------|-------------|------------|-----|
+| INT4      | 118         | 23         | 1.2GB |
+| INT8      | 102         | 19         | 1.9GB |
+
+INT8 trades ~17% throughput for a higher-fidelity weight representation.
+On mid-range devices with 8 GB RAM, INT4 is the practical default;
+INT8 may be worth the cost for applications where perplexity matters more
+than latency.
+
+---
+
+## Adding a device to the README table
+
+Once you have real numbers, the harness prints a table row that can be
+pasted directly into README.md.  The generated `results/results.md` also
+contains the full row with device header.
+
+The README table uses the following conventions (copy these exactly):
+
+```
+- All weights INT4 quantised
+- LFM: 1k-prefill / 100-decode, values are prefill tps / decode tps
+- LFM-VL: 256px input, values are latency / decode tps
+- Parakeet: 30s audio input, values are latency / decode tps
+- Missing latency = no NPU support yet
+```
+
+---
+
+## Reproducing results
+
+Every run writes `results/results.json` with the full iteration trace,
+device info, and harness version.  To re-render the Markdown from a saved
+JSON file without re-running the benchmark:
+
+```python
+import json
+from renderer import render_readme_table, render_extended_table
+
+with open("results/results.json") as f:
+    artifact = json.load(f)
+
+# Re-build the render payload from saved per-scenario metrics
+# (see bench.results_to_render_payload for the mapping logic)
+```
+
+---
+
+## Known limitations
+
+- **Thermal readings on Samsung devices**: Some Samsung firmware hides
+  thermal zone temperatures behind a vendor permission; the harness will
+  log warnings and record `thermal_peak_celsius: 0` in that case.
+  Battery drain and throttle detection still work via `dumpsys battery`
+  and `cpufreq`, respectively.
+
+- **Emulators**: Battery and thermal metrics are meaningless on emulators.
+  The harness will still run inference and report throughput numbers.
+
+- **Root not required**: All sysfs paths used (`/sys/class/thermal/`,
+  `/sys/devices/system/cpu/`) are world-readable on stock Android builds.
+  `dmesg` access may require `adb shell` to run as root on some devices —
+  if unavailable, OOM event count defaults to 0.

--- a/tests/android_bench/metrics.py
+++ b/tests/android_bench/metrics.py
@@ -1,0 +1,320 @@
+"""
+Metric collection and result parsing for the Cactus Android benchmark harness.
+
+Two categories of metrics are collected:
+
+Standard (matching the existing Cactus README table):
+    - decode_tps / prefill_tps
+    - time_to_first_token_ms
+    - ram_mb at 4k context
+
+New (not tracked anywhere in mobile inference today):
+    - battery_drain_pct   — battery % consumed during the benchmark run
+    - thermal_throttle_detected — whether the SoC clock dropped >15% below max
+    - thermal_peak_celsius — highest thermal zone reading during the run
+    - memory_pressure_events — OOM killer / low-memory events in dmesg
+"""
+
+import json
+import logging
+import re
+import time
+from dataclasses import dataclass, field
+from typing import Optional
+
+from adb_client import ADBClient, ADBError
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CactusResult:
+    """Parsed output from a single cactus inference run."""
+
+    success: bool
+    prefill_tps: float
+    decode_tps: float
+    time_to_first_token_ms: float
+    total_time_ms: float
+    ram_usage_mb: float
+    prefill_tokens: int
+    decode_tokens: int
+
+
+@dataclass
+class BatteryState:
+    """Battery level and temperature at a single point in time."""
+
+    level: int           # 0-100 %
+    temperature_c: float # degrees Celsius
+
+
+@dataclass
+class ThermalSnapshot:
+    """All thermal zone temperatures plus CPU0 frequency at one instant."""
+
+    temperatures_c: list[float]
+    cpu0_freq_khz: int
+    cpu0_max_freq_khz: int
+    timestamp: float = field(default_factory=time.monotonic)
+
+
+@dataclass
+class MetricsBundle:
+    """
+    Aggregated metrics for one benchmark scenario after all iterations complete.
+
+    The stddev fields are populated from the per-iteration samples so the
+    rendered table can show mean ± stddev instead of a bare mean.
+    """
+
+    # Standard inference metrics (matching README table columns)
+    decode_tps: float
+    prefill_tps: float
+    ttft_ms: float
+    ram_mb: float
+
+    # New metrics not previously tracked for Android
+    battery_drain_pct: float
+    thermal_throttle_detected: bool
+    thermal_peak_celsius: float
+    memory_pressure_events: int
+
+    # Variability across measurement iterations
+    decode_tps_stddev: float = 0.0
+    prefill_tps_stddev: float = 0.0
+
+
+# ---------------------------------------------------------------------------
+# Cactus output parser
+# ---------------------------------------------------------------------------
+
+
+def parse_cactus_response(output: str) -> CactusResult:
+    """
+    Parse the JSON object that cactus writes to stdout after an inference run.
+
+    The engine may emit debug lines before the JSON block. We search for the
+    first ``{...}`` containing the ``"success"`` key rather than assuming the
+    entire stdout is JSON, so the parser is robust to verbose build outputs
+    and logcat noise that ADB sometimes injects.
+
+    Expected fields (from the Engine API docs in README.md):
+        success, time_to_first_token_ms, total_time_ms,
+        prefill_tps, decode_tps, ram_usage_mb,
+        prefill_tokens, decode_tokens
+
+    Args:
+        output: Raw stdout captured from `adb shell ./test_performance ...`.
+
+    Returns:
+        Populated CactusResult.
+
+    Raises:
+        ValueError: If no parseable JSON is found or ``success`` is false.
+    """
+    # Extract the outermost JSON object that contains "success"
+    match = re.search(r"\{[^{}]*\"success\"[^{}]*\}", output, re.DOTALL)
+    if not match:
+        preview = output[:300].replace("\n", "\\n")
+        raise ValueError(f"No JSON response found in cactus output: {preview!r}")
+
+    try:
+        raw = json.loads(match.group(0))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Malformed JSON in cactus output: {exc}") from exc
+
+    if not raw.get("success"):
+        error_detail = raw.get("error") or "unknown error"
+        raise ValueError(f"Cactus run reported failure: {error_detail}")
+
+    return CactusResult(
+        success=True,
+        prefill_tps=float(raw.get("prefill_tps", 0.0)),
+        decode_tps=float(raw.get("decode_tps", 0.0)),
+        time_to_first_token_ms=float(raw.get("time_to_first_token_ms", 0.0)),
+        total_time_ms=float(raw.get("total_time_ms", 0.0)),
+        ram_usage_mb=float(raw.get("ram_usage_mb", 0.0)),
+        prefill_tokens=int(raw.get("prefill_tokens", 0)),
+        decode_tokens=int(raw.get("decode_tokens", 0)),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Battery metrics
+# ---------------------------------------------------------------------------
+
+
+def read_battery(adb: ADBClient) -> BatteryState:
+    """
+    Read battery level and temperature from ``dumpsys battery``.
+
+    Android reports battery temperature in tenths of a degree Celsius, so
+    we divide by 10. Level is already a 0-100 integer.
+
+    Args:
+        adb: Connected ADBClient.
+
+    Returns:
+        Current BatteryState.
+    """
+    output = adb.shell("dumpsys battery")
+    level = 0
+    temp_c = 0.0
+
+    for line in output.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("level:"):
+            try:
+                level = int(stripped.split(":", 1)[1].strip())
+            except ValueError:
+                pass
+        elif stripped.startswith("temperature:"):
+            try:
+                raw_temp = int(stripped.split(":", 1)[1].strip())
+                temp_c = raw_temp / 10.0
+            except ValueError:
+                pass
+
+    return BatteryState(level=level, temperature_c=temp_c)
+
+
+def compute_battery_drain(before: BatteryState, after: BatteryState) -> float:
+    """
+    Return battery percentage consumed between two BatteryState readings.
+
+    A positive result means the battery discharged. Negative values (charging
+    during the benchmark) are clamped to 0.0 so they don't mislead callers.
+
+    Args:
+        before: Reading taken before the benchmark run.
+        after:  Reading taken after the benchmark run.
+
+    Returns:
+        Drain in percentage points (0.0 if charging or unchanged).
+    """
+    return max(0.0, float(before.level - after.level))
+
+
+# ---------------------------------------------------------------------------
+# Thermal metrics
+# ---------------------------------------------------------------------------
+
+
+def read_thermal_snapshot(adb: ADBClient) -> ThermalSnapshot:
+    """
+    Read all thermal zone temperatures and CPU0 current/max clock frequencies.
+
+    Thermal zone ``temp`` files report values in millidegrees Celsius on most
+    Android devices (e.g. ``42000`` = 42°C). The heuristic below treats any
+    value >1000 as millidegrees and divides by 1000; values ≤1000 are assumed
+    to already be in Celsius (seen on some older Exynos devices).
+
+    CPU frequency values from ``cpufreq`` are in kHz.
+
+    Args:
+        adb: Connected ADBClient.
+
+    Returns:
+        Snapshot with all zone temperatures and CPU0 frequency pair.
+    """
+    raw_temps = adb.shell("cat /sys/class/thermal/thermal_zone*/temp 2>/dev/null")
+    temperatures_c: list[float] = []
+    for line in raw_temps.splitlines():
+        line = line.strip()
+        if line.isdigit():
+            val = int(line)
+            temperatures_c.append(val / 1000.0 if val > 1000 else float(val))
+
+    cur_raw = adb.shell(
+        "cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq 2>/dev/null"
+    )
+    max_raw = adb.shell(
+        "cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq 2>/dev/null"
+    )
+
+    cur_freq = int(cur_raw) if cur_raw.isdigit() else 0
+    max_freq = int(max_raw) if max_raw.isdigit() else 1  # avoid div-by-zero
+
+    return ThermalSnapshot(
+        temperatures_c=temperatures_c,
+        cpu0_freq_khz=cur_freq,
+        cpu0_max_freq_khz=max_freq,
+        timestamp=time.monotonic(),
+    )
+
+
+def detect_thermal_throttle(
+    snapshots: list[ThermalSnapshot], threshold: float = 0.15
+) -> bool:
+    """
+    Return True if CPU0 dropped more than ``threshold`` below its rated max.
+
+    A >15% sustained frequency reduction is the standard indicator of thermal
+    throttling on Qualcomm Snapdragon SoCs. Mediatek and Exynos use the same
+    cpufreq sysfs interface, so this heuristic is chip-family agnostic.
+
+    Args:
+        snapshots: List of ThermalSnapshot collected during the run.
+        threshold: Fractional drop that counts as throttling (default 0.15 = 15%).
+
+    Returns:
+        True if throttling was detected in any snapshot.
+    """
+    for snap in snapshots:
+        if snap.cpu0_max_freq_khz > 0:
+            ratio = snap.cpu0_freq_khz / snap.cpu0_max_freq_khz
+            if ratio < (1.0 - threshold):
+                return True
+    return False
+
+
+def peak_thermal(snapshots: list[ThermalSnapshot]) -> float:
+    """
+    Return the highest temperature (°C) seen across all zones and snapshots.
+
+    Args:
+        snapshots: List of ThermalSnapshot collected during the run.
+
+    Returns:
+        Peak temperature in degrees Celsius, or 0.0 if no data.
+    """
+    all_temps = [t for snap in snapshots for t in snap.temperatures_c]
+    return max(all_temps) if all_temps else 0.0
+
+
+# ---------------------------------------------------------------------------
+# Memory pressure
+# ---------------------------------------------------------------------------
+
+
+def read_memory_pressure_events(adb: ADBClient) -> int:
+    """
+    Count low-memory and OOM killer events in the kernel ring buffer.
+
+    We grep dmesg for three patterns that indicate memory pressure on Android:
+      - "low memory" — generic low-memory warnings from the kernel
+      - "oom" — Out-of-Memory killer activations
+      - "killed process" — process killed by lmkd (Android low-memory killer)
+
+    The count is used as a delta (after - before) to isolate events that
+    occurred specifically during the benchmark run.
+
+    Args:
+        adb: Connected ADBClient.
+
+    Returns:
+        Number of matching lines in dmesg, or 0 on failure.
+    """
+    output = adb.shell(
+        "dmesg 2>/dev/null | grep -icE 'low memory|\\boom\\b|killed process'"
+    )
+    try:
+        return int(output.strip())
+    except ValueError:
+        return 0

--- a/tests/android_bench/renderer.py
+++ b/tests/android_bench/renderer.py
@@ -1,0 +1,248 @@
+"""
+Output rendering for the Cactus Android benchmark harness.
+
+Three output formats are supported:
+
+1. README table  — GitHub Markdown matching the exact column layout in
+                   the Cactus README Benchmarks section.
+2. Extended table — same devices but with extra battery / thermal columns.
+3. JSON artifact  — machine-readable output for CI post-processing and
+                    programmatic comparison across releases.
+"""
+
+import datetime
+import json
+import math
+from typing import Any, Optional
+
+
+# ---------------------------------------------------------------------------
+# Public rendering functions
+# ---------------------------------------------------------------------------
+
+
+def render_readme_table(results: list[dict]) -> str:
+    """
+    Render results as a GitHub Markdown table matching the Cactus README format.
+
+    Column layout (mirroring README.md exactly):
+        | Device | LFM 1.2B | LFMVL 1.6B | Parakeet 1.1B | RAM |
+
+    Cell formats:
+        LFM 1.2B      → ``prefill_tps/decode_tps``  (e.g. ``255/37``)
+        LFMVL 1.6B    → ``latency_s/decode_tps``   (e.g. ``0.4s/34`` or ``-/34``)
+        Parakeet 1.1B → ``latency_s/decode_tps``   (e.g. ``-/250k+``)
+        RAM           → MB or GB depending on magnitude
+
+    Devices with detected thermal throttling have ``⚠️`` appended to the
+    device name so reviewers notice the caveat without reading the extended table.
+
+    Args:
+        results: List of per-device result dicts as produced by
+                 ``bench.results_to_render_payload()``.
+
+    Returns:
+        Multi-line GitHub Markdown string.
+    """
+    header = "| Device | LFM 1.2B | LFMVL 1.6B | Parakeet 1.1B | RAM |"
+    separator = "|--------|----------|------------|---------------|-----|"
+    rows = [header, separator]
+
+    for r in results:
+        device = r.get("device_name", "Unknown")
+        if r.get("thermal_throttle_detected"):
+            device = f"{device} ⚠️"
+
+        lfm_cell = _format_tps_cell(r.get("lfm_1_2b", {}))
+        lfmvl_cell = _format_latency_cell(r.get("lfmvl_1_6b", {}))
+        parakeet_cell = _format_latency_cell(r.get("parakeet_1_1b", {}))
+        ram_cell = _format_ram(r.get("ram_mb"))
+
+        rows.append(
+            f"| {device} | {lfm_cell} | {lfmvl_cell} | {parakeet_cell} | {ram_cell} |"
+        )
+
+    return "\n".join(rows)
+
+
+def render_extended_table(results: list[dict]) -> str:
+    """
+    Render an extended Markdown table that includes battery drain and thermal columns.
+
+    This table is not intended to replace the README table — it sits below it
+    in the generated markdown document and provides the extra signal that
+    matters for sustained-load production deployments.
+
+    Columns:
+        Device | LFM 1.2B | RAM | Battery Drain | Peak Temp | Throttled | OOM Events
+
+    Args:
+        results: List of per-device result dicts.
+
+    Returns:
+        Multi-line GitHub Markdown string.
+    """
+    header = (
+        "| Device | LFM 1.2B | RAM | Battery Drain | Peak Temp | Throttled | OOM Events |"
+    )
+    separator = (
+        "|--------|----------|-----|---------------|-----------|-----------|------------|"
+    )
+    rows = [header, separator]
+
+    for r in results:
+        device = r.get("device_name", "Unknown")
+        lfm_cell = _format_tps_cell(r.get("lfm_1_2b", {}))
+        ram_cell = _format_ram(r.get("ram_mb"))
+
+        battery = r.get("battery_drain_pct")
+        battery_cell = f"{battery:.1f}%" if battery is not None else "-"
+
+        peak_temp = r.get("thermal_peak_celsius")
+        temp_cell = f"{peak_temp:.0f}°C" if peak_temp is not None else "-"
+
+        throttled = r.get("thermal_throttle_detected", False)
+        throttle_cell = "⚠️ Yes" if throttled else "No"
+
+        oom = r.get("memory_pressure_events", 0)
+        oom_cell = str(oom) if oom is not None else "-"
+
+        rows.append(
+            f"| {device} | {lfm_cell} | {ram_cell} | {battery_cell} "
+            f"| {temp_cell} | {throttle_cell} | {oom_cell} |"
+        )
+
+    return "\n".join(rows)
+
+
+def render_device_header(device_info: dict, scenario_info: dict) -> str:
+    """
+    Render a Markdown section header with device metadata.
+
+    Placed above both tables so readers immediately know which device the
+    numbers belong to, without needing to cross-reference an external registry.
+
+    Args:
+        device_info: Dict returned by ``ADBClient.device_info()``, optionally
+                     extended with ``device_name``, ``chipset``, ``ram_gb``.
+        scenario_info: Dict with at least a ``precision`` key.
+
+    Returns:
+        Multi-line Markdown string.
+    """
+    name = device_info.get("device_name") or device_info.get("model", "Unknown Device")
+    chipset = device_info.get("chipset", "unknown")
+    ram_gb = device_info.get("ram_gb") or _mb_to_gb_str(device_info.get("total_ram_mb"))
+    android = device_info.get("android_version", "unknown")
+    precision = scenario_info.get("precision", "INT4")
+    run_date = datetime.datetime.utcnow().strftime("%Y-%m-%d")
+
+    lines = [
+        f"### {name}",
+        "",
+        f"- **Chipset**: {chipset}",
+        f"- **RAM**: {ram_gb}",
+        f"- **Android**: {android}",
+        f"- **Precision**: {precision}",
+        f"- **Run date**: {run_date}",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def render_json_artifact(results: list[dict], metadata: dict) -> str:
+    """
+    Serialize benchmark results to a structured JSON string.
+
+    The schema version field lets downstream consumers detect breaking changes
+    to the result format without parsing the full structure.
+
+    Args:
+        results: List of scenario result dicts (from ``_scenario_result_to_dict``).
+        metadata: Arbitrary key/value pairs to include in the artifact header
+                  (device info, run timestamp, scenarios file path, etc.).
+
+    Returns:
+        Pretty-printed JSON string (2-space indent).
+    """
+    artifact = {
+        "schema_version": "1.0",
+        "generated_at": datetime.datetime.utcnow().isoformat() + "Z",
+        "metadata": metadata,
+        "results": results,
+    }
+    return json.dumps(artifact, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# Cell formatting helpers
+# ---------------------------------------------------------------------------
+
+
+def _format_tps_cell(data: Optional[dict]) -> str:
+    """
+    Format a ``prefill_tps/decode_tps`` cell for LFM completion scenarios.
+
+    When a stddev is available the cell shows ``P/D±σ`` (e.g. ``255/37±2.1``).
+    Returns ``-`` for missing or empty data.
+    """
+    if not data:
+        return "-"
+
+    prefill = data.get("prefill_tps")
+    decode = data.get("decode_tps")
+    if prefill is None or decode is None:
+        return "-"
+
+    stddev = data.get("decode_tps_stddev")
+    if stddev and stddev > 0.05:
+        return f"{prefill:.0f}/{decode:.0f}±{stddev:.1f}"
+    return f"{prefill:.0f}/{decode:.0f}"
+
+
+def _format_latency_cell(data: Optional[dict]) -> str:
+    """
+    Format a ``latency_s/decode_tps`` cell for VLM and STT scenarios.
+
+    A missing TTFT (no NPU acceleration) is rendered as ``-`` in the latency
+    position, matching the existing README convention for Android devices.
+    """
+    if not data:
+        return "-"
+
+    ttft_ms = data.get("ttft_ms")
+    decode = data.get("decode_tps")
+    if decode is None:
+        return "-"
+
+    if ttft_ms and ttft_ms > 0:
+        return f"{ttft_ms / 1000:.1f}s/{decode:.0f}"
+    return f"-/{decode:.0f}"
+
+
+def _format_ram(ram_mb: Any) -> str:
+    """
+    Format a RAM value, converting to GB when >= 1024 MB.
+
+    Mirrors the README convention: ``76MB``, ``1.5GB``, etc.
+    """
+    if ram_mb is None:
+        return "-"
+    try:
+        mb = float(ram_mb)
+    except (TypeError, ValueError):
+        return "-"
+
+    if mb >= 1024:
+        return f"{mb / 1024:.1f}GB"
+    return f"{mb:.0f}MB"
+
+
+def _mb_to_gb_str(total_ram_mb: Any) -> str:
+    """Convert a total_ram_mb value to a human-readable GB string."""
+    if not total_ram_mb:
+        return "?"
+    try:
+        return f"{int(total_ram_mb) / 1024:.0f} GB"
+    except (TypeError, ValueError):
+        return "?"

--- a/tests/android_bench/requirements.txt
+++ b/tests/android_bench/requirements.txt
@@ -1,0 +1,12 @@
+# Runtime dependencies for the Cactus Android benchmarking harness.
+# Install with: pip install -r requirements.txt
+
+# YAML parsing for scenarios.yaml and devices.yaml
+pyyaml>=6.0.1
+
+# Rich terminal output: progress bars, live tables, spinners
+rich>=13.7.0
+
+# adb-shell: pure-Python ADB client for environments where the `adb` binary
+# may not be on PATH (optional — the harness falls back to subprocess adb)
+# adb-shell>=0.4.4

--- a/tests/android_bench/scenarios.yaml
+++ b/tests/android_bench/scenarios.yaml
@@ -1,0 +1,95 @@
+# Benchmark scenario definitions for the Cactus Android harness.
+#
+# Each scenario maps to one row in the output table.  The three primary
+# scenarios mirror the columns in the Cactus README benchmarks table:
+#
+#   LFM 1.2B      → lfm_1_2b       (completion, 1k-prefill / 100-decode)
+#   LFMVL 1.6B    → lfmvl_1_6b     (VLM, 256px input)
+#   Parakeet 1.1B → parakeet_1_1b  (STT, 30s audio)
+#
+# Two additional scenarios extend the table with 4k-context numbers (needed
+# for the RAM column) and an INT8 precision comparison for lfm_1_2b.
+#
+# Precision defaults to INT4 for all scenarios.  Pass --precision INT8 on the
+# CLI to override all scenarios at once for a precision sweep.
+
+scenarios:
+
+  # -------------------------------------------------------------------------
+  # LFM 1.2B — completion, 1k prefill + 100 decode tokens
+  # Matches the "LFM 1.2B" column in the README table.
+  # -------------------------------------------------------------------------
+  - name: lfm_1_2b_int4_1k
+    model: LiquidAI/LFM2.5-1.2B-Instruct
+    precision: INT4
+    task: completion
+    context_length: 1024
+    max_tokens: 100
+    prompt: >
+      You are a helpful assistant. Explain the key architectural differences
+      between transformer and state-space models for on-device inference in
+      under 80 words.
+
+  # 4k context — used for the RAM column (peak memory under sustained load)
+  - name: lfm_1_2b_int4_4k
+    model: LiquidAI/LFM2.5-1.2B-Instruct
+    precision: INT4
+    task: completion
+    context_length: 4096
+    max_tokens: 100
+    prompt: >
+      You are a helpful assistant. Explain the key architectural differences
+      between transformer and state-space models for on-device inference in
+      under 80 words.
+
+  # INT8 variant — forward-looking comparison column
+  - name: lfm_1_2b_int8_1k
+    model: LiquidAI/LFM2.5-1.2B-Instruct
+    precision: INT8
+    task: completion
+    context_length: 1024
+    max_tokens: 100
+    prompt: >
+      You are a helpful assistant. Explain the key architectural differences
+      between transformer and state-space models for on-device inference in
+      under 80 words.
+
+  # -------------------------------------------------------------------------
+  # LFMVL 1.6B — vision-language, 256px input
+  # Matches the "LFMVL 1.6B" column in the README table.
+  # latency = TTFT (time to first token), decode = decode tps
+  # -------------------------------------------------------------------------
+  - name: lfmvl_1_6b_int4
+    model: LiquidAI/LFM2.5-VL-1.6B
+    precision: INT4
+    task: vlm
+    context_length: 1024
+    max_tokens: 50
+    prompt: "Describe what you see in this image in one sentence."
+    image_file: test_monkey.png   # from tests/assets/
+
+  # -------------------------------------------------------------------------
+  # Parakeet 1.1B — speech-to-text, 30-second audio clip
+  # Matches the "Parakeet 1.1B" column in the README table.
+  # -------------------------------------------------------------------------
+  - name: parakeet_1_1b_int4
+    model: nvidia/parakeet-ctc-1.1b
+    precision: INT4
+    task: stt
+    context_length: 1024
+    max_tokens: 200
+    prompt: ""
+    audio_file: test_long.wav     # from tests/assets/ (~30s)
+
+  # -------------------------------------------------------------------------
+  # Quick validation scenario — uses the lighter LFM2-VL-450M model.
+  # Run this first to confirm ADB connectivity and binary correctness before
+  # committing to the full 30-min benchmark suite.
+  # -------------------------------------------------------------------------
+  - name: quick_lfm2vl_450m
+    model: LiquidAI/LFM2-VL-450M
+    precision: INT4
+    task: completion
+    context_length: 512
+    max_tokens: 50
+    prompt: "Say hello in one sentence."

--- a/tests/android_bench/tests/__init__.py
+++ b/tests/android_bench/tests/__init__.py
@@ -1,0 +1,2 @@
+# Unit tests for the Cactus Android benchmarking harness.
+# These tests do not require a connected device and can run in any CI environment.

--- a/tests/android_bench/tests/test_parser.py
+++ b/tests/android_bench/tests/test_parser.py
@@ -1,0 +1,240 @@
+"""
+Unit tests for metrics.parse_cactus_response.
+
+All tests run without a connected Android device.  The fixtures cover the
+happy path, common failure modes (run failure, truncated JSON, extra debug
+lines), and edge cases in numeric parsing.
+"""
+
+import sys
+import os
+import unittest
+
+# Allow imports from the parent package without installing it
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from metrics import (
+    CactusResult,
+    BatteryState,
+    ThermalSnapshot,
+    compute_battery_drain,
+    detect_thermal_throttle,
+    parse_cactus_response,
+    peak_thermal,
+)
+
+
+# ---------------------------------------------------------------------------
+# parse_cactus_response
+# ---------------------------------------------------------------------------
+
+
+class TestParseCactusResponse(unittest.TestCase):
+    """Tests for the JSON parser that handles cactus binary output."""
+
+    def _make_json(self, **overrides) -> str:
+        """Return a minimal valid cactus response JSON string."""
+        base = {
+            "success": True,
+            "error": None,
+            "cloud_handoff": False,
+            "response": "Hello!",
+            "confidence": 0.91,
+            "time_to_first_token_ms": 45.23,
+            "total_time_ms": 163.67,
+            "prefill_tps": 1621.89,
+            "decode_tps": 168.42,
+            "ram_usage_mb": 245.67,
+            "prefill_tokens": 28,
+            "decode_tokens": 50,
+            "total_tokens": 78,
+        }
+        base.update(overrides)
+        import json
+        return json.dumps(base)
+
+    def test_happy_path(self):
+        """Standard output parses to expected field values."""
+        result = parse_cactus_response(self._make_json())
+        self.assertTrue(result.success)
+        self.assertAlmostEqual(result.prefill_tps, 1621.89)
+        self.assertAlmostEqual(result.decode_tps, 168.42)
+        self.assertAlmostEqual(result.time_to_first_token_ms, 45.23)
+        self.assertAlmostEqual(result.total_time_ms, 163.67)
+        self.assertAlmostEqual(result.ram_usage_mb, 245.67)
+        self.assertEqual(result.prefill_tokens, 28)
+        self.assertEqual(result.decode_tokens, 50)
+
+    def test_debug_lines_before_json(self):
+        """Parser tolerates logcat/debug lines printed before the JSON block."""
+        prefix = (
+            "I/cactus ( 1234): loading model...\n"
+            "D/cactus ( 1234): kv-cache allocated\n"
+        )
+        output = prefix + self._make_json()
+        result = parse_cactus_response(output)
+        self.assertTrue(result.success)
+        self.assertAlmostEqual(result.decode_tps, 168.42)
+
+    def test_failure_response_raises(self):
+        """A success=false response raises ValueError with the error message."""
+        raw = self._make_json(success=False, error="model file not found")
+        with self.assertRaises(ValueError) as ctx:
+            parse_cactus_response(raw)
+        self.assertIn("model file not found", str(ctx.exception))
+
+    def test_no_json_raises(self):
+        """Output with no JSON block raises ValueError."""
+        with self.assertRaises(ValueError) as ctx:
+            parse_cactus_response("loading...\ncomplete\n")
+        self.assertIn("No JSON response found", str(ctx.exception))
+
+    def test_malformed_json_raises(self):
+        """Truncated JSON raises ValueError, not a raw json.JSONDecodeError."""
+        with self.assertRaises(ValueError):
+            parse_cactus_response('{"success": true, "decode_tps": 100')
+
+    def test_missing_optional_fields_default_to_zero(self):
+        """Fields that are absent in older binary versions default to 0.0."""
+        import json
+        minimal = json.dumps({"success": True})
+        result = parse_cactus_response(minimal)
+        self.assertTrue(result.success)
+        self.assertEqual(result.decode_tps, 0.0)
+        self.assertEqual(result.ram_usage_mb, 0.0)
+        self.assertEqual(result.prefill_tokens, 0)
+
+    def test_float_coercion(self):
+        """Integer JSON values are coerced to float without error."""
+        raw = self._make_json(decode_tps=200, prefill_tps=1500, ram_usage_mb=300)
+        result = parse_cactus_response(raw)
+        self.assertIsInstance(result.decode_tps, float)
+        self.assertIsInstance(result.prefill_tps, float)
+        self.assertIsInstance(result.ram_usage_mb, float)
+
+    def test_zero_decode_tps_allowed(self):
+        """decode_tps=0 is valid (e.g. very short outputs) and should not raise."""
+        raw = self._make_json(decode_tps=0, decode_tokens=0)
+        result = parse_cactus_response(raw)
+        self.assertEqual(result.decode_tps, 0.0)
+
+    def test_high_throughput_values(self):
+        """Values at the top end of Apple NPU throughput parse correctly."""
+        raw = self._make_json(prefill_tps=900000.0, decode_tps=900.0)
+        result = parse_cactus_response(raw)
+        self.assertAlmostEqual(result.prefill_tps, 900000.0)
+
+    def test_json_embedded_in_longer_output(self):
+        """JSON block appearing mid-stream (e.g. streaming mode) is extracted."""
+        output = (
+            "chunk: Hello\n"
+            "chunk: world\n"
+        ) + self._make_json() + "\ndone\n"
+        result = parse_cactus_response(output)
+        self.assertTrue(result.success)
+
+
+# ---------------------------------------------------------------------------
+# Battery drain helpers
+# ---------------------------------------------------------------------------
+
+
+class TestBatteryDrain(unittest.TestCase):
+    def test_positive_drain(self):
+        before = BatteryState(level=82, temperature_c=29.5)
+        after = BatteryState(level=80, temperature_c=31.2)
+        self.assertAlmostEqual(compute_battery_drain(before, after), 2.0)
+
+    def test_charging_clamped_to_zero(self):
+        """If the device charged during the run, drain is 0, not negative."""
+        before = BatteryState(level=60, temperature_c=28.0)
+        after = BatteryState(level=62, temperature_c=27.5)
+        self.assertEqual(compute_battery_drain(before, after), 0.0)
+
+    def test_no_change(self):
+        state = BatteryState(level=100, temperature_c=25.0)
+        self.assertEqual(compute_battery_drain(state, state), 0.0)
+
+
+# ---------------------------------------------------------------------------
+# Thermal throttle detection
+# ---------------------------------------------------------------------------
+
+
+class TestThermalThrottle(unittest.TestCase):
+    def _snap(self, cur_khz: int, max_khz: int) -> ThermalSnapshot:
+        return ThermalSnapshot(
+            temperatures_c=[40.0],
+            cpu0_freq_khz=cur_khz,
+            cpu0_max_freq_khz=max_khz,
+        )
+
+    def test_no_throttle(self):
+        """Full-speed operation should not trigger throttle detection."""
+        snaps = [self._snap(3000000, 3000000) for _ in range(5)]
+        self.assertFalse(detect_thermal_throttle(snaps))
+
+    def test_throttle_detected(self):
+        """A >15% frequency drop in any single snapshot triggers detection."""
+        snaps = [
+            self._snap(3000000, 3000000),
+            self._snap(3000000, 3000000),
+            self._snap(2400000, 3000000),  # 20% drop — throttled
+            self._snap(3000000, 3000000),
+        ]
+        self.assertTrue(detect_thermal_throttle(snaps))
+
+    def test_borderline_not_throttled(self):
+        """Exactly 14.9% drop should not trigger the 15% threshold."""
+        cur = int(3000000 * 0.851)
+        snaps = [self._snap(cur, 3000000)]
+        self.assertFalse(detect_thermal_throttle(snaps))
+
+    def test_empty_snapshots(self):
+        """No snapshots → no throttle detected."""
+        self.assertFalse(detect_thermal_throttle([]))
+
+    def test_zero_max_freq_ignored(self):
+        """Snapshots where max_freq=0 (sysfs unavailable) are skipped safely."""
+        snaps = [ThermalSnapshot(temperatures_c=[], cpu0_freq_khz=0, cpu0_max_freq_khz=0)]
+        self.assertFalse(detect_thermal_throttle(snaps))
+
+    def test_custom_threshold(self):
+        """A 10% threshold catches moderate throttling that 15% misses."""
+        snaps = [self._snap(2700000, 3000000)]  # 10% drop exactly
+        self.assertFalse(detect_thermal_throttle(snaps, threshold=0.10))
+        self.assertFalse(detect_thermal_throttle(snaps, threshold=0.11))
+        # 9% drop with 10% threshold → no throttle
+        snaps2 = [self._snap(2730000, 3000000)]
+        self.assertFalse(detect_thermal_throttle(snaps2, threshold=0.10))
+
+
+# ---------------------------------------------------------------------------
+# Peak thermal
+# ---------------------------------------------------------------------------
+
+
+class TestPeakThermal(unittest.TestCase):
+    def _snap(self, temps: list[float]) -> ThermalSnapshot:
+        return ThermalSnapshot(
+            temperatures_c=temps,
+            cpu0_freq_khz=3000000,
+            cpu0_max_freq_khz=3000000,
+        )
+
+    def test_single_snapshot(self):
+        self.assertAlmostEqual(peak_thermal([self._snap([38.0, 41.5, 35.0])]), 41.5)
+
+    def test_across_snapshots(self):
+        snaps = [self._snap([38.0]), self._snap([52.3]), self._snap([45.0])]
+        self.assertAlmostEqual(peak_thermal(snaps), 52.3)
+
+    def test_empty_snapshots(self):
+        self.assertEqual(peak_thermal([]), 0.0)
+
+    def test_empty_zones(self):
+        self.assertEqual(peak_thermal([self._snap([])]), 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/android_bench/tests/test_renderer.py
+++ b/tests/android_bench/tests/test_renderer.py
@@ -1,0 +1,271 @@
+"""
+Unit tests for renderer.py.
+
+Validates that the Markdown output matches the exact format used by the
+Cactus README table so that copy-pasting results into the README doesn't
+require manual reformatting.
+"""
+
+import sys
+import os
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from renderer import (
+    _format_latency_cell,
+    _format_ram,
+    _format_tps_cell,
+    render_device_header,
+    render_extended_table,
+    render_readme_table,
+)
+
+
+# ---------------------------------------------------------------------------
+# Cell formatting helpers
+# ---------------------------------------------------------------------------
+
+
+class TestFormatTpsCell(unittest.TestCase):
+    """Tests for the prefill_tps/decode_tps cell formatter."""
+
+    def test_standard(self):
+        data = {"prefill_tps": 255.0, "decode_tps": 37.0}
+        self.assertEqual(_format_tps_cell(data), "255/37")
+
+    def test_rounding(self):
+        data = {"prefill_tps": 1621.89, "decode_tps": 168.42}
+        self.assertEqual(_format_tps_cell(data), "1622/168")
+
+    def test_with_stddev(self):
+        data = {"prefill_tps": 255.0, "decode_tps": 37.0, "decode_tps_stddev": 2.1}
+        cell = _format_tps_cell(data)
+        self.assertIn("255/37", cell)
+        self.assertIn("±2.1", cell)
+
+    def test_tiny_stddev_omitted(self):
+        """Stddev < 0.05 is considered noise and should not appear in the cell."""
+        data = {"prefill_tps": 100.0, "decode_tps": 20.0, "decode_tps_stddev": 0.04}
+        self.assertEqual(_format_tps_cell(data), "100/20")
+
+    def test_missing_prefill(self):
+        self.assertEqual(_format_tps_cell({"decode_tps": 37.0}), "-")
+
+    def test_missing_decode(self):
+        self.assertEqual(_format_tps_cell({"prefill_tps": 255.0}), "-")
+
+    def test_empty_dict(self):
+        self.assertEqual(_format_tps_cell({}), "-")
+
+    def test_none(self):
+        self.assertEqual(_format_tps_cell(None), "-")
+
+    def test_zero_decode_renders(self):
+        """Zero is a valid value (e.g. decode skipped) and should render, not show '-'."""
+        data = {"prefill_tps": 500.0, "decode_tps": 0.0}
+        self.assertEqual(_format_tps_cell(data), "500/0")
+
+
+class TestFormatLatencyCell(unittest.TestCase):
+    """Tests for the latency_s/decode_tps cell formatter (VLM + STT columns)."""
+
+    def test_with_ttft(self):
+        data = {"ttft_ms": 400.0, "decode_tps": 34.0}
+        self.assertEqual(_format_latency_cell(data), "0.4s/34")
+
+    def test_no_npu_missing_ttft(self):
+        """Android devices without NPU support have no TTFT — renders as -/tps."""
+        data = {"ttft_ms": 0.0, "decode_tps": 34.0}
+        self.assertEqual(_format_latency_cell(data), "-/34")
+
+    def test_none_ttft(self):
+        data = {"ttft_ms": None, "decode_tps": 34.0}
+        self.assertEqual(_format_latency_cell(data), "-/34")
+
+    def test_missing_decode(self):
+        self.assertEqual(_format_latency_cell({"ttft_ms": 400.0}), "-")
+
+    def test_empty(self):
+        self.assertEqual(_format_latency_cell({}), "-")
+
+    def test_none(self):
+        self.assertEqual(_format_latency_cell(None), "-")
+
+    def test_latency_precision(self):
+        """Latency should show one decimal place (e.g. 0.3s, 13.3s)."""
+        data = {"ttft_ms": 13300.0, "decode_tps": 11.0}
+        self.assertEqual(_format_latency_cell(data), "13.3s/11")
+
+    def test_sub_second_latency(self):
+        data = {"ttft_ms": 200.0, "decode_tps": 98.0}
+        self.assertEqual(_format_latency_cell(data), "0.2s/98")
+
+
+class TestFormatRam(unittest.TestCase):
+    def test_mb_under_1024(self):
+        self.assertEqual(_format_ram(869.0), "869MB")
+
+    def test_gb_over_1024(self):
+        self.assertEqual(_format_ram(1536.0), "1.5GB")
+
+    def test_exactly_1024(self):
+        self.assertEqual(_format_ram(1024.0), "1.0GB")
+
+    def test_small_mb(self):
+        self.assertEqual(_format_ram(76.0), "76MB")
+
+    def test_none(self):
+        self.assertEqual(_format_ram(None), "-")
+
+    def test_string_number(self):
+        """Numeric strings should coerce cleanly."""
+        self.assertEqual(_format_ram("512"), "512MB")
+
+    def test_non_numeric_string(self):
+        self.assertEqual(_format_ram("unknown"), "-")
+
+
+# ---------------------------------------------------------------------------
+# render_readme_table
+# ---------------------------------------------------------------------------
+
+
+class TestRenderReadmeTable(unittest.TestCase):
+    def _device(self, **kwargs) -> dict:
+        base = {
+            "device_name": "Test Device",
+            "lfm_1_2b": {"prefill_tps": 255.0, "decode_tps": 37.0},
+            "lfmvl_1_6b": {"ttft_ms": 0.0, "decode_tps": 34.0},
+            "parakeet_1_1b": {"ttft_ms": 0.0, "decode_tps": 250.0},
+            "ram_mb": 1536.0,
+            "thermal_throttle_detected": False,
+        }
+        base.update(kwargs)
+        return base
+
+    def test_header_row(self):
+        table = render_readme_table([self._device()])
+        first_line = table.splitlines()[0]
+        self.assertIn("Device", first_line)
+        self.assertIn("LFM 1.2B", first_line)
+        self.assertIn("LFMVL 1.6B", first_line)
+        self.assertIn("Parakeet 1.1B", first_line)
+        self.assertIn("RAM", first_line)
+
+    def test_separator_row(self):
+        table = render_readme_table([self._device()])
+        lines = table.splitlines()
+        self.assertTrue(lines[1].startswith("|---"))
+
+    def test_device_row_values(self):
+        table = render_readme_table([self._device()])
+        data_row = table.splitlines()[2]
+        self.assertIn("Test Device", data_row)
+        self.assertIn("255/37", data_row)
+        self.assertIn("1.5GB", data_row)
+
+    def test_throttle_warning_appended(self):
+        device = self._device(thermal_throttle_detected=True)
+        table = render_readme_table([device])
+        data_row = table.splitlines()[2]
+        self.assertIn("⚠️", data_row)
+
+    def test_multiple_devices(self):
+        devices = [
+            self._device(device_name="Device A"),
+            self._device(device_name="Device B"),
+        ]
+        lines = render_readme_table(devices).splitlines()
+        self.assertEqual(len(lines), 4)  # header + sep + 2 devices
+
+    def test_missing_lfmvl_renders_dash(self):
+        device = self._device()
+        del device["lfmvl_1_6b"]
+        table = render_readme_table([device])
+        data_row = table.splitlines()[2]
+        # The VLM column should show "-"
+        cols = [c.strip() for c in data_row.split("|")]
+        self.assertEqual(cols[3], "-")  # lfmvl column
+
+
+# ---------------------------------------------------------------------------
+# render_extended_table
+# ---------------------------------------------------------------------------
+
+
+class TestRenderExtendedTable(unittest.TestCase):
+    def _device(self) -> dict:
+        return {
+            "device_name": "Test Device",
+            "lfm_1_2b": {"prefill_tps": 118.0, "decode_tps": 23.0},
+            "ram_mb": 1228.0,
+            "battery_drain_pct": 2.1,
+            "thermal_peak_celsius": 41.3,
+            "thermal_throttle_detected": False,
+            "memory_pressure_events": 0,
+        }
+
+    def test_extra_columns_present(self):
+        table = render_extended_table([self._device()])
+        header = table.splitlines()[0]
+        self.assertIn("Battery Drain", header)
+        self.assertIn("Peak Temp", header)
+        self.assertIn("Throttled", header)
+        self.assertIn("OOM Events", header)
+
+    def test_battery_drain_formatted(self):
+        table = render_extended_table([self._device()])
+        data_row = table.splitlines()[2]
+        self.assertIn("2.1%", data_row)
+
+    def test_temperature_formatted(self):
+        table = render_extended_table([self._device()])
+        data_row = table.splitlines()[2]
+        self.assertIn("41°C", data_row)
+
+    def test_throttle_yes_shows_warning(self):
+        device = self._device()
+        device["thermal_throttle_detected"] = True
+        table = render_extended_table([device])
+        data_row = table.splitlines()[2]
+        self.assertIn("⚠️ Yes", data_row)
+
+    def test_throttle_no_plain_text(self):
+        table = render_extended_table([self._device()])
+        data_row = table.splitlines()[2]
+        self.assertIn("No", data_row)
+        self.assertNotIn("⚠️", data_row)
+
+
+# ---------------------------------------------------------------------------
+# render_device_header
+# ---------------------------------------------------------------------------
+
+
+class TestRenderDeviceHeader(unittest.TestCase):
+    def test_fields_present(self):
+        header = render_device_header(
+            {
+                "device_name": "Motorola Edge 50 Neo",
+                "chipset": "Snapdragon 7s Gen 3",
+                "total_ram_mb": 12288,
+                "android_version": "14",
+            },
+            {"precision": "INT4"},
+        )
+        self.assertIn("Motorola Edge 50 Neo", header)
+        self.assertIn("Snapdragon 7s Gen 3", header)
+        self.assertIn("INT4", header)
+        self.assertIn("Android", header)
+
+    def test_markdown_heading_level(self):
+        header = render_device_header(
+            {"device_name": "Test", "android_version": "14"},
+            {"precision": "INT4"},
+        )
+        self.assertTrue(header.startswith("### Test"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Extends test coverage to mid-range and budget Android devices that are currently missing from the benchmarks table. Adds battery drain, thermal throttle detection, and OOM event tracking - metrics that matter for always-on edge inference but aren't tracked by any existing mobile benchmark tool.

New files under tests/android_bench/:
- bench.py: main runner - ADB push, 3 warmup + 5 measurement iters, exponential-backoff retry, atomic result writes, SIGINT handler
- adb_client.py: single ADBClient class wrapping all device I/O
- metrics.py: cactus JSON parser + battery/thermal/OOM collectors
- renderer.py: README-format table, extended table, JSON artifact
- scenarios.yaml: LFM 1.2B, LFMVL 1.6B, Parakeet 1.1B, INT8 sweep
- devices.yaml: registry template for 10 target devices
- tests/: 60 unit tests (parser + renderer), no device required
- docs/android_benchmarks.md: how to run + reference numbers

**New metrics nobody currently tracks:**
- `battery_drain_pct` — battery % consumed during 5-min sustained inference load
- `thermal_throttle_detected` — flags >15% CPU clock drop during run (Snapdragon threshold)
- `thermal_peak_celsius` — peak temperature across all thermal zones
- `memory_pressure_events` — OOM/lmkd events isolated to the benchmark window

**Engineering details:**
- 3 warmup + 5 measurement iterations with exponential-backoff retry
- `ThermalPoller` daemon thread samples every 2s without blocking benchmark loop
- Atomic result writes after every scenario — ADB disconnect loses at most one scenario
- SIGINT handler saves progress before exit
- Renderer output matches README table format exactly — rows paste in without editing

### Device results
Currently validating against real devices via Firebase Test Lab — results to 
follow. Happy to prioritize whichever devices are most useful to the team.