### PR TITLE
fix apple i8mm detection to use runtime sysctl check

### DIFF
--- a/apple/CmakeLists.txt
+++ b/apple/CmakeLists.txt
@@ -242,7 +242,7 @@ if(BUILD_SME2)
     target_compile_definitions(cactus PRIVATE CACTUS_COMPILE_SME2)
 endif()
 
-# I8MM support: all Apple Silicon supports I8MM
+# I8MM support: detected at runtime via sysctl, not all Apple Silicon has FEAT_I8MM
 add_library(cactus_i8mm_obj OBJECT ${I8MM_SOURCE})
 target_include_directories(cactus_i8mm_obj PRIVATE
     ${SOURCE_DIR} ${SOURCE_DIR}/engine ${SOURCE_DIR}/graph

--- a/cactus/kernel/kernel_utils.h
+++ b/cactus/kernel/kernel_utils.h
@@ -53,7 +53,11 @@ inline bool cpu_has_i8mm() {
 
     std::call_once(once, []() {
 #if defined(__APPLE__)
-    has = true;
+    int ret = 0;
+    size_t size = sizeof(ret);
+    if (sysctlbyname("hw.optional.arm.FEAT_I8MM", &ret, &size, nullptr, 0) == 0) {
+        has = (ret == 1);
+    }
 #elif defined(__ANDROID__)
     unsigned long hwcap2 = getauxval(AT_HWCAP2);
     #ifndef HWCAP2_I8MM


### PR DESCRIPTION
## Problem
On Apple, `cpu_has_i8mm()` was hardcoded to `has = true`, which could incorrectly enable i8mm kernels on unsupported hardware.  
This is causing illegal-instruction crashes instead of safely falling back to non-i8mm paths.

## History
- Early implementation (old `cactus_has_i8mm()` path, e.g. `a8b3f013`) used hardcoded Apple support.
- Runtime detection was later introduced in `1e3f7b58` using:
  `sysctlbyname("hw.optional.arm.FEAT_I8MM", ...)`.
- During refactor in `c38aec77` (`cpu_has_i8mm()`), Apple logic regressed back to:
  `has = true`.

## Fix
- Restore runtime detection in `cpu_has_i8mm()` for Apple.
- Replace hardcoded `has = true` with `sysctlbyname("hw.optional.arm.FEAT_I8MM", ...)`.
- Keep existing `std::call_once` probe pattern and conservative default (`false` if probe fails).