### PR TITLE
Per-layer KV heads, attention logit capping, MoE per-expert scales, NPU multi-input

### DIFF
--- a/cactus/engine/engine.h
+++ b/cactus/engine/engine.h
@@ -155,6 +155,11 @@ struct Config {
     float rope_local_base_freq = 10000.0f;
     float final_logit_softcapping = 0.0f;
     float global_partial_rotary_factor = 1.0f;
+    uint32_t expert_intermediate_size = 0;
+    uint32_t global_head_dim = 0;
+    uint32_t num_global_kv_heads = 0;
+    bool attention_k_eq_v = false;
+    bool enable_moe_block = false;
     std::vector<float> activation_sparsity_ppf;
 
     uint32_t vision_head_dim = 64;
@@ -416,16 +421,16 @@ struct KVCache {
         std::vector<float> key_scales;
         std::vector<float> value_scales;
         size_t head_dim = 0;
+        size_t kv_heads = 0;
     };
 
     std::vector<LayerCache> layer_caches;
 
-    size_t window_size = DEFAULT_WINDOW_SIZE;  
-    size_t sink_size = DEFAULT_SINK_SIZE;    
+    size_t window_size = DEFAULT_WINDOW_SIZE;
+    size_t sink_size = DEFAULT_SINK_SIZE;
     size_t current_seq_len = 0;
     size_t total_seq_len = 0;
     size_t max_seq_len = 2048;
-    size_t num_kv_heads = 0;
     size_t num_layers = 0;
     Precision precision;
     size_t element_size = 4;
@@ -434,12 +439,13 @@ struct KVCache {
     size_t get_effective_seq_len() const { return current_seq_len; }
     size_t get_total_seq_len() const { return total_seq_len; }
     size_t get_layer_head_dim(size_t layer_idx) const { return layer_caches[layer_idx].head_dim; }
+    size_t get_layer_kv_heads(size_t layer_idx) const { return layer_caches[layer_idx].kv_heads; }
 
-    void init(size_t num_layers, size_t max_seq, size_t num_kv_heads, const std::vector<size_t>& layer_dims, Precision model_precision);
+    void init(size_t num_layers, size_t max_seq, const std::vector<size_t>& layer_dims, const std::vector<size_t>& layer_kv_heads, Precision model_precision);
     void reset();
     void update_from_graph(CactusGraph* gb, const std::vector<size_t>& k_nodes,
                           const std::vector<size_t>& v_nodes, size_t seq_len,
-                          size_t num_layers, size_t kv_heads);
+                          size_t num_layers);
 
     void update_from_npu(size_t layer_idx, const __fp16* k_data, const __fp16* v_data,
                          size_t num_tokens, size_t kv_heads, size_t head_dim);
@@ -663,6 +669,9 @@ protected:
     virtual std::vector<size_t> get_kv_layer_dims() const {
         return std::vector<size_t>(config_.num_layers, config_.attention_head_dim);
     }
+    virtual std::vector<size_t> get_kv_layer_heads() const {
+        return std::vector<size_t>(config_.num_layers, config_.attention_kv_heads);
+    }
     virtual void post_init() {}
     virtual void post_execute_updates(CactusGraph*, size_t) {}
     Config config_;
@@ -802,6 +811,7 @@ public:
         bool remove_dc_offset = false;
         float preemphasis = 0.0f;
         bool hann_periodic = true;
+        bool hann_shifted = false;
         size_t fft_override = 0;
     };
 

--- a/cactus/engine/engine_cache.cpp
+++ b/cactus/engine/engine_cache.cpp
@@ -8,16 +8,16 @@
 namespace cactus {
 namespace engine {
 
-void KVCache::init(size_t layers, size_t max_seq, size_t kv_heads, const std::vector<size_t>& layer_dims, Precision model_precision) {
+void KVCache::init(size_t layers, size_t max_seq, const std::vector<size_t>& layer_dims, const std::vector<size_t>& layer_kv_heads, Precision model_precision) {
     num_layers = layers;
     max_seq_len = max_seq;
-    num_kv_heads = kv_heads;
     precision = model_precision;
     element_size = PrecisionTraits::size_of(precision);
 
     layer_caches.resize(num_layers);
     for (size_t i = 0; i < num_layers; i++) {
         layer_caches[i].head_dim = layer_dims[i];
+        layer_caches[i].kv_heads = layer_kv_heads[i];
     }
 
     current_seq_len = 0;
@@ -28,13 +28,14 @@ void KVCache::set_window_size(size_t window, size_t sink) {
     window_size = window;
     sink_size = sink;
 
-    if (num_kv_heads > 0 && window_size > 0) {
+    if (window_size > 0) {
         for (size_t layer_idx = 0; layer_idx < num_layers; layer_idx++) {
             size_t head_dim = get_layer_head_dim(layer_idx);
             if (head_dim == 0) continue;
-            size_t cache_bytes = window_size * num_kv_heads * head_dim * element_size;
+            size_t layer_kv = get_layer_kv_heads(layer_idx);
+            size_t cache_bytes = window_size * layer_kv * head_dim * element_size;
             size_t num_groups = (head_dim + KV_QUANT_GROUP_SIZE - 1) / KV_QUANT_GROUP_SIZE;
-            size_t num_scales = window_size * num_kv_heads * num_groups;
+            size_t num_scales = window_size * layer_kv * num_groups;
             auto& cache = layer_caches[layer_idx];
 
             cache.keys.resize(cache_bytes);
@@ -105,7 +106,7 @@ KVCache::CircularView KVCache::get_value_view(size_t layer) {
 
 void KVCache::update_from_graph(CactusGraph* gb, const std::vector<size_t>& k_nodes,
                                const std::vector<size_t>& v_nodes, size_t seq_len,
-                               size_t layers, size_t kv_heads) {
+                               size_t layers) {
     size_t old_seq_len = current_seq_len;
     size_t new_total_len = old_seq_len + seq_len;
 
@@ -136,6 +137,7 @@ void KVCache::update_from_graph(CactusGraph* gb, const std::vector<size_t>& k_no
             const auto& v_buffer = gb->get_output_buffer(v_nodes[layer_idx]);
 
             size_t dim = get_layer_head_dim(layer_idx);
+            size_t kv_heads = get_layer_kv_heads(layer_idx);
             size_t elements_per_token = kv_heads * dim;
             size_t num_groups = (dim + KV_QUANT_GROUP_SIZE - 1) / KV_QUANT_GROUP_SIZE;
             size_t scales_per_token = kv_heads * num_groups;
@@ -492,13 +494,14 @@ void KVCache::remove_token_range(size_t start, size_t count) {
         size_t dim = get_layer_head_dim(i);
         if (dim == 0) continue;
         auto& layer = layer_caches[i];
-        size_t bytes_per_tok = num_kv_heads * dim * element_size;
+        size_t layer_kv_heads = get_layer_kv_heads(i);
+        size_t bytes_per_tok = layer_kv_heads * dim * element_size;
 
         erase_bytes(layer.keys,   start * bytes_per_tok, count * bytes_per_tok, tail_tokens * bytes_per_tok);
         erase_bytes(layer.values, start * bytes_per_tok, count * bytes_per_tok, tail_tokens * bytes_per_tok);
 
         if (precision == Precision::INT8 && !layer.key_scales.empty()) {
-            size_t scaler_per_tok = num_kv_heads * dim / KV_QUANT_GROUP_SIZE;
+            size_t scaler_per_tok = layer_kv_heads * dim / KV_QUANT_GROUP_SIZE;
             erase_floats(layer.key_scales, start * scaler_per_tok, count * scaler_per_tok, tail_tokens * scaler_per_tok);
             erase_floats(layer.value_scales, start * scaler_per_tok, count * scaler_per_tok, tail_tokens * scaler_per_tok);
         }
@@ -516,10 +519,11 @@ void KVCache::compact_to_windows(const std::vector<size_t>& target_windows) {
         if (target == 0) continue;
 
         auto& layer = layer_caches[i];
-        size_t layer_tokens = layer.keys.size() / (num_kv_heads * dim * element_size);
+        size_t layer_kv_heads = get_layer_kv_heads(i);
+        size_t layer_tokens = layer.keys.size() / (layer_kv_heads * dim * element_size);
         if (layer_tokens <= target) continue;
 
-        size_t bytes_per_token = num_kv_heads * dim * element_size;
+        size_t bytes_per_token = layer_kv_heads * dim * element_size;
         size_t keep_bytes = target * bytes_per_token;
         size_t discard_bytes = (layer_tokens - target) * bytes_per_token;
 
@@ -530,7 +534,7 @@ void KVCache::compact_to_windows(const std::vector<size_t>& target_windows) {
 
         if (precision == Precision::INT8 && !layer.key_scales.empty()) {
             size_t num_groups = (dim + KV_QUANT_GROUP_SIZE - 1) / KV_QUANT_GROUP_SIZE;
-            size_t scales_per_token = num_kv_heads * num_groups;
+            size_t scales_per_token = layer_kv_heads * num_groups;
             size_t keep_scales = target * scales_per_token;
             size_t discard_scales = (layer_tokens - target) * scales_per_token;
 

--- a/cactus/engine/engine_model.cpp
+++ b/cactus/engine/engine_model.cpp
@@ -136,7 +136,7 @@ bool Model::init_internal(CactusGraph* gb, const std::string& model_folder, size
                                  config_.model_type == Config::ModelType::PARAKEET_TDT)
                                ? Precision::FP16
                                : Precision::INT8;
-    kv_cache_.init(config_.num_layers, context_size, config_.attention_kv_heads, get_kv_layer_dims(), cache_precision);
+    kv_cache_.init(config_.num_layers, context_size, get_kv_layer_dims(), get_kv_layer_heads(), cache_precision);
 
     size_t window_size = std::min(context_size, size_t(512));
     size_t sink_size = 4;
@@ -347,7 +347,7 @@ std::vector<float> Model::get_audio_embeddings(const std::vector<float>& /*mel_b
 
 void Model::update_kv_cache(CactusGraph* gb, size_t seq_len) {
     kv_cache_.update_from_graph(gb, cache_k_output_nodes_, cache_v_output_nodes_,
-                               seq_len, config_.num_layers, config_.attention_kv_heads);
+                               seq_len, config_.num_layers);
 }
 
 void Model::remove_thinking_tokens(const std::vector<std::pair<size_t, size_t>>& ranges) {
@@ -601,6 +601,11 @@ bool Config::from_json(const std::string& config_path) {
         else if (key == "rope_local_base_freq") rope_local_base_freq = std::stof(value);
         else if (key == "final_logit_softcapping") final_logit_softcapping = std::stof(value);
         else if (key == "global_partial_rotary_factor") global_partial_rotary_factor = std::stof(value);
+        else if (key == "expert_intermediate_size") expert_intermediate_size = static_cast<uint32_t>(std::stoul(value));
+        else if (key == "global_head_dim") global_head_dim = static_cast<uint32_t>(std::stoul(value));
+        else if (key == "num_global_kv_heads" || key == "num_global_key_value_heads") num_global_kv_heads = static_cast<uint32_t>(std::stoul(value));
+        else if (key == "attention_k_eq_v") attention_k_eq_v = (value == "true" || value == "1");
+        else if (key == "enable_moe_block") enable_moe_block = (value == "true" || value == "1");
         else if (key == "vision_head_dim") vision_head_dim = static_cast<uint32_t>(std::stoul(value));
         else if (key == "vision_kv_heads") vision_kv_heads = static_cast<uint32_t>(std::stoul(value));
         else if (key == "vision_intermediate_size") vision_intermediate_size = static_cast<uint32_t>(std::stoul(value));

--- a/cactus/engine/engine_signals.cpp
+++ b/cactus/engine/engine_signals.cpp
@@ -706,7 +706,10 @@ std::vector<float> AudioProcessor::compute_spectrogram(
             : static_cast<float>(window_length - 1);
         const size_t left_pad = (analysis_frame_length - window_length) / 2;
         for (size_t i = 0; i < window_length; ++i) {
-            const float w = 0.5f * (1.0f - std::cos(2.0f * static_cast<float>(M_PI) * static_cast<float>(i) / denom));
+            float idx = config.hann_shifted
+                ? (static_cast<float>(i) + 0.5f)
+                : static_cast<float>(i);
+            const float w = 0.5f * (1.0f - std::cos(2.0f * static_cast<float>(M_PI) * idx / denom));
             window[left_pad + i] = w;
         }
     }

--- a/cactus/ffi/cactus_utils.h
+++ b/cactus/ffi/cactus_utils.h
@@ -151,6 +151,7 @@ inline cactus::engine::AudioProcessor::SpectrogramConfig get_htk_spectrogram_con
     cfg.min_value    = 0.001f;
     cfg.remove_dc_offset = false;
     cfg.hann_periodic = true;
+    cfg.hann_shifted = true;
     return cfg;
 }
 

--- a/cactus/graph/graph.h
+++ b/cactus/graph/graph.h
@@ -514,7 +514,9 @@ public:
                      size_t num_experts_per_tok,
                      bool normalize_routing,
                      float epsilon,
-                     float routed_scaling_factor);
+                     float routed_scaling_factor,
+                     Activation activation = Activation::SILU,
+                     size_t per_expert_scale = 0);
     size_t moe_layer(size_t hidden,
                      size_t routing_probs,
                      size_t topk_indices,

--- a/cactus/graph/graph_builder.cpp
+++ b/cactus/graph/graph_builder.cpp
@@ -365,7 +365,9 @@ size_t CactusGraph::moe_layer(size_t hidden,
                               size_t num_experts_per_tok,
                               bool normalize_routing,
                               float epsilon,
-                              float routed_scaling_factor) {
+                              float routed_scaling_factor,
+                              Activation activation,
+                              size_t per_expert_scale) {
     const auto& hidden_buffer = get_output_buffer(hidden);
     const auto& routing_buffer = get_output_buffer(routing_probs);
     const auto& topk_buffer = get_output_buffer(topk_indices);
@@ -384,13 +386,14 @@ size_t CactusGraph::moe_layer(size_t hidden,
     }
 
     std::vector<size_t> input_ids;
-    input_ids.reserve(3 + 3 * num_experts);
+    input_ids.reserve(3 + 3 * num_experts + 1);
     input_ids.push_back(hidden);
     input_ids.push_back(routing_probs);
     input_ids.push_back(topk_indices);
     for (size_t i = 0; i < num_experts; ++i) input_ids.push_back(w1_weights[i]);
     for (size_t i = 0; i < num_experts; ++i) input_ids.push_back(w3_weights[i]);
     for (size_t i = 0; i < num_experts; ++i) input_ids.push_back(w2_weights[i]);
+    if (per_expert_scale != 0) input_ids.push_back(per_expert_scale);
 
     OpParams params;
     params.num_experts = num_experts;
@@ -399,6 +402,8 @@ size_t CactusGraph::moe_layer(size_t hidden,
     params.epsilon = epsilon;
     params.scalar = routed_scaling_factor;
     params.output_precision = hidden_buffer.precision;
+    params.activation = activation;
+    params.moe_gated = true;
 
     return add_node(OpType::MOE_LAYER, input_ids, hidden_buffer.shape, params);
 }

--- a/cactus/graph/graph_ops_nn.cpp
+++ b/cactus/graph/graph_ops_nn.cpp
@@ -345,9 +345,10 @@ void compute_moe_layer_node(GraphNode& node, const std::vector<std::unique_ptr<G
     const float routed_scaling_factor = node.params.scalar;
     const bool gated = node.params.moe_gated;
     const Activation activation = node.params.activation;
-    const size_t expected_inputs = gated ? (3 + 3 * num_experts) : (3 + 2 * num_experts);
-    if (node.input_ids.size() != expected_inputs) {
-        throw std::runtime_error("moe_layer expects " + std::to_string(expected_inputs) + " inputs, got " + std::to_string(node.input_ids.size()));
+    const size_t base_inputs = gated ? (3 + 3 * num_experts) : (3 + 2 * num_experts);
+    bool has_per_expert_scale = node.input_ids.size() == base_inputs + 1;
+    if (node.input_ids.size() != base_inputs && node.input_ids.size() != base_inputs + 1) {
+        throw std::runtime_error("moe_layer expects " + std::to_string(base_inputs) + " or " + std::to_string(base_inputs + 1) + " inputs, got " + std::to_string(node.input_ids.size()));
     }
 
     const auto& hidden_buffer = nodes[node_index_map.at(node.input_ids[0])]->output_buffer;
@@ -359,6 +360,15 @@ void compute_moe_layer_node(GraphNode& node, const std::vector<std::unique_ptr<G
     }
     if (topk_idx_buffer.precision != Precision::FP32) {
         throw std::runtime_error("moe_layer expects FP32 topk indices");
+    }
+
+    const __fp16* expert_scales_fp16 = nullptr;
+    if (has_per_expert_scale) {
+        const auto& scale_buffer = nodes[node_index_map.at(node.input_ids[base_inputs])]->output_buffer;
+        if (scale_buffer.precision != Precision::FP16) {
+            throw std::runtime_error("moe_layer expects FP16 per_expert_scale");
+        }
+        expert_scales_fp16 = scale_buffer.data_as<__fp16>();
     }
 
     const size_t token_count = hidden_buffer.shape[0];
@@ -385,7 +395,7 @@ void compute_moe_layer_node(GraphNode& node, const std::vector<std::unique_ptr<G
     size_t* expert_offsets = moe_expert_offsets_buf.data(); 
     size_t* expert_tokens_flat = moe_expert_tokens_buf.data();  
 
-   std::memset(expert_offsets, 0, (num_experts + 1) * sizeof(size_t));
+    std::memset(expert_offsets, 0, (num_experts + 1) * sizeof(size_t));
     for (size_t tok = 0; tok < token_count; ++tok) {
         for (size_t k = 0; k < top_k; ++k) {
             float raw_idx = topk_idx[tok * top_k + k];
@@ -490,6 +500,9 @@ void compute_moe_layer_node(GraphNode& node, const std::vector<std::unique_ptr<G
                 route_weight = expert_prob / routing_denom[tok];
             }
             route_weight *= routed_scaling_factor;
+            if (expert_scales_fp16) {
+                route_weight *= static_cast<float>(expert_scales_fp16[expert_idx]);
+            }
 
             auto* out_row = output + tok * hidden_dim;
             const auto* expert_row = expert_out + i * hidden_dim;
@@ -714,7 +727,7 @@ void compute_attention_node(GraphNode& node, const std::vector<std::unique_ptr<G
                          value_buffer.data_as<__fp16>(), node.output_buffer.data_as<__fp16>(),
                          batch_size, seq_len, kv_seq_len, num_q_heads, num_kv_heads, head_dim, node.params.scale, mask_ptr,
                          node.params.position_offset, node.params.window_size, node.params.is_causal,
-                         node.params.attention_mask_is_additive, mask_per_head);
+                         node.params.attention_mask_is_additive, mask_per_head, node.params.logit_cap);
 }
 
 void compute_attention_int8_hybrid_node(GraphNode& node, const std::vector<std::unique_ptr<GraphNode>>& nodes, const std::unordered_map<size_t, size_t>& node_index_map) {

--- a/cactus/kernel/kernel.h
+++ b/cactus/kernel/kernel.h
@@ -165,7 +165,8 @@ void cactus_batchnorm_f32(
 void cactus_attention_f16(const __fp16* queries, const __fp16* keys, const __fp16* values, __fp16* output,
                           size_t batch_size, size_t seq_len, size_t kv_seq_len, size_t num_q_heads, size_t num_kv_heads,
                           size_t head_dim, float scale, const __fp16* mask, size_t position_offset = 0, size_t window_size = 0,
-                          bool is_causal = true, bool mask_is_additive = false, bool mask_per_head = false);
+                          bool is_causal = true, bool mask_is_additive = false, bool mask_per_head = false,
+                          float logit_cap = 0.0f);
 
 void cactus_attention_hybrid_int8_fp16(
     const __fp16* queries,        

--- a/cactus/kernel/kernel_attention.cpp
+++ b/cactus/kernel/kernel_attention.cpp
@@ -377,13 +377,14 @@ void cactus_attention_f16(
     size_t window_size,
     bool is_causal,
     bool mask_is_additive,
-    bool mask_per_head
+    bool mask_per_head,
+    float logit_cap
 ) {
     if (scale == 0.0f) {
         scale = 1.0f / sqrtf(static_cast<float>(head_dim));
     }
-    
-    if (mask == nullptr && head_dim % 8 == 0) {
+
+    if (mask == nullptr && head_dim % 8 == 0 && logit_cap == 0.0f) {
         cactus_attention_f16_fast(
             queries, keys, values, output,
             batch_size, seq_len, kv_seq_len,
@@ -541,10 +542,14 @@ void cactus_attention_f16(
                                 }
                             }
                             
+                            if (logit_cap > 0.0f && std::isfinite(score)) {
+                                score = logit_cap * tanhf(score / logit_cap);
+                            }
+
                             block_scores[kv_idx] = score;
                             block_max = std::max(block_max, score);
                         }
-                        
+
                         float current_block_scale = 1.0f;
 
                         if (block_max > NEG_INF) {

--- a/cactus/npu/npu_ane.mm
+++ b/cactus/npu/npu_ane.mm
@@ -367,7 +367,7 @@ static void copyFP16ToMLArray(const __fp16* data, size_t count, MLMultiArray* ar
     }
     if (!result || error) return 0;
 
-    if (_cachedMultiOutputArray) {
+    if (_multiPredictionOptions && _cachedMultiOutputArray) {
         return copyMLArrayToFP16(_cachedMultiOutputArray, output);
     }
 

--- a/cactus/npu/npu_ane.mm
+++ b/cactus/npu/npu_ane.mm
@@ -19,6 +19,10 @@
 @property (nonatomic, strong) NSString* cachedOutputName;
 @property (nonatomic, assign) NSUInteger cachedOutputSize;
 @property (nonatomic, strong) MLPredictionOptions* predictionOptions;
+@property (nonatomic, strong) NSMutableDictionary<NSString*, MLMultiArray*>* cachedMultiInputArrays;
+@property (nonatomic, strong) MLMultiArray* cachedMultiOutputArray;
+@property (nonatomic, strong) MLPredictionOptions* multiPredictionOptions;
+@property (nonatomic, assign) BOOL multiInputPreallocated;
 
 - (instancetype)initWithModelPath:(NSString*)path;
 - (NSArray<NSNumber*>*)getInputShape;
@@ -33,6 +37,10 @@
                              data:(const __fp16*)data
                             shape:(NSArray<NSNumber*>*)shape
                        outputName:(NSString*)outputName;
+- (BOOL)preallocateMultiInputBuffersWithOutputName:(NSString*)outputName;
+- (size_t)predictMultiInputWithDict:(NSMutableDictionary<NSString*, MLFeatureValue*>*)inputDict
+                         outputData:(__fp16*)output
+                         outputName:(NSString*)outputName;
 
 @end
 
@@ -281,6 +289,93 @@
     return outputFeature.multiArrayValue;
 }
 
+static size_t copyMLArrayToFP16(MLMultiArray* array, __fp16* output) {
+    size_t count = array.count;
+    if (array.dataType == MLMultiArrayDataTypeFloat16) {
+        if (output != (__fp16*)array.dataPointer)
+            memcpy(output, array.dataPointer, count * sizeof(__fp16));
+    } else {
+        const float* src = (const float*)array.dataPointer;
+        for (size_t i = 0; i < count; i++) output[i] = (__fp16)src[i];
+    }
+    return count;
+}
+
+static void copyFP16ToMLArray(const __fp16* data, size_t count, MLMultiArray* array) {
+    if (array.dataType == MLMultiArrayDataTypeFloat16) {
+        memcpy(array.dataPointer, data, count * sizeof(__fp16));
+    } else {
+        float* dst = (float*)array.dataPointer;
+        for (size_t i = 0; i < count; i++) dst[i] = (float)data[i];
+    }
+}
+
+- (BOOL)preallocateMultiInputBuffersWithOutputName:(NSString*)outputName {
+    if (!_model || !_modelDescription) return NO;
+
+    NSError* error = nil;
+    _cachedMultiInputArrays = [NSMutableDictionary new];
+
+    for (NSString* inputName in _modelDescription.inputDescriptionsByName) {
+        MLFeatureDescription* desc = _modelDescription.inputDescriptionsByName[inputName];
+        if (desc.type != MLFeatureTypeMultiArray) continue;
+
+        MLMultiArray* array = [[MLMultiArray alloc]
+            initWithShape:desc.multiArrayConstraint.shape
+                 dataType:desc.multiArrayConstraint.dataType
+                    error:&error];
+        if (!array || error) return NO;
+        _cachedMultiInputArrays[inputName] = array;
+    }
+
+    NSString* outName = (outputName && outputName.length > 0)
+        ? outputName : _modelDescription.outputDescriptionsByName.allKeys.firstObject;
+
+    MLFeatureDescription* outputDesc = _modelDescription.outputDescriptionsByName[outName];
+    if (outputDesc && outputDesc.type == MLFeatureTypeMultiArray) {
+        _cachedMultiOutputArray = [[MLMultiArray alloc]
+            initWithShape:outputDesc.multiArrayConstraint.shape
+                 dataType:outputDesc.multiArrayConstraint.dataType
+                    error:&error];
+        if (!_cachedMultiOutputArray || error) return NO;
+
+        _multiPredictionOptions = [[MLPredictionOptions alloc] init];
+        if (@available(macOS 14.0, iOS 17.0, *)) {
+            _multiPredictionOptions.outputBackings = @{outName: _cachedMultiOutputArray};
+        }
+    }
+
+    _multiInputPreallocated = YES;
+    return YES;
+}
+
+- (size_t)predictMultiInputWithDict:(NSMutableDictionary<NSString*, MLFeatureValue*>*)inputDict
+                         outputData:(__fp16*)output
+                         outputName:(NSString*)outputName {
+    if (!_model) return 0;
+
+    NSError* error = nil;
+    MLDictionaryFeatureProvider* provider =
+        [[MLDictionaryFeatureProvider alloc] initWithDictionary:inputDict error:&error];
+    if (!provider || error) return 0;
+
+    id<MLFeatureProvider> result = nil;
+    if (_multiPredictionOptions) {
+        result = [_model predictionFromFeatures:provider options:_multiPredictionOptions error:&error];
+    } else {
+        result = [_model predictionFromFeatures:provider error:&error];
+    }
+    if (!result || error) return 0;
+
+    if (_cachedMultiOutputArray) {
+        return copyMLArrayToFP16(_cachedMultiOutputArray, output);
+    }
+
+    MLFeatureValue* outFeature = [result featureValueForName:outputName];
+    if (!outFeature || !outFeature.multiArrayValue) return 0;
+    return copyMLArrayToFP16(outFeature.multiArrayValue, output);
+}
+
 @end
 
 namespace cactus {
@@ -401,19 +496,7 @@ size_t ANEEncoder::encode(const __fp16* input,
                                              outputName:outName];
 
         if (mlOutput) {
-            size_t count = mlOutput.count;
-            if (mlOutput.dataType == MLMultiArrayDataTypeFloat16) {
-                __fp16* outputPtr = (__fp16*)mlOutput.dataPointer;
-                if (output != outputPtr) {
-                    memcpy(output, outputPtr, count * sizeof(__fp16));
-                }
-            } else {
-                const float* fp32Ptr = (const float*)mlOutput.dataPointer;
-                for (size_t i = 0; i < count; i++) {
-                    output[i] = (__fp16)fp32Ptr[i];
-                }
-            }
-            return count;
+            return copyMLArrayToFP16(mlOutput, output);
         }
     }
 
@@ -470,78 +553,41 @@ size_t ANEEncoder::encode_multimodal_input(
     @autoreleasepool {
         CactusANEImpl* impl = (__bridge CactusANEImpl*)impl_;
 
-        NSMutableDictionary<NSString*, MLFeatureValue*>* inputDict = [NSMutableDictionary new];
+        NSString* outName = output_name.empty()
+            ? impl.modelDescription.outputDescriptionsByName.allKeys.firstObject
+            : [NSString stringWithUTF8String:output_name.c_str()];
 
-        MLMultiArrayDataType inputDataType = MLMultiArrayDataTypeFloat16;
-        NSDictionary<NSString*, MLFeatureDescription*>* inputDescs = impl.modelDescription.inputDescriptionsByName;
-        for (MLFeatureDescription* desc in inputDescs.allValues) {
-            if (desc.multiArrayConstraint) {
-                inputDataType = desc.multiArrayConstraint.dataType;
-                break;
-            }
+        if (!impl.multiInputPreallocated) {
+            [impl preallocateMultiInputBuffersWithOutputName:outName];
         }
 
+        NSMutableDictionary<NSString*, MLFeatureValue*>* inputDict = [NSMutableDictionary new];
+
         for (const auto& input : inputs) {
-            NSMutableArray<NSNumber*>* shapeArray = [NSMutableArray arrayWithCapacity:input.shape.size()];
-            for (int dim : input.shape) {
-                [shapeArray addObject:@(dim)];
-            }
+            NSString* nsName = [NSString stringWithUTF8String:input.name.c_str()];
 
             size_t total = 1;
             for (int dim : input.shape) total *= dim;
 
-            NSError* arrayError = nil;
-            MLMultiArray* array = [[MLMultiArray alloc] initWithShape:shapeArray
-                                                            dataType:inputDataType
-                                                               error:&arrayError];
-            if (!array || arrayError) {
-                CACTUS_LOG_ERROR("npu", "ANE encode_multimodal_input: failed to create input array for " << input.name);
-                return 0;
-            }
-            if (inputDataType == MLMultiArrayDataTypeFloat16) {
-                memcpy(array.dataPointer, input.data, total * sizeof(__fp16));
-            } else {
-                float* fp32_ptr = (float*)array.dataPointer;
-                for (size_t i = 0; i < total; i++) {
-                    fp32_ptr[i] = (float)input.data[i];
-                }
+            MLMultiArray* array = impl.cachedMultiInputArrays[nsName];
+            if (!array) {
+                MLMultiArrayDataType dataType = MLMultiArrayDataTypeFloat16;
+                MLFeatureDescription* desc = impl.modelDescription.inputDescriptionsByName[nsName];
+                if (desc && desc.multiArrayConstraint) dataType = desc.multiArrayConstraint.dataType;
+
+                NSMutableArray<NSNumber*>* shapeArray = [NSMutableArray arrayWithCapacity:input.shape.size()];
+                for (int dim : input.shape) [shapeArray addObject:@(dim)];
+
+                NSError* arrayError = nil;
+                array = [[MLMultiArray alloc] initWithShape:shapeArray dataType:dataType error:&arrayError];
+                if (!array || arrayError) return 0;
             }
 
-            NSString* nsName = [NSString stringWithUTF8String:input.name.c_str()];
+            copyFP16ToMLArray(input.data, total, array);
             inputDict[nsName] = [MLFeatureValue featureValueWithMultiArray:array];
         }
 
-        NSError* error = nil;
-        MLDictionaryFeatureProvider* provider =
-            [[MLDictionaryFeatureProvider alloc] initWithDictionary:inputDict error:&error];
-        if (!provider || error) return 0;
-
-        id<MLFeatureProvider> result = [impl.model predictionFromFeatures:provider error:&error];
-        if (!result || error) return 0;
-
-        NSString* outName = nil;
-        if (!output_name.empty()) {
-            outName = [NSString stringWithUTF8String:output_name.c_str()];
-        } else {
-            NSArray<NSString*>* outputNames = impl.modelDescription.outputDescriptionsByName.allKeys;
-            if (outputNames.count > 0) outName = outputNames[0];
-        }
-
-        if (!outName) return 0;
-        MLFeatureValue* outFeature = [result featureValueForName:outName];
-        if (!outFeature || !outFeature.multiArrayValue) return 0;
-
-        MLMultiArray* outArray = outFeature.multiArrayValue;
-        size_t count = outArray.count;
-        if (outArray.dataType == MLMultiArrayDataTypeFloat16) {
-            memcpy(output, outArray.dataPointer, count * sizeof(__fp16));
-        } else {
-            const float* fp32_ptr = (const float*)outArray.dataPointer;
-            for (size_t i = 0; i < count; i++) {
-                output[i] = (__fp16)fp32_ptr[i];
-            }
-        }
-        return count;
+        return [impl predictMultiInputWithDict:inputDict outputData:output outputName:outName];
     }
 }
 

--- a/tests/test_kv_cache.cpp
+++ b/tests/test_kv_cache.cpp
@@ -27,7 +27,7 @@ bool test_sliding_window_basic() {
     const size_t sink_size = 4;
 
     KVCache cache;
-    cache.init(num_layers, max_seq, num_kv_heads, std::vector<size_t>(num_layers, head_dim), Precision::INT8);
+    cache.init(num_layers, max_seq, std::vector<size_t>(num_layers, head_dim), std::vector<size_t>(num_layers, num_kv_heads), Precision::INT8);
     cache.set_window_size(window_size, sink_size);
 
     CactusGraph graph;
@@ -52,7 +52,7 @@ bool test_sliding_window_basic() {
         }
 
         graph.execute();
-        cache.update_from_graph(&graph, k_nodes, v_nodes, seq_len, num_layers, num_kv_heads);
+        cache.update_from_graph(&graph, k_nodes, v_nodes, seq_len, num_layers);
 
         assert(cache.get_effective_seq_len() == seq_len);
     }
@@ -76,7 +76,7 @@ bool test_sliding_window_basic() {
         }
 
         graph.execute();
-        cache.update_from_graph(&graph, k_nodes, v_nodes, additional_seq, num_layers, num_kv_heads);
+        cache.update_from_graph(&graph, k_nodes, v_nodes, additional_seq, num_layers);
 
         assert(cache.get_effective_seq_len() == window_size);
     }
@@ -102,7 +102,7 @@ bool test_sliding_window_basic() {
         }
 
         graph.execute();
-        cache.update_from_graph(&graph, k_nodes, v_nodes, additional_seq, num_layers, num_kv_heads);
+        cache.update_from_graph(&graph, k_nodes, v_nodes, additional_seq, num_layers);
 
         assert(cache.get_effective_seq_len() == window_size);
 
@@ -138,7 +138,7 @@ bool test_incremental_updates() {
     const size_t sink_size = 2;
 
     KVCache cache;
-    cache.init(num_layers, 2048, num_kv_heads, std::vector<size_t>(num_layers, head_dim), Precision::FP16);
+    cache.init(num_layers, 2048, std::vector<size_t>(num_layers, head_dim), std::vector<size_t>(num_layers, num_kv_heads), Precision::FP16);
     cache.set_window_size(window_size, sink_size);
 
     CactusGraph graph;
@@ -162,7 +162,7 @@ bool test_incremental_updates() {
         v_nodes.push_back(v_node);
 
         graph.execute();
-        cache.update_from_graph(&graph, k_nodes, v_nodes, seq_len, num_layers, num_kv_heads);
+        cache.update_from_graph(&graph, k_nodes, v_nodes, seq_len, num_layers);
 
         size_t expected_len = min(token + 1, window_size);
         assert(cache.get_effective_seq_len() == expected_len);
@@ -181,7 +181,7 @@ bool test_incremental_updates() {
 
 bool test_reset_functionality() {
     KVCache cache;
-    cache.init(2, 1024, 8, std::vector<size_t>(2, 64), Precision::FP16);
+    cache.init(2, 1024, std::vector<size_t>(2, 64), std::vector<size_t>(2, 8), Precision::FP16);
     cache.set_window_size(16, 4);
 
     CactusGraph graph;
@@ -202,7 +202,7 @@ bool test_reset_functionality() {
     }
 
     graph.execute();
-    cache.update_from_graph(&graph, k_nodes, v_nodes, 10, 2, 8);
+    cache.update_from_graph(&graph, k_nodes, v_nodes, 10, 2);
 
     assert(cache.get_effective_seq_len() == 10);
     assert(cache.get_total_seq_len() == 10);
@@ -224,7 +224,7 @@ bool test_large_window() {
     const size_t window_size = 512;
 
     KVCache cache;
-    cache.init(num_layers, 2048, num_kv_heads, std::vector<size_t>(num_layers, head_dim), Precision::FP16);
+    cache.init(num_layers, 2048, std::vector<size_t>(num_layers, head_dim), std::vector<size_t>(num_layers, num_kv_heads), Precision::FP16);
     cache.set_window_size(window_size, 4);
 
     CactusGraph graph;
@@ -249,7 +249,7 @@ bool test_large_window() {
     }
 
     graph.execute();
-    cache.update_from_graph(&graph, k_nodes, v_nodes, seq_len, num_layers, num_kv_heads);
+    cache.update_from_graph(&graph, k_nodes, v_nodes, seq_len, num_layers);
 
     assert(cache.get_effective_seq_len() == window_size);
     assert(cache.get_total_seq_len() == seq_len);


### PR DESCRIPTION
## Summary

Model-agnostic infrastructure improvements across kernel, graph, engine, and NPU layers.

### Kernel (`kernel.h`, `kernel_attention.cpp`)
- **Attention logit soft-capping**: New `float logit_cap` parameter on `cactus_attention_f16`. When > 0, clamps scores via `logit_cap * tanh(score / logit_cap)` before softmax. Fast path only dispatches when `logit_cap == 0.0f`

### Graph (`graph.h`, `graph_builder.cpp`, `graph_ops_nn.cpp`)
- **MoE per-expert scales**: `moe_layer()` now accepts an optional `per_expert_scale` node providing per-expert FP16 scale factors applied to route weights
- **MoE configurable activation**: `moe_layer()` now takes `Activation activation` parameter (default SILU) instead of hardcoding
- **Logit cap passthrough**: `attention_masked` → kernel call now forwards `logit_cap` from `OpParams`

### Engine (`engine.h`, `engine_cache.cpp`, `engine_model.cpp`)
- **Per-layer KV heads**: KVCache refactored from single global `num_kv_heads` to per-layer `kv_heads` stored in `LayerCache`. Supports models with heterogeneous attention (e.g., alternating local/global layers with different KV head counts)
- **New Config fields**: `expert_intermediate_size`, `global_head_dim`, `num_global_kv_heads`, `attention_k_eq_v`, `enable_moe_block` — parsed from model config JSON
- **Virtual `get_kv_layer_heads()`**: Models can override to provide per-layer KV head counts

### Audio (`engine_signals.cpp`, `cactus_utils.h`)
- **Hann shifted window**: New `hann_shifted` flag on `SpectrogramConfig` for shifted Hann windows (`i + 0.5` indexing). Applied in HTK spectrogram config

### NPU (`npu_ane.mm`)
- **Cached multi-input CoreML prediction**: Pre-allocated input/output buffers via `preallocateMultiInputBuffersWithOutputName` to avoid per-call MLMultiArray allocation overhead
- **Helper functions**: `copyMLArrayToFP16` / `copyFP16ToMLArray` for type-safe data bridging, used in both single-input and multi-input paths
- **Fix**: Gate cached output array usage on `_multiPredictionOptions` to avoid returning stale data on pre-macOS 14

### Tests (`test_kv_cache.cpp`)
- Updated `KVCache::init` and `update_from_graph` call sites to match new per-layer KV heads API

## Test plan
- [x] Builds clean on macOS (cmake + make)
- [x] `cactus test --exhaustive` passes all 11 golden tests (0 failures)
- [x] All unit tests pass (graph, kernel, KV cache, embedding, STT, VLM, LLM, telemetry)
- [x] NPU/ANE loads correctly with fresh model weights