### PR TITLE
Graph remaining ops

### DIFF
--- a/cactus/graph/graph_io.cpp
+++ b/cactus/graph/graph_io.cpp
@@ -1,4 +1,5 @@
 #include "graph.h"
+#include "graph_param_io.h"
 #include <fstream>
 #include <stdexcept>
 #include <sys/mman.h>
@@ -35,14 +36,6 @@ namespace {
       out.write(reinterpret_cast<const char*>(&v), sizeof(v));
     }
 
-    inline void write_i32(std::ostream& out, int32_t v) {
-      out.write(reinterpret_cast<const char*>(&v), sizeof(v));
-    }
-
-    inline void write_f32(std::ostream& out, float v) {
-      out.write(reinterpret_cast<const char*>(&v), sizeof(v));
-    }
-
     void write_size_vector(std::ostream& out, const std::vector<size_t>& values) {
       uint32_t size = static_cast<uint32_t>(values.size());
       write_u32(out, size);
@@ -56,127 +49,6 @@ namespace {
       write_u32(out, size);
       for (uint32_t v : values) {
         write_u32(out, v);
-      }
-    }
-
-    void write_op_params(std::ostream& out, const GraphFile::NodeEntry& node) {
-      uint32_t param_flags = 0;
-
-      constexpr uint32_t PARAM_SCALAR            = 1u << 0;
-      constexpr uint32_t PARAM_AXIS              = 1u << 1;
-      constexpr uint32_t PARAM_NEW_SHAPE         = 1u << 2;
-      constexpr uint32_t PARAM_PRETRANSPOSED_RHS = 1u << 3;
-      constexpr uint32_t PARAM_BACKEND           = 1u << 4;
-      constexpr uint32_t PARAM_SLICE             = 1u << 5;
-      constexpr uint32_t PARAM_EPSILON           = 1u << 6;
-      constexpr uint32_t PARAM_NUM_GROUPS        = 1u << 7;
-      constexpr uint32_t PARAM_INDEX_VALUE       = 1u << 8;
-      constexpr uint32_t PARAM_PERMUTATION       = 1u << 9;
-
-      switch (node.op_type) {
-        case OpType::POW:
-        case OpType::SCALAR_ADD:
-        case OpType::SCALAR_SUBTRACT:
-        case OpType::SCALAR_MULTIPLY:
-        case OpType::SCALAR_DIVIDE:
-          param_flags |= PARAM_SCALAR;
-          break;
-        default:
-          break;
-      }
-
-      switch (node.op_type) {
-        case OpType::SOFTMAX:
-        case OpType::SUM:
-        case OpType::MEAN:
-        case OpType::VARIANCE:
-        case OpType::MIN:
-        case OpType::MAX:
-        case OpType::INDEX:
-        case OpType::CONCAT:
-        case OpType::CAT:
-          param_flags |= PARAM_AXIS;
-          break;
-        default:
-          break;
-      }
-
-      if (node.op_type == OpType::INDEX) {
-        param_flags |= PARAM_INDEX_VALUE;
-      }
-
-      switch (node.op_type) {
-        case OpType::VIEW:
-        case OpType::RESHAPE:
-        case OpType::FLATTEN:
-          param_flags |= PARAM_NEW_SHAPE;
-          break;
-        default:
-          break;
-      }
-
-      if (node.op_type == OpType::MATMUL) {
-        param_flags |= PARAM_PRETRANSPOSED_RHS;
-        param_flags |= PARAM_BACKEND;
-      }
-
-      if (node.op_type == OpType::TRANSPOSE) {
-        param_flags |= PARAM_PERMUTATION;
-        param_flags |= PARAM_BACKEND;
-      }
-
-      if (node.op_type == OpType::SLICE) {
-        param_flags |= PARAM_AXIS;
-        param_flags |= PARAM_SLICE;
-      }
-
-      switch (node.op_type) {
-        case OpType::RMS_NORM:
-        case OpType::LAYERNORM:
-        case OpType::GROUPNORM:
-        case OpType::BATCHNORM:
-          param_flags |= PARAM_EPSILON;
-          break;
-        default:
-          break;
-      }
-
-      if (node.op_type == OpType::GROUPNORM) {
-        param_flags |= PARAM_NUM_GROUPS;
-      }
-
-      write_u32(out, param_flags);
-
-      if (param_flags & PARAM_SCALAR) {
-        write_f32(out, node.params.scalar);
-      }
-      if (param_flags & PARAM_AXIS) {
-        write_i32(out, static_cast<int32_t>(node.params.axis));
-      }
-      if (param_flags & PARAM_NEW_SHAPE) {
-        write_size_vector(out, node.params.new_shape);
-      }
-      if (param_flags & PARAM_PRETRANSPOSED_RHS) {
-        write_u32(out, node.params.pretransposed_rhs ? 1u : 0u);
-      }
-      if (param_flags & PARAM_BACKEND) {
-        write_u32(out, static_cast<uint32_t>(node.params.backend));
-      }
-      if (param_flags & PARAM_SLICE) {
-        write_u64(out, static_cast<uint64_t>(node.params.slice_start));
-        write_u64(out, static_cast<uint64_t>(node.params.slice_length));
-      }
-      if (param_flags & PARAM_EPSILON) {
-        write_f32(out, node.params.epsilon);
-      }
-      if (param_flags & PARAM_NUM_GROUPS) {
-        write_u64(out, static_cast<uint64_t>(node.params.num_groups));
-      }
-      if (param_flags & PARAM_INDEX_VALUE) {
-        write_u64(out, static_cast<uint64_t>(node.params.index_value));
-      }
-      if (param_flags & PARAM_PERMUTATION) {
-        write_size_vector(out, node.params.permutation);
       }
     }
 
@@ -219,7 +91,7 @@ namespace {
         write_u32_vector(out, node.inputs);
         write_size_vector(out, node.output_shape);
         write_u32(out, static_cast<uint32_t>(node.precision));
-        write_op_params(out, node);
+        GraphParamIO::write_op_params(out, node.op_type, node.params);
       }
 
       if (!out) {
@@ -246,24 +118,6 @@ namespace {
         return v;
     }
 
-    int32_t read_i32(std::istream& in) {
-        int32_t v = 0;
-        in.read(reinterpret_cast<char*>(&v), sizeof(v));
-        if (!in) {
-            throw std::runtime_error("Unexpected EOF while reading int32");
-        }
-        return v;
-    }
-
-    float read_f32(std::istream& in) {
-        float v = 0.0f;
-        in.read(reinterpret_cast<char*>(&v), sizeof(v));
-        if (!in) {
-            throw std::runtime_error("Unexpected EOF while reading float");
-        }
-        return v;
-    }
-
     std::vector<uint32_t> read_u32_vector(std::istream& in) {
         uint32_t count = read_u32(in);
         std::vector<uint32_t> values;
@@ -282,72 +136,6 @@ namespace {
             values.push_back(static_cast<size_t>(read_u64(in)));
         }
         return values;
-    }
-
-    void read_op_params(std::istream& in, GraphFile::NodeEntry& node) {
-        uint32_t param_flags = read_u32(in);
-
-        constexpr uint32_t PARAM_SCALAR            = 1u << 0;
-        constexpr uint32_t PARAM_AXIS              = 1u << 1;
-        constexpr uint32_t PARAM_NEW_SHAPE         = 1u << 2;
-        constexpr uint32_t PARAM_PRETRANSPOSED_RHS = 1u << 3;
-        constexpr uint32_t PARAM_BACKEND           = 1u << 4;
-        constexpr uint32_t PARAM_SLICE             = 1u << 5;
-        constexpr uint32_t PARAM_EPSILON           = 1u << 6;
-        constexpr uint32_t PARAM_NUM_GROUPS        = 1u << 7;
-        constexpr uint32_t PARAM_INDEX_VALUE       = 1u << 8;
-        constexpr uint32_t PARAM_PERMUTATION       = 1u << 9;
-        constexpr uint32_t PARAM_KNOWN_MASK =
-            PARAM_SCALAR |
-            PARAM_AXIS |
-            PARAM_NEW_SHAPE |
-            PARAM_PRETRANSPOSED_RHS |
-            PARAM_BACKEND |
-            PARAM_SLICE |
-            PARAM_EPSILON |
-            PARAM_NUM_GROUPS |
-            PARAM_INDEX_VALUE |
-            PARAM_PERMUTATION;
-
-        if ((param_flags & ~PARAM_KNOWN_MASK) != 0) {
-            throw std::runtime_error("Graph file corrupted: unknown param flags");
-        }
-
-        if (param_flags & PARAM_SCALAR) {
-            node.params.scalar = read_f32(in);
-        }
-        if (param_flags & PARAM_AXIS) {
-            node.params.axis = static_cast<int>(read_i32(in));
-        }
-        if (param_flags & PARAM_NEW_SHAPE) {
-            node.params.new_shape = read_size_vector(in);
-        }
-        if (param_flags & PARAM_PRETRANSPOSED_RHS) {
-            node.params.pretransposed_rhs = (read_u32(in) != 0);
-        }
-        if (param_flags & PARAM_BACKEND) {
-            uint32_t backend_val = read_u32(in);
-            if (backend_val > static_cast<uint32_t>(ComputeBackend::NPU)) {
-                throw std::runtime_error("Graph file corrupted: invalid backend");
-            }
-            node.params.backend = static_cast<ComputeBackend>(backend_val);
-        }
-        if (param_flags & PARAM_SLICE) {
-            node.params.slice_start = static_cast<size_t>(read_u64(in));
-            node.params.slice_length = static_cast<size_t>(read_u64(in));
-        }
-        if (param_flags & PARAM_EPSILON) {
-            node.params.epsilon = read_f32(in);
-        }
-        if (param_flags & PARAM_NUM_GROUPS) {
-            node.params.num_groups = static_cast<size_t>(read_u64(in));
-        }
-        if (param_flags & PARAM_INDEX_VALUE) {
-            node.params.index_value = static_cast<size_t>(read_u64(in));
-        }
-        if (param_flags & PARAM_PERMUTATION) {
-            node.params.permutation = read_size_vector(in);
-        }
     }
 
     bool is_binary_broadcast_op(OpType op_type) {
@@ -387,7 +175,7 @@ namespace {
         if (header.magic != CACTUS_GRAPH_MAGIC) {
             throw std::runtime_error("Invalid graph file: bad magic");
         }
-        if (header.version != 1 && header.version != 2) {
+        if (header.version != 4) {
             throw std::runtime_error("Unsupported graph file version: " +
                 std::to_string(header.version));
         }
@@ -410,7 +198,7 @@ namespace {
             throw std::runtime_error("Graph file corrupted: invalid precision");
         }
         node.precision = static_cast<Precision>(precision_val);
-        read_op_params(in, node);
+        GraphParamIO::read_op_params(in, node.op_type, node.params);
         return node;
     }
     
@@ -621,7 +409,7 @@ void save_graph(const CactusGraph& graph,
 
   SerializedGraph sg;
   sg.header.magic = CACTUS_GRAPH_MAGIC;
-  sg.header.version = 2;
+  sg.header.version = 4;
   sg.header.node_count = static_cast<uint32_t>(graph.nodes_.size());
   sg.header.flags = 0;
 

--- a/cactus/graph/graph_io.cpp
+++ b/cactus/graph/graph_io.cpp
@@ -71,6 +71,7 @@ namespace {
       constexpr uint32_t PARAM_EPSILON           = 1u << 6;
       constexpr uint32_t PARAM_NUM_GROUPS        = 1u << 7;
       constexpr uint32_t PARAM_INDEX_VALUE       = 1u << 8;
+      constexpr uint32_t PARAM_PERMUTATION       = 1u << 9;
 
       switch (node.op_type) {
         case OpType::POW:
@@ -116,6 +117,11 @@ namespace {
 
       if (node.op_type == OpType::MATMUL) {
         param_flags |= PARAM_PRETRANSPOSED_RHS;
+        param_flags |= PARAM_BACKEND;
+      }
+
+      if (node.op_type == OpType::TRANSPOSE) {
+        param_flags |= PARAM_PERMUTATION;
         param_flags |= PARAM_BACKEND;
       }
 
@@ -168,6 +174,9 @@ namespace {
       }
       if (param_flags & PARAM_INDEX_VALUE) {
         write_u64(out, static_cast<uint64_t>(node.params.index_value));
+      }
+      if (param_flags & PARAM_PERMUTATION) {
+        write_size_vector(out, node.params.permutation);
       }
     }
 
@@ -287,6 +296,7 @@ namespace {
         constexpr uint32_t PARAM_EPSILON           = 1u << 6;
         constexpr uint32_t PARAM_NUM_GROUPS        = 1u << 7;
         constexpr uint32_t PARAM_INDEX_VALUE       = 1u << 8;
+        constexpr uint32_t PARAM_PERMUTATION       = 1u << 9;
         constexpr uint32_t PARAM_KNOWN_MASK =
             PARAM_SCALAR |
             PARAM_AXIS |
@@ -296,7 +306,8 @@ namespace {
             PARAM_SLICE |
             PARAM_EPSILON |
             PARAM_NUM_GROUPS |
-            PARAM_INDEX_VALUE;
+            PARAM_INDEX_VALUE |
+            PARAM_PERMUTATION;
 
         if ((param_flags & ~PARAM_KNOWN_MASK) != 0) {
             throw std::runtime_error("Graph file corrupted: unknown param flags");
@@ -333,6 +344,9 @@ namespace {
         }
         if (param_flags & PARAM_INDEX_VALUE) {
             node.params.index_value = static_cast<size_t>(read_u64(in));
+        }
+        if (param_flags & PARAM_PERMUTATION) {
+            node.params.permutation = read_size_vector(in);
         }
     }
 
@@ -373,7 +387,7 @@ namespace {
         if (header.magic != CACTUS_GRAPH_MAGIC) {
             throw std::runtime_error("Invalid graph file: bad magic");
         }
-        if (header.version != 1) {
+        if (header.version != 1 && header.version != 2) {
             throw std::runtime_error("Unsupported graph file version: " +
                 std::to_string(header.version));
         }
@@ -607,7 +621,7 @@ void save_graph(const CactusGraph& graph,
 
   SerializedGraph sg;
   sg.header.magic = CACTUS_GRAPH_MAGIC;
-  sg.header.version = 1;
+  sg.header.version = 2;
   sg.header.node_count = static_cast<uint32_t>(graph.nodes_.size());
   sg.header.flags = 0;
 

--- a/cactus/graph/graph_param_io.cpp
+++ b/cactus/graph/graph_param_io.cpp
@@ -1,0 +1,380 @@
+#include "graph_param_io.h"
+
+#include <stdexcept>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace {
+
+void write_u32(std::ostream& out, uint32_t v) {
+    out.write(reinterpret_cast<const char*>(&v), sizeof(v));
+}
+
+void write_u64(std::ostream& out, uint64_t v) {
+    out.write(reinterpret_cast<const char*>(&v), sizeof(v));
+}
+
+void write_i32(std::ostream& out, int32_t v) {
+    out.write(reinterpret_cast<const char*>(&v), sizeof(v));
+}
+
+void write_f32(std::ostream& out, float v) {
+    out.write(reinterpret_cast<const char*>(&v), sizeof(v));
+}
+
+uint32_t read_u32(std::istream& in) {
+    uint32_t v = 0;
+    in.read(reinterpret_cast<char*>(&v), sizeof(v));
+    if (!in) throw std::runtime_error("Unexpected EOF while reading uint32");
+    return v;
+}
+
+uint64_t read_u64(std::istream& in) {
+    uint64_t v = 0;
+    in.read(reinterpret_cast<char*>(&v), sizeof(v));
+    if (!in) throw std::runtime_error("Unexpected EOF while reading uint64");
+    return v;
+}
+
+int32_t read_i32(std::istream& in) {
+    int32_t v = 0;
+    in.read(reinterpret_cast<char*>(&v), sizeof(v));
+    if (!in) throw std::runtime_error("Unexpected EOF while reading int32");
+    return v;
+}
+
+float read_f32(std::istream& in) {
+    float v = 0.0f;
+    in.read(reinterpret_cast<char*>(&v), sizeof(v));
+    if (!in) throw std::runtime_error("Unexpected EOF while reading float");
+    return v;
+}
+
+void write_size_vector(std::ostream& out, const std::vector<size_t>& values) {
+    write_u32(out, static_cast<uint32_t>(values.size()));
+    for (size_t v : values) write_u64(out, static_cast<uint64_t>(v));
+}
+
+std::vector<size_t> read_size_vector(std::istream& in) {
+    uint32_t count = read_u32(in);
+    std::vector<size_t> values;
+    values.reserve(count);
+    for (uint32_t i = 0; i < count; ++i) values.push_back(static_cast<size_t>(read_u64(in)));
+    return values;
+}
+
+void write_u32_vector(std::ostream& out, const std::vector<uint32_t>& values) {
+    write_u32(out, static_cast<uint32_t>(values.size()));
+    for (uint32_t v : values) write_u32(out, v);
+}
+
+std::vector<uint32_t> read_u32_vector(std::istream& in) {
+    uint32_t count = read_u32(in);
+    std::vector<uint32_t> values;
+    values.reserve(count);
+    for (uint32_t i = 0; i < count; ++i) values.push_back(read_u32(in));
+    return values;
+}
+
+void write_f32_vector(std::ostream& out, const std::vector<float>& values) {
+    write_u32(out, static_cast<uint32_t>(values.size()));
+    for (float v : values) write_f32(out, v);
+}
+
+std::vector<float> read_f32_vector(std::istream& in) {
+    uint32_t count = read_u32(in);
+    std::vector<float> values;
+    values.reserve(count);
+    for (uint32_t i = 0; i < count; ++i) values.push_back(read_f32(in));
+    return values;
+}
+
+enum class ParamField : uint32_t {
+    Scalar = 1,
+    Axis,
+    NewShape,
+    PretransposedRhs,
+    Backend,
+    SliceStart,
+    SliceLength,
+    Epsilon,
+    NumGroups,
+    IndexValue,
+    Permutation,
+    Scale,
+    Theta,
+    PositionOffset,
+    WindowSize,
+    IsCausal,
+    AttentionMaskIsAdditive,
+    LogitCap,
+    TopK,
+    Temperature,
+    TopP,
+    MinP,
+    RepetitionPenalty,
+    RandomSeed,
+    BiasIndices,
+    BiasValues,
+    NormalizeRouting,
+    NumExperts,
+    NumExpertsPerTok,
+    MoeGated,
+    Activation,
+    NumKvHeads,
+    ChunkSize,
+    DstHeight,
+    DstWidth,
+    AlignCorners,
+    NumClasses,
+    NumAltupInputs,
+    KernelSize,
+    Stride,
+    Dilation,
+    NumFftBins,
+    CacheSeqLen,
+    HeadDim,
+    VHeadDim,
+    CachedKeysInt8Ptr,
+    CachedValuesInt8Ptr,
+    CachedKScalesPtr,
+    CachedVScalesPtr,
+};
+
+enum class FieldPersistence {
+    Persistent,
+    RuntimeOnly,
+    Derived,
+};
+
+struct FieldSpec {
+    ParamField field;
+    FieldPersistence persistence;
+};
+
+using Schema = std::vector<FieldSpec>;
+
+const Schema& op_schema(OpType op_type) {
+    static const Schema kEmpty{};
+    static const std::unordered_map<OpType, Schema> kSchemas = {
+        {OpType::POW, {{ParamField::Scalar, FieldPersistence::Persistent}}},
+        {OpType::SCALAR_ADD, {{ParamField::Scalar, FieldPersistence::Persistent}}},
+        {OpType::SCALAR_SUBTRACT, {{ParamField::Scalar, FieldPersistence::Persistent}}},
+        {OpType::SCALAR_MULTIPLY, {{ParamField::Scalar, FieldPersistence::Persistent}}},
+        {OpType::SCALAR_DIVIDE, {{ParamField::Scalar, FieldPersistence::Persistent}}},
+        {OpType::SOFTMAX, {{ParamField::Axis, FieldPersistence::Persistent}}},
+        {OpType::SUM, {{ParamField::Axis, FieldPersistence::Persistent}}},
+        {OpType::MEAN, {{ParamField::Axis, FieldPersistence::Persistent}}},
+        {OpType::VARIANCE, {{ParamField::Axis, FieldPersistence::Persistent}}},
+        {OpType::MIN, {{ParamField::Axis, FieldPersistence::Persistent}}},
+        {OpType::MAX, {{ParamField::Axis, FieldPersistence::Persistent}}},
+        {OpType::INDEX, {{ParamField::Axis, FieldPersistence::Persistent}, {ParamField::IndexValue, FieldPersistence::Persistent}}},
+        {OpType::CONCAT, {{ParamField::Axis, FieldPersistence::Persistent}}},
+        {OpType::CAT, {{ParamField::Axis, FieldPersistence::Persistent}}},
+        {OpType::VIEW, {{ParamField::NewShape, FieldPersistence::Persistent}}},
+        {OpType::RESHAPE, {{ParamField::NewShape, FieldPersistence::Persistent}}},
+        {OpType::FLATTEN, {{ParamField::NewShape, FieldPersistence::Persistent}}},
+        {OpType::MATMUL, {{ParamField::PretransposedRhs, FieldPersistence::Persistent}, {ParamField::Backend, FieldPersistence::Persistent}}},
+        {OpType::TRANSPOSE, {{ParamField::Permutation, FieldPersistence::Persistent}, {ParamField::Backend, FieldPersistence::Persistent}}},
+        {OpType::SLICE, {{ParamField::Axis, FieldPersistence::Persistent}, {ParamField::SliceStart, FieldPersistence::Persistent}, {ParamField::SliceLength, FieldPersistence::Persistent}}},
+        {OpType::RMS_NORM, {{ParamField::Epsilon, FieldPersistence::Persistent}}},
+        {OpType::LAYERNORM, {{ParamField::Epsilon, FieldPersistence::Persistent}}},
+        {OpType::GROUPNORM, {{ParamField::Epsilon, FieldPersistence::Persistent}, {ParamField::NumGroups, FieldPersistence::Persistent}}},
+        {OpType::BATCHNORM, {{ParamField::Epsilon, FieldPersistence::Persistent}, {ParamField::Axis, FieldPersistence::Persistent}}},
+        {OpType::ROPE, {{ParamField::Theta, FieldPersistence::Persistent}, {ParamField::PositionOffset, FieldPersistence::Persistent}, {ParamField::Backend, FieldPersistence::Persistent}}},
+        {OpType::ROPE_GPTJ, {{ParamField::Theta, FieldPersistence::Persistent}, {ParamField::PositionOffset, FieldPersistence::Persistent}, {ParamField::Scalar, FieldPersistence::Persistent}, {ParamField::Backend, FieldPersistence::Persistent}}},
+        {OpType::TOPK, {{ParamField::TopK, FieldPersistence::Persistent}}},
+        {OpType::ATTENTION, {{ParamField::Scale, FieldPersistence::Persistent}, {ParamField::PositionOffset, FieldPersistence::Persistent}, {ParamField::WindowSize, FieldPersistence::Persistent}, {ParamField::IsCausal, FieldPersistence::Persistent}, {ParamField::AttentionMaskIsAdditive, FieldPersistence::Persistent}, {ParamField::LogitCap, FieldPersistence::Persistent}, {ParamField::Backend, FieldPersistence::Persistent}}},
+        {OpType::REL_POS_BIAS, {{ParamField::Scale, FieldPersistence::Persistent}}},
+        {OpType::ATTENTION_INT8_HYBRID, {
+            {ParamField::Scale, FieldPersistence::Persistent},
+            {ParamField::PositionOffset, FieldPersistence::Persistent},
+            {ParamField::WindowSize, FieldPersistence::Persistent},
+            {ParamField::NumKvHeads, FieldPersistence::Persistent},
+            {ParamField::CacheSeqLen, FieldPersistence::Persistent},
+            {ParamField::HeadDim, FieldPersistence::Persistent},
+            {ParamField::VHeadDim, FieldPersistence::Persistent},
+            {ParamField::CachedKeysInt8Ptr, FieldPersistence::RuntimeOnly},
+            {ParamField::CachedValuesInt8Ptr, FieldPersistence::RuntimeOnly},
+            {ParamField::CachedKScalesPtr, FieldPersistence::RuntimeOnly},
+            {ParamField::CachedVScalesPtr, FieldPersistence::RuntimeOnly},
+        }},
+        {OpType::MOE_LAYER, {{ParamField::Scalar, FieldPersistence::Persistent}, {ParamField::Epsilon, FieldPersistence::Persistent}, {ParamField::NormalizeRouting, FieldPersistence::Persistent}, {ParamField::NumExperts, FieldPersistence::Persistent}, {ParamField::NumExpertsPerTok, FieldPersistence::Persistent}, {ParamField::MoeGated, FieldPersistence::Persistent}, {ParamField::Activation, FieldPersistence::Persistent}}},
+        {OpType::GATED_DELTANET_DECODE, {{ParamField::Scale, FieldPersistence::Persistent}, {ParamField::NumKvHeads, FieldPersistence::Persistent}}},
+        {OpType::GATED_DELTANET_PREFILL, {{ParamField::Scale, FieldPersistence::Persistent}, {ParamField::NumKvHeads, FieldPersistence::Persistent}, {ParamField::ChunkSize, FieldPersistence::Persistent}}},
+        {OpType::STFT, {{ParamField::Stride, FieldPersistence::Persistent}, {ParamField::NumFftBins, FieldPersistence::Persistent}}},
+        {OpType::BILINEAR_INTERPOLATION, {{ParamField::DstHeight, FieldPersistence::Persistent}, {ParamField::DstWidth, FieldPersistence::Persistent}, {ParamField::AlignCorners, FieldPersistence::Persistent}}},
+        {OpType::SCATTER_TOPK, {{ParamField::NumClasses, FieldPersistence::Persistent}}},
+        {OpType::ALTUP_PREDICT, {{ParamField::NumAltupInputs, FieldPersistence::Persistent}}},
+        {OpType::ALTUP_CORRECT, {{ParamField::NumAltupInputs, FieldPersistence::Persistent}}},
+        {OpType::MAXPOOL1D, {{ParamField::KernelSize, FieldPersistence::Persistent}, {ParamField::Stride, FieldPersistence::Persistent}}},
+        {OpType::CONV1D_CAUSAL, {{ParamField::Dilation, FieldPersistence::Persistent}}},
+        {OpType::CONV1D_K3, {{ParamField::Stride, FieldPersistence::Persistent}}},
+        {OpType::CONV1D_K7S3, {{ParamField::Stride, FieldPersistence::Persistent}}},
+        {OpType::CONV1D, {{ParamField::Stride, FieldPersistence::Persistent}}},
+        {OpType::SAMPLE, {{ParamField::Temperature, FieldPersistence::Persistent}, {ParamField::TopP, FieldPersistence::Persistent}, {ParamField::MinP, FieldPersistence::Persistent}, {ParamField::RepetitionPenalty, FieldPersistence::Persistent}, {ParamField::TopK, FieldPersistence::Persistent}, {ParamField::RandomSeed, FieldPersistence::Persistent}, {ParamField::BiasIndices, FieldPersistence::Persistent}, {ParamField::BiasValues, FieldPersistence::Persistent}}},
+    };
+
+    auto it = kSchemas.find(op_type);
+    return it == kSchemas.end() ? kEmpty : it->second;
+}
+
+void write_field(std::ostream& out, ParamField field, const OpParams& params) {
+    switch (field) {
+        case ParamField::Scalar: write_f32(out, params.scalar); break;
+        case ParamField::Axis: write_i32(out, static_cast<int32_t>(params.axis)); break;
+        case ParamField::NewShape: write_size_vector(out, params.new_shape); break;
+        case ParamField::PretransposedRhs: write_u32(out, params.pretransposed_rhs ? 1u : 0u); break;
+        case ParamField::Backend: write_u32(out, static_cast<uint32_t>(params.backend)); break;
+        case ParamField::SliceStart: write_u64(out, static_cast<uint64_t>(params.slice_start)); break;
+        case ParamField::SliceLength: write_u64(out, static_cast<uint64_t>(params.slice_length)); break;
+        case ParamField::Epsilon: write_f32(out, params.epsilon); break;
+        case ParamField::NumGroups: write_u64(out, static_cast<uint64_t>(params.num_groups)); break;
+        case ParamField::IndexValue: write_u64(out, static_cast<uint64_t>(params.index_value)); break;
+        case ParamField::Permutation: write_size_vector(out, params.permutation); break;
+        case ParamField::Scale: write_f32(out, params.scale); break;
+        case ParamField::Theta: write_f32(out, params.theta); break;
+        case ParamField::PositionOffset: write_u64(out, static_cast<uint64_t>(params.position_offset)); break;
+        case ParamField::WindowSize: write_u64(out, static_cast<uint64_t>(params.window_size)); break;
+        case ParamField::IsCausal: write_u32(out, params.is_causal ? 1u : 0u); break;
+        case ParamField::AttentionMaskIsAdditive: write_u32(out, params.attention_mask_is_additive ? 1u : 0u); break;
+        case ParamField::LogitCap: write_f32(out, params.logit_cap); break;
+        case ParamField::TopK: write_u64(out, static_cast<uint64_t>(params.top_k)); break;
+        case ParamField::Temperature: write_f32(out, params.temperature); break;
+        case ParamField::TopP: write_f32(out, params.top_p); break;
+        case ParamField::MinP: write_f32(out, params.min_p); break;
+        case ParamField::RepetitionPenalty: write_f32(out, params.repetition_penalty); break;
+        case ParamField::RandomSeed: write_u64(out, static_cast<uint64_t>(params.random_seed)); break;
+        case ParamField::BiasIndices: write_u32_vector(out, params.bias_indices); break;
+        case ParamField::BiasValues: write_f32_vector(out, params.bias_values); break;
+        case ParamField::NormalizeRouting: write_u32(out, params.normalize_routing ? 1u : 0u); break;
+        case ParamField::NumExperts: write_u64(out, static_cast<uint64_t>(params.num_experts)); break;
+        case ParamField::NumExpertsPerTok: write_u64(out, static_cast<uint64_t>(params.num_experts_per_tok)); break;
+        case ParamField::MoeGated: write_u32(out, params.moe_gated ? 1u : 0u); break;
+        case ParamField::Activation: write_u32(out, static_cast<uint32_t>(params.activation)); break;
+        case ParamField::NumKvHeads: write_u64(out, static_cast<uint64_t>(params.num_kv_heads)); break;
+        case ParamField::ChunkSize: write_u64(out, static_cast<uint64_t>(params.chunk_size)); break;
+        case ParamField::DstHeight: write_u64(out, static_cast<uint64_t>(params.dst_height)); break;
+        case ParamField::DstWidth: write_u64(out, static_cast<uint64_t>(params.dst_width)); break;
+        case ParamField::AlignCorners: write_u32(out, params.align_corners ? 1u : 0u); break;
+        case ParamField::NumClasses: write_u64(out, static_cast<uint64_t>(params.num_classes)); break;
+        case ParamField::NumAltupInputs: write_u64(out, static_cast<uint64_t>(params.num_altup_inputs)); break;
+        case ParamField::KernelSize: write_u64(out, static_cast<uint64_t>(params.kernel_size)); break;
+        case ParamField::Stride: write_u64(out, static_cast<uint64_t>(params.stride)); break;
+        case ParamField::Dilation: write_u64(out, static_cast<uint64_t>(params.dilation)); break;
+        case ParamField::NumFftBins: write_u64(out, static_cast<uint64_t>(params.num_fft_bins)); break;
+        case ParamField::CacheSeqLen: write_u64(out, static_cast<uint64_t>(params.cache_seq_len)); break;
+        case ParamField::HeadDim: write_u64(out, static_cast<uint64_t>(params.head_dim)); break;
+        case ParamField::VHeadDim: write_u64(out, static_cast<uint64_t>(params.v_head_dim)); break;
+        case ParamField::CachedKeysInt8Ptr:
+        case ParamField::CachedValuesInt8Ptr:
+        case ParamField::CachedKScalesPtr:
+        case ParamField::CachedVScalesPtr:
+            throw std::runtime_error("Attempted to serialize runtime-only pointer field");
+    }
+}
+
+void read_field(std::istream& in, ParamField field, OpParams& params) {
+    switch (field) {
+        case ParamField::Scalar: params.scalar = read_f32(in); break;
+        case ParamField::Axis: params.axis = static_cast<int>(read_i32(in)); break;
+        case ParamField::NewShape: params.new_shape = read_size_vector(in); break;
+        case ParamField::PretransposedRhs: params.pretransposed_rhs = (read_u32(in) != 0); break;
+        case ParamField::Backend: {
+            uint32_t backend_val = read_u32(in);
+            if (backend_val > static_cast<uint32_t>(ComputeBackend::NPU)) {
+                throw std::runtime_error("Graph file corrupted: invalid backend");
+            }
+            params.backend = static_cast<ComputeBackend>(backend_val);
+            break;
+        }
+        case ParamField::SliceStart: params.slice_start = static_cast<size_t>(read_u64(in)); break;
+        case ParamField::SliceLength: params.slice_length = static_cast<size_t>(read_u64(in)); break;
+        case ParamField::Epsilon: params.epsilon = read_f32(in); break;
+        case ParamField::NumGroups: params.num_groups = static_cast<size_t>(read_u64(in)); break;
+        case ParamField::IndexValue: params.index_value = static_cast<size_t>(read_u64(in)); break;
+        case ParamField::Permutation: params.permutation = read_size_vector(in); break;
+        case ParamField::Scale: params.scale = read_f32(in); break;
+        case ParamField::Theta: params.theta = read_f32(in); break;
+        case ParamField::PositionOffset: params.position_offset = static_cast<size_t>(read_u64(in)); break;
+        case ParamField::WindowSize: params.window_size = static_cast<size_t>(read_u64(in)); break;
+        case ParamField::IsCausal: params.is_causal = (read_u32(in) != 0); break;
+        case ParamField::AttentionMaskIsAdditive: params.attention_mask_is_additive = (read_u32(in) != 0); break;
+        case ParamField::LogitCap: params.logit_cap = read_f32(in); break;
+        case ParamField::TopK: params.top_k = static_cast<size_t>(read_u64(in)); break;
+        case ParamField::Temperature: params.temperature = read_f32(in); break;
+        case ParamField::TopP: params.top_p = read_f32(in); break;
+        case ParamField::MinP: params.min_p = read_f32(in); break;
+        case ParamField::RepetitionPenalty: params.repetition_penalty = read_f32(in); break;
+        case ParamField::RandomSeed: params.random_seed = static_cast<size_t>(read_u64(in)); break;
+        case ParamField::BiasIndices: params.bias_indices = read_u32_vector(in); break;
+        case ParamField::BiasValues: params.bias_values = read_f32_vector(in); break;
+        case ParamField::NormalizeRouting: params.normalize_routing = (read_u32(in) != 0); break;
+        case ParamField::NumExperts: params.num_experts = static_cast<size_t>(read_u64(in)); break;
+        case ParamField::NumExpertsPerTok: params.num_experts_per_tok = static_cast<size_t>(read_u64(in)); break;
+        case ParamField::MoeGated: params.moe_gated = (read_u32(in) != 0); break;
+        case ParamField::Activation: params.activation = static_cast<Activation>(read_u32(in)); break;
+        case ParamField::NumKvHeads: params.num_kv_heads = static_cast<size_t>(read_u64(in)); break;
+        case ParamField::ChunkSize: params.chunk_size = static_cast<size_t>(read_u64(in)); break;
+        case ParamField::DstHeight: params.dst_height = static_cast<size_t>(read_u64(in)); break;
+        case ParamField::DstWidth: params.dst_width = static_cast<size_t>(read_u64(in)); break;
+        case ParamField::AlignCorners: params.align_corners = (read_u32(in) != 0); break;
+        case ParamField::NumClasses: params.num_classes = static_cast<size_t>(read_u64(in)); break;
+        case ParamField::NumAltupInputs: params.num_altup_inputs = static_cast<size_t>(read_u64(in)); break;
+        case ParamField::KernelSize: params.kernel_size = static_cast<size_t>(read_u64(in)); break;
+        case ParamField::Stride: params.stride = static_cast<size_t>(read_u64(in)); break;
+        case ParamField::Dilation: params.dilation = static_cast<size_t>(read_u64(in)); break;
+        case ParamField::NumFftBins: params.num_fft_bins = static_cast<size_t>(read_u64(in)); break;
+        case ParamField::CacheSeqLen: params.cache_seq_len = static_cast<size_t>(read_u64(in)); break;
+        case ParamField::HeadDim: params.head_dim = static_cast<size_t>(read_u64(in)); break;
+        case ParamField::VHeadDim: params.v_head_dim = static_cast<size_t>(read_u64(in)); break;
+        case ParamField::CachedKeysInt8Ptr:
+        case ParamField::CachedValuesInt8Ptr:
+        case ParamField::CachedKScalesPtr:
+        case ParamField::CachedVScalesPtr:
+            throw std::runtime_error("Graph file corrupted: runtime-only field serialized");
+    }
+}
+
+} // namespace
+
+namespace GraphParamIO {
+
+void write_op_params(std::ostream& out, OpType op_type, const OpParams& params) {
+    const auto& schema = op_schema(op_type);
+    std::vector<ParamField> fields;
+    fields.reserve(schema.size());
+    for (const auto& spec : schema) {
+        if (spec.persistence == FieldPersistence::Persistent) {
+            fields.push_back(spec.field);
+        }
+    }
+
+    write_u32(out, static_cast<uint32_t>(fields.size()));
+    for (ParamField field : fields) {
+        write_u32(out, static_cast<uint32_t>(field));
+        write_field(out, field, params);
+    }
+}
+
+void read_op_params(std::istream& in, OpType op_type, OpParams& params) {
+    uint32_t field_count = read_u32(in);
+    const auto& schema = op_schema(op_type);
+    std::unordered_set<uint32_t> allowed;
+    for (const auto& spec : schema) {
+        if (spec.persistence == FieldPersistence::Persistent) {
+            allowed.insert(static_cast<uint32_t>(spec.field));
+        }
+    }
+
+    for (uint32_t i = 0; i < field_count; ++i) {
+        uint32_t raw_field = read_u32(in);
+        if (allowed.count(raw_field) == 0) {
+            throw std::runtime_error("Graph file corrupted: field not allowed for op");
+        }
+        read_field(in, static_cast<ParamField>(raw_field), params);
+    }
+}
+
+} // namespace GraphParamIO

--- a/cactus/graph/graph_param_io.h
+++ b/cactus/graph/graph_param_io.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "graph.h"
+#include <iosfwd>
+
+namespace GraphParamIO {
+
+void write_op_params(std::ostream& out, OpType op_type, const OpParams& params);
+void read_op_params(std::istream& in, OpType op_type, OpParams& params);
+
+} // namespace GraphParamIO

--- a/docs/cactus_graph.md
+++ b/docs/cactus_graph.md
@@ -423,6 +423,66 @@ size_t similarity = fixture.graph().divide(dot_product, fixture.graph().multiply
 3. **Test edge cases**: Include tests for broadcasting, empty tensors, and large inputs
 4. **Check precision**: Test operations with different precision types
 
+### Contributing Graph Operations
+1. ** Define the op in core graph types ** 
+Add the new OpType in `cactus/graph/graph.h`
+If the op needs additional parameters, add the fields to OpParams in the same file 
+
+2. ** Add a graph builder API **  
+Add a builder method in `cactus/graph/graph_builder.cpp` and its declaration in 
+`cactus/graph/graph.h`
+Follow the pattern of existing builder methods, e.g. for a new "relu" op:
+```cpp
+size_t CactusGraph::relu(size_t input) {
+    OpParams params;
+    return add_node(OpType::RELU, {input}, params);
+}
+```
+3. ** Implement the op in the execution engine **
+Implement the krnel or graph op code in the relevant file, usually in `cactus/kernel/`
+Register the new op in the dispatch table in `cactus/graph/graph_execute.cpp` for the supported backends (CPU, NPU)
+
+4. ** Export op in FFI bindings **
+- header: `cactus/ffi/cactus_ffi.h`
+- implementation: `cactus/ffi/cactus_ffi.cpp`
+
+5. ** Add python ctypes declaration ** 
+Add `_lib.cactus_graph_my_new_op.argtypes/restype` in `python/src/cactus.py`
+
+6. ** Add python graph wrapper ** 
+Add `Graph.my_new_op(...)` in `python/src/graph.py`, and optionally a Tensor
+  convenience method.
+
+7. ** Add serialization schema entry if needed **
+If your op has extra parameters that need to be saved/loaded that are not in the 
+default node, add new ParamField enum values. 
+
+If the op has any graph-persistent params:
+
+- add any new ParamField enum values in cactus/graph/graph_param_io.cpp
+- add read/write logic for those fields
+- add the op’s schema entry in `op_schema(...)`
+
+If the op has no params, you may not need to touch schema beyond maybe adding an
+empty schema entry.
+
+The syntax pattern there is:
+```
+{OpType::MY_NEW_OP, {
+    {ParamField::Alpha, FieldPersistence::Persistent},
+    {ParamField::Mode, FieldPersistence::Persistent},
+}},
+```
+8. ** Add test coverage **
+Add unit tests to `tests/test_graph.cpp` covering the native graph function, and 
+add python tests in `python/tests/test_graph.py` covering the Python API and end-to-end execution.
+
+and then support those fields in `write_field(...)` / `read_field(...)`.
+
+If a field is runtime-only, mark it RuntimeOnly instead of Persistent.
+
+
+
 ### Error Handling
 ```cpp
 try {

--- a/python/src/cactus.py
+++ b/python/src/cactus.py
@@ -190,6 +190,44 @@ _lib.cactus_graph_matmul.argtypes = [
     cactus_graph_t, cactus_node_t, cactus_node_t, ctypes.c_bool, ctypes.c_int32, ctypes.POINTER(cactus_node_t)
 ]
 _lib.cactus_graph_matmul.restype = ctypes.c_int
+_lib.cactus_graph_gather.argtypes = [
+    cactus_graph_t, cactus_node_t, cactus_node_t, ctypes.POINTER(cactus_node_t)
+]
+_lib.cactus_graph_gather.restype = ctypes.c_int
+_lib.cactus_graph_embedding_from_tensor.argtypes = [
+    cactus_graph_t, cactus_node_t, cactus_node_t, ctypes.POINTER(cactus_node_t)
+]
+_lib.cactus_graph_embedding_from_tensor.restype = ctypes.c_int
+_lib.cactus_graph_embedding_from_file.argtypes = [
+    cactus_graph_t, ctypes.c_char_p, cactus_node_t, ctypes.POINTER(cactus_node_t)
+]
+_lib.cactus_graph_embedding_from_file.restype = ctypes.c_int
+_lib.cactus_graph_mmap_embeddings.argtypes = [
+    cactus_graph_t, ctypes.c_char_p, ctypes.POINTER(cactus_node_t)
+]
+_lib.cactus_graph_mmap_embeddings.restype = ctypes.c_int
+_lib.cactus_graph_mmap_weights.argtypes = [
+    cactus_graph_t, ctypes.c_char_p, ctypes.POINTER(cactus_node_t)
+]
+_lib.cactus_graph_mmap_weights.restype = ctypes.c_int
+_lib.cactus_graph_bilinear_interpolation.argtypes = [
+    cactus_graph_t, cactus_node_t, ctypes.c_size_t, ctypes.c_size_t, ctypes.POINTER(cactus_node_t)
+]
+_lib.cactus_graph_bilinear_interpolation.restype = ctypes.c_int
+_lib.cactus_graph_set_grouped_scales.argtypes = [
+    cactus_graph_t, cactus_node_t, ctypes.c_size_t, ctypes.c_size_t, ctypes.c_void_p
+]
+_lib.cactus_graph_set_grouped_scales.restype = ctypes.c_int
+_lib.cactus_graph_set_interleaved.argtypes = [
+    cactus_graph_t, cactus_node_t, ctypes.c_bool, ctypes.c_size_t
+]
+_lib.cactus_graph_set_interleaved.restype = ctypes.c_int
+_lib.cactus_graph_release_weight_pages.argtypes = [cactus_graph_t, cactus_node_t]
+_lib.cactus_graph_release_weight_pages.restype = ctypes.c_int
+_lib.cactus_graph_prefetch_weight_pages.argtypes = [cactus_graph_t, cactus_node_t]
+_lib.cactus_graph_prefetch_weight_pages.restype = ctypes.c_int
+_lib.cactus_graph_release_all_weight_pages.argtypes = [cactus_graph_t]
+_lib.cactus_graph_release_all_weight_pages.restype = ctypes.c_int
 
 _lib.cactus_graph_sum.argtypes = [
     cactus_graph_t, cactus_node_t, ctypes.c_int32, ctypes.POINTER(cactus_node_t)
@@ -257,10 +295,133 @@ _lib.cactus_graph_rms_norm.argtypes = [
     cactus_graph_t, cactus_node_t, cactus_node_t, ctypes.c_float, ctypes.POINTER(cactus_node_t)
 ]
 _lib.cactus_graph_rms_norm.restype = ctypes.c_int
+_lib.cactus_graph_topk.argtypes = [
+    cactus_graph_t, cactus_node_t, ctypes.c_size_t, ctypes.POINTER(cactus_node_t)
+]
+_lib.cactus_graph_topk.restype = ctypes.c_int
+_lib.cactus_graph_rope.argtypes = [
+    cactus_graph_t, cactus_node_t, ctypes.c_float, ctypes.c_size_t, ctypes.c_int32, ctypes.POINTER(cactus_node_t)
+]
+_lib.cactus_graph_rope.restype = ctypes.c_int
+_lib.cactus_graph_rope_gptj.argtypes = [
+    cactus_graph_t, cactus_node_t, ctypes.c_float, ctypes.c_size_t, ctypes.c_size_t, ctypes.c_int32, ctypes.POINTER(cactus_node_t)
+]
+_lib.cactus_graph_rope_gptj.restype = ctypes.c_int
 _lib.cactus_graph_softmax.argtypes = [
     cactus_graph_t, cactus_node_t, ctypes.c_int32, ctypes.POINTER(cactus_node_t)
 ]
 _lib.cactus_graph_softmax.restype = ctypes.c_int
+_lib.cactus_graph_attention.argtypes = [
+    cactus_graph_t, cactus_node_t, cactus_node_t, cactus_node_t, ctypes.c_float, ctypes.c_bool,
+    ctypes.c_size_t, ctypes.c_size_t, ctypes.c_int32, ctypes.c_bool, cactus_node_t, ctypes.c_bool,
+    ctypes.POINTER(cactus_node_t)
+]
+_lib.cactus_graph_attention.restype = ctypes.c_int
+_lib.cactus_graph_rel_pos_bias.argtypes = [
+    cactus_graph_t, cactus_node_t, cactus_node_t, ctypes.c_float, ctypes.POINTER(cactus_node_t)
+]
+_lib.cactus_graph_rel_pos_bias.restype = ctypes.c_int
+_lib.cactus_graph_attention_int8_hybrid.argtypes = [
+    cactus_graph_t, cactus_node_t, cactus_node_t, cactus_node_t, ctypes.c_float, ctypes.c_size_t,
+    ctypes.POINTER(ctypes.c_int8), ctypes.POINTER(ctypes.c_int8),
+    ctypes.POINTER(ctypes.c_float), ctypes.POINTER(ctypes.c_float),
+    ctypes.c_size_t, ctypes.c_size_t, ctypes.c_size_t, ctypes.c_size_t, ctypes.POINTER(cactus_node_t)
+]
+_lib.cactus_graph_attention_int8_hybrid.restype = ctypes.c_int
+_lib.cactus_graph_conv1d_causal.argtypes = [
+    cactus_graph_t, cactus_node_t, cactus_node_t, ctypes.c_size_t, ctypes.c_size_t, ctypes.POINTER(cactus_node_t)
+]
+_lib.cactus_graph_conv1d_causal.restype = ctypes.c_int
+_lib.cactus_graph_conv1d_k3.argtypes = [
+    cactus_graph_t, cactus_node_t, cactus_node_t, ctypes.c_size_t, ctypes.POINTER(cactus_node_t)
+]
+_lib.cactus_graph_conv1d_k3.restype = ctypes.c_int
+_lib.cactus_graph_conv1d_k7s3.argtypes = [
+    cactus_graph_t, cactus_node_t, cactus_node_t, cactus_node_t, ctypes.POINTER(cactus_node_t)
+]
+_lib.cactus_graph_conv1d_k7s3.restype = ctypes.c_int
+_lib.cactus_graph_conv1d.argtypes = [
+    cactus_graph_t, cactus_node_t, cactus_node_t, ctypes.c_bool, cactus_node_t, ctypes.c_size_t, ctypes.POINTER(cactus_node_t)
+]
+_lib.cactus_graph_conv1d.restype = ctypes.c_int
+_lib.cactus_graph_conv1d_same_depthwise_k9.argtypes = [
+    cactus_graph_t, cactus_node_t, cactus_node_t, ctypes.c_bool, cactus_node_t, ctypes.POINTER(cactus_node_t)
+]
+_lib.cactus_graph_conv1d_same_depthwise_k9.restype = ctypes.c_int
+_lib.cactus_graph_conv1d_pointwise.argtypes = [
+    cactus_graph_t, cactus_node_t, cactus_node_t, ctypes.c_bool, cactus_node_t, ctypes.POINTER(cactus_node_t)
+]
+_lib.cactus_graph_conv1d_pointwise.restype = ctypes.c_int
+_lib.cactus_graph_conv2d_k3s2p1.argtypes = [
+    cactus_graph_t, cactus_node_t, cactus_node_t, ctypes.c_bool, cactus_node_t, ctypes.POINTER(cactus_node_t)
+]
+_lib.cactus_graph_conv2d_k3s2p1.restype = ctypes.c_int
+_lib.cactus_graph_conv2d_depthwise_k3s2p1.argtypes = [
+    cactus_graph_t, cactus_node_t, cactus_node_t, ctypes.c_bool, cactus_node_t, ctypes.POINTER(cactus_node_t)
+]
+_lib.cactus_graph_conv2d_depthwise_k3s2p1.restype = ctypes.c_int
+_lib.cactus_graph_conv2d_pointwise_1x1.argtypes = [
+    cactus_graph_t, cactus_node_t, cactus_node_t, ctypes.c_bool, cactus_node_t, ctypes.POINTER(cactus_node_t)
+]
+_lib.cactus_graph_conv2d_pointwise_1x1.restype = ctypes.c_int
+_lib.cactus_graph_lstm_cell.argtypes = [
+    cactus_graph_t, cactus_node_t, cactus_node_t, cactus_node_t, cactus_node_t, cactus_node_t, cactus_node_t, cactus_node_t, ctypes.POINTER(cactus_node_t)
+]
+_lib.cactus_graph_lstm_cell.restype = ctypes.c_int
+_lib.cactus_graph_gated_deltanet_decode.argtypes = [
+    cactus_graph_t, cactus_node_t, cactus_node_t, cactus_node_t, cactus_node_t, cactus_node_t, cactus_node_t, ctypes.c_float, ctypes.POINTER(cactus_node_t)
+]
+_lib.cactus_graph_gated_deltanet_decode.restype = ctypes.c_int
+_lib.cactus_graph_gated_deltanet_prefill.argtypes = [
+    cactus_graph_t, cactus_node_t, cactus_node_t, cactus_node_t, cactus_node_t, cactus_node_t, cactus_node_t, ctypes.c_size_t, ctypes.c_float, ctypes.POINTER(cactus_node_t)
+]
+_lib.cactus_graph_gated_deltanet_prefill.restype = ctypes.c_int
+_lib.cactus_graph_stft.argtypes = [
+    cactus_graph_t, cactus_node_t, cactus_node_t, ctypes.c_size_t, ctypes.c_size_t, ctypes.POINTER(cactus_node_t)
+]
+_lib.cactus_graph_stft.restype = ctypes.c_int
+_lib.cactus_graph_altup_predict.argtypes = [
+    cactus_graph_t, cactus_node_t, ctypes.POINTER(cactus_node_t), ctypes.c_size_t, ctypes.POINTER(cactus_node_t)
+]
+_lib.cactus_graph_altup_predict.restype = ctypes.c_int
+_lib.cactus_graph_altup_correct.argtypes = [
+    cactus_graph_t, cactus_node_t, cactus_node_t, ctypes.POINTER(cactus_node_t), ctypes.c_size_t, ctypes.POINTER(cactus_node_t)
+]
+_lib.cactus_graph_altup_correct.restype = ctypes.c_int
+_lib.cactus_graph_gaussian_topk.argtypes = [
+    cactus_graph_t, cactus_node_t, ctypes.c_float, ctypes.POINTER(cactus_node_t)
+]
+_lib.cactus_graph_gaussian_topk.restype = ctypes.c_int
+_lib.cactus_graph_moe_layer_gated.argtypes = [
+    cactus_graph_t, cactus_node_t, cactus_node_t, cactus_node_t,
+    ctypes.POINTER(cactus_node_t), ctypes.POINTER(cactus_node_t), ctypes.POINTER(cactus_node_t),
+    ctypes.c_size_t, ctypes.c_size_t, ctypes.c_bool, ctypes.c_float, ctypes.c_float, ctypes.POINTER(cactus_node_t)
+]
+_lib.cactus_graph_moe_layer_gated.restype = ctypes.c_int
+_lib.cactus_graph_moe_layer_ungated.argtypes = [
+    cactus_graph_t, cactus_node_t, cactus_node_t, cactus_node_t,
+    ctypes.POINTER(cactus_node_t), ctypes.POINTER(cactus_node_t),
+    ctypes.c_size_t, ctypes.c_size_t, ctypes.c_bool, ctypes.c_float, ctypes.c_float, ctypes.c_int32, ctypes.POINTER(cactus_node_t)
+]
+_lib.cactus_graph_moe_layer_ungated.restype = ctypes.c_int
+_lib.cactus_graph_sample.argtypes = [
+    cactus_graph_t, cactus_node_t, ctypes.c_float, ctypes.c_float, ctypes.c_size_t, ctypes.POINTER(cactus_node_t)
+]
+_lib.cactus_graph_sample.restype = ctypes.c_int
+_lib.cactus_graph_scatter_topk.argtypes = [
+    cactus_graph_t, cactus_node_t, cactus_node_t, ctypes.c_size_t, ctypes.POINTER(cactus_node_t)
+]
+_lib.cactus_graph_scatter_topk.restype = ctypes.c_int
+_lib.cactus_graph_persistent.argtypes = [
+    cactus_graph_t, cactus_node_t, ctypes.POINTER(cactus_node_t)
+]
+_lib.cactus_graph_persistent.restype = ctypes.c_int
+_lib.cactus_graph_is_populated.argtypes = [
+    cactus_graph_t, cactus_node_t, ctypes.POINTER(ctypes.c_int32)
+]
+_lib.cactus_graph_is_populated.restype = ctypes.c_int
+_lib.cactus_graph_invalidate_persistent.argtypes = [cactus_graph_t, cactus_node_t]
+_lib.cactus_graph_invalidate_persistent.restype = ctypes.c_int
 
 _lib.cactus_graph_execute.argtypes = [cactus_graph_t]
 _lib.cactus_graph_execute.restype = ctypes.c_int

--- a/python/src/graph.py
+++ b/python/src/graph.py
@@ -10,6 +10,14 @@ class Graph:
     FP16 = 1
     FP32 = 2
     INT4 = 3
+    CPU = 0
+    NPU = 1
+    ACT_SILU = 0
+    ACT_GELU = 1
+    ACT_GELU_ERF = 2
+    ACT_RELU = 3
+    ACT_SIGMOID = 4
+    ACT_TANH = 5
 
     def __init__(self):
         self.h = _lib.cactus_graph_create()
@@ -61,6 +69,22 @@ class Graph:
         if rc != 0:
             raise RuntimeError("graph_set_input failed")
 
+    def set_external_input(self, tensor, data_ptr, dtype=None):
+        if not isinstance(tensor, Tensor):
+            raise TypeError("tensor must be a Tensor")
+        if tensor.g is not self:
+            raise ValueError("tensor belongs to a different graph")
+        target_dtype = int(tensor.dtype if dtype is None else dtype)
+        ptr = ctypes.c_void_p(data_ptr if isinstance(data_ptr, int) else int(data_ptr))
+        rc = _lib.cactus_graph_set_external_input(
+            self.h,
+            cactus_node_t(tensor.id),
+            ptr,
+            target_dtype,
+        )
+        if rc != 0:
+            raise RuntimeError("graph_set_external_input failed")
+
     def hard_reset(self):
         rc = _lib.cactus_graph_hard_reset(self.h)
         if rc != 0:
@@ -73,6 +97,9 @@ class Graph:
 
     def add(self, a, b):
         return self._binary("cactus_graph_add", a, b)
+
+    def add_clipped(self, a, b):
+        return self._binary("cactus_graph_add_clipped", a, b)
 
     def subtract(self, a, b):
         return self._binary("cactus_graph_subtract", a, b)
@@ -99,6 +126,61 @@ class Graph:
             raise RuntimeError("graph_pow failed")
         return self._tensor_from_node(out.value)
 
+    def precision_cast(self, x, dtype):
+        x = self._ensure_tensor(x)
+        out = cactus_node_t()
+        rc = _lib.cactus_graph_precision_cast(self.h, cactus_node_t(x.id), int(dtype), ctypes.byref(out))
+        if rc != 0:
+            raise RuntimeError("graph_precision_cast failed")
+        return self._tensor_from_node(out.value)
+
+    def quantize_activations(self, x):
+        x = self._ensure_tensor(x)
+        out = cactus_node_t()
+        rc = _lib.cactus_graph_quantize_activations(self.h, cactus_node_t(x.id), ctypes.byref(out))
+        if rc != 0:
+            raise RuntimeError("graph_quantize_activations failed")
+        return self._tensor_from_node(out.value)
+
+    def _scalar(self, fn_name, x, value=None):
+        x = self._ensure_tensor(x)
+        out = cactus_node_t()
+        fn = getattr(_lib, fn_name)
+        if value is None:
+            rc = fn(self.h, cactus_node_t(x.id), ctypes.byref(out))
+        else:
+            rc = fn(self.h, cactus_node_t(x.id), ctypes.c_float(float(value)), ctypes.byref(out))
+        if rc != 0:
+            raise RuntimeError(f"{fn_name} failed")
+        return self._tensor_from_node(out.value)
+
+    def scalar_add(self, x, value):
+        return self._scalar("cactus_graph_scalar_add", x, value)
+
+    def scalar_subtract(self, x, value):
+        return self._scalar("cactus_graph_scalar_subtract", x, value)
+
+    def scalar_multiply(self, x, value):
+        return self._scalar("cactus_graph_scalar_multiply", x, value)
+
+    def scalar_divide(self, x, value):
+        return self._scalar("cactus_graph_scalar_divide", x, value)
+
+    def scalar_exp(self, x):
+        return self._scalar("cactus_graph_scalar_exp", x)
+
+    def scalar_sqrt(self, x):
+        return self._scalar("cactus_graph_scalar_sqrt", x)
+
+    def scalar_cos(self, x):
+        return self._scalar("cactus_graph_scalar_cos", x)
+
+    def scalar_sin(self, x):
+        return self._scalar("cactus_graph_scalar_sin", x)
+
+    def scalar_log(self, x):
+        return self._scalar("cactus_graph_scalar_log", x)
+
     def view(self, x, shape):
         x = self._ensure_tensor(x)
         shape = tuple(int(v) for v in shape)
@@ -107,6 +189,16 @@ class Graph:
         rc = _lib.cactus_graph_view(self.h, cactus_node_t(x.id), arr, len(shape), ctypes.byref(out))
         if rc != 0:
             raise RuntimeError("graph_view failed")
+        return self._tensor_from_node(out.value)
+
+    def reshape(self, x, shape):
+        x = self._ensure_tensor(x)
+        shape = tuple(int(v) for v in shape)
+        arr = (ctypes.c_size_t * len(shape))(*shape)
+        out = cactus_node_t()
+        rc = _lib.cactus_graph_reshape(self.h, cactus_node_t(x.id), arr, len(shape), ctypes.byref(out))
+        if rc != 0:
+            raise RuntimeError("graph_reshape failed")
         return self._tensor_from_node(out.value)
 
     def flatten(self, x, start_dim=0, end_dim=-1):
@@ -122,6 +214,171 @@ class Graph:
         if rc != 0:
             raise RuntimeError("graph_flatten failed")
         return self._tensor_from_node(out.value)
+
+    def slice(self, x, axis, start, length=0):
+        x = self._ensure_tensor(x)
+        out = cactus_node_t()
+        rc = _lib.cactus_graph_slice(
+            self.h,
+            cactus_node_t(x.id),
+            ctypes.c_int32(int(axis)),
+            ctypes.c_size_t(int(start)),
+            ctypes.c_size_t(int(length)),
+            ctypes.byref(out),
+        )
+        if rc != 0:
+            raise RuntimeError("graph_slice failed")
+        return self._tensor_from_node(out.value)
+
+    def index(self, x, index_value, axis=0):
+        x = self._ensure_tensor(x)
+        out = cactus_node_t()
+        rc = _lib.cactus_graph_index(
+            self.h,
+            cactus_node_t(x.id),
+            ctypes.c_size_t(int(index_value)),
+            ctypes.c_int32(int(axis)),
+            ctypes.byref(out),
+        )
+        if rc != 0:
+            raise RuntimeError("graph_index failed")
+        return self._tensor_from_node(out.value)
+
+    def transpose(self, x, backend=CPU):
+        x = self._ensure_tensor(x)
+        out = cactus_node_t()
+        rc = _lib.cactus_graph_transpose(
+            self.h,
+            cactus_node_t(x.id),
+            ctypes.c_int32(int(backend)),
+            ctypes.byref(out),
+        )
+        if rc != 0:
+            raise RuntimeError("graph_transpose failed")
+        return self._tensor_from_node(out.value)
+
+    def permute(self, x, permutation, backend=CPU):
+        x = self._ensure_tensor(x)
+        permutation = tuple(int(v) for v in permutation)
+        arr = (ctypes.c_size_t * len(permutation))(*permutation)
+        out = cactus_node_t()
+        rc = _lib.cactus_graph_transpose_n(
+            self.h,
+            cactus_node_t(x.id),
+            arr,
+            len(permutation),
+            ctypes.c_int32(int(backend)),
+            ctypes.byref(out),
+        )
+        if rc != 0:
+            raise RuntimeError("graph_transpose_n failed")
+        return self._tensor_from_node(out.value)
+
+    def matmul(self, a, b, pretransposed_rhs=False, backend=CPU):
+        a = self._ensure_tensor(a)
+        b = self._ensure_tensor(b)
+        out = cactus_node_t()
+        rc = _lib.cactus_graph_matmul(
+            self.h,
+            cactus_node_t(a.id),
+            cactus_node_t(b.id),
+            ctypes.c_bool(bool(pretransposed_rhs)),
+            ctypes.c_int32(int(backend)),
+            ctypes.byref(out),
+        )
+        if rc != 0:
+            raise RuntimeError("graph_matmul failed")
+        return self._tensor_from_node(out.value)
+
+    def gather(self, tensor, indices):
+        tensor = self._ensure_tensor(tensor)
+        indices = self._ensure_tensor(indices)
+        out = cactus_node_t()
+        rc = _lib.cactus_graph_gather(self.h, cactus_node_t(tensor.id), cactus_node_t(indices.id), ctypes.byref(out))
+        if rc != 0:
+            raise RuntimeError("graph_gather failed")
+        return self._tensor_from_node(out.value)
+
+    def embedding_from_tensor(self, embedding_tensor, indices):
+        embedding_tensor = self._ensure_tensor(embedding_tensor)
+        indices = self._ensure_tensor(indices)
+        out = cactus_node_t()
+        rc = _lib.cactus_graph_embedding_from_tensor(
+            self.h, cactus_node_t(embedding_tensor.id), cactus_node_t(indices.id), ctypes.byref(out)
+        )
+        if rc != 0:
+            raise RuntimeError("graph_embedding_from_tensor failed")
+        return self._tensor_from_node(out.value)
+
+    def embedding_from_file(self, filename, indices):
+        indices = self._ensure_tensor(indices)
+        out = cactus_node_t()
+        rc = _lib.cactus_graph_embedding_from_file(self.h, str(filename).encode(), cactus_node_t(indices.id), ctypes.byref(out))
+        if rc != 0:
+            raise RuntimeError("graph_embedding_from_file failed")
+        return self._tensor_from_node(out.value)
+
+    def mmap_embeddings(self, filename):
+        out = cactus_node_t()
+        rc = _lib.cactus_graph_mmap_embeddings(self.h, str(filename).encode(), ctypes.byref(out))
+        if rc != 0:
+            raise RuntimeError("graph_mmap_embeddings failed")
+        return self._tensor_from_node(out.value)
+
+    def mmap_weights(self, filename):
+        out = cactus_node_t()
+        rc = _lib.cactus_graph_mmap_weights(self.h, str(filename).encode(), ctypes.byref(out))
+        if rc != 0:
+            raise RuntimeError("graph_mmap_weights failed")
+        return self._tensor_from_node(out.value)
+
+    def bilinear_interpolation(self, pos_embeds, dst_height, dst_width):
+        pos_embeds = self._ensure_tensor(pos_embeds)
+        out = cactus_node_t()
+        rc = _lib.cactus_graph_bilinear_interpolation(
+            self.h, cactus_node_t(pos_embeds.id), ctypes.c_size_t(int(dst_height)), ctypes.c_size_t(int(dst_width)), ctypes.byref(out)
+        )
+        if rc != 0:
+            raise RuntimeError("graph_bilinear_interpolation failed")
+        return self._tensor_from_node(out.value)
+
+    def set_grouped_scales(self, tensor, group_size, num_groups, scales):
+        tensor = self._ensure_tensor(tensor)
+        arr = np.ascontiguousarray(scales, dtype=np.float16)
+        rc = _lib.cactus_graph_set_grouped_scales(
+            self.h,
+            cactus_node_t(tensor.id),
+            ctypes.c_size_t(int(group_size)),
+            ctypes.c_size_t(int(num_groups)),
+            arr.ctypes.data_as(ctypes.c_void_p),
+        )
+        if rc != 0:
+            raise RuntimeError("graph_set_grouped_scales failed")
+
+    def set_interleaved(self, tensor, interleaved=True, original_n=0):
+        tensor = self._ensure_tensor(tensor)
+        rc = _lib.cactus_graph_set_interleaved(
+            self.h, cactus_node_t(tensor.id), ctypes.c_bool(bool(interleaved)), ctypes.c_size_t(int(original_n))
+        )
+        if rc != 0:
+            raise RuntimeError("graph_set_interleaved failed")
+
+    def release_weight_pages(self, tensor):
+        tensor = self._ensure_tensor(tensor)
+        rc = _lib.cactus_graph_release_weight_pages(self.h, cactus_node_t(tensor.id))
+        if rc != 0:
+            raise RuntimeError("graph_release_weight_pages failed")
+
+    def prefetch_weight_pages(self, tensor):
+        tensor = self._ensure_tensor(tensor)
+        rc = _lib.cactus_graph_prefetch_weight_pages(self.h, cactus_node_t(tensor.id))
+        if rc != 0:
+            raise RuntimeError("graph_prefetch_weight_pages failed")
+
+    def release_all_weight_pages(self):
+        rc = _lib.cactus_graph_release_all_weight_pages(self.h)
+        if rc != 0:
+            raise RuntimeError("graph_release_all_weight_pages failed")
 
     def concat(self, a, b, axis=0):
         a = self._ensure_tensor(a)
@@ -155,16 +412,17 @@ class Graph:
             raise RuntimeError("graph_cat failed")
         return self._tensor_from_node(out.value)
 
-    def group_norm(self, x, normalized_shape, eps=1e-5):
+    def groupnorm(self, x, weight, bias, num_groups, eps=1e-5):
         x = self._ensure_tensor(x)
-        normalized_shape = tuple(int(v) for v in normalized_shape)
-        shape_arr = (ctypes.c_size_t * len(normalized_shape))(*normalized_shape)
+        weight = self._ensure_tensor(weight)
+        bias = self._ensure_tensor(bias)
         out = cactus_node_t()
-        rc = _lib.cactus_graph_group_norm(
+        rc = _lib.cactus_graph_groupnorm(
             self.h,
             cactus_node_t(x.id),
-            shape_arr,
-            len(normalized_shape),
+            cactus_node_t(weight.id),
+            cactus_node_t(bias.id),
+            ctypes.c_size_t(int(num_groups)),
             ctypes.c_float(float(eps)),
             ctypes.byref(out),
         )
@@ -172,22 +430,126 @@ class Graph:
             raise RuntimeError("graph_group_norm failed")
         return self._tensor_from_node(out.value)
 
-    def layer_norm(self, x, normalized_shape, eps=1e-5):
+    def group_norm(self, x, weight, bias, num_groups, eps=1e-5):
+        return self.groupnorm(x, weight, bias, num_groups, eps=eps)
+
+    def layernorm(self, x, weight, bias=None, eps=1e-5):
         x = self._ensure_tensor(x)
-        normalized_shape = tuple(int(v) for v in normalized_shape)
-        shape_arr = (ctypes.c_size_t * len(normalized_shape))(*normalized_shape)
+        weight = self._ensure_tensor(weight)
+        has_bias = bias is not None
+        bias_node = cactus_node_t(0)
+        if has_bias:
+            bias = self._ensure_tensor(bias)
+            bias_node = cactus_node_t(bias.id)
         out = cactus_node_t()
-        rc = _lib.cactus_graph_layer_norm(
+        rc = _lib.cactus_graph_layernorm(
             self.h,
             cactus_node_t(x.id),
-            shape_arr,
-            len(normalized_shape),
+            cactus_node_t(weight.id),
+            bias_node,
             ctypes.c_float(float(eps)),
+            ctypes.c_bool(has_bias),
             ctypes.byref(out),
         )
         if rc != 0:
             raise RuntimeError("graph_layer_norm failed")
         return self._tensor_from_node(out.value)
+
+    def layer_norm(self, x, weight, bias=None, eps=1e-5):
+        return self.layernorm(x, weight, bias=bias, eps=eps)
+
+    def batchnorm(self, x, weight, bias, running_mean, running_var, axis=1, eps=1e-5):
+        x = self._ensure_tensor(x)
+        weight = self._ensure_tensor(weight)
+        bias = self._ensure_tensor(bias)
+        running_mean = self._ensure_tensor(running_mean)
+        running_var = self._ensure_tensor(running_var)
+        out = cactus_node_t()
+        rc = _lib.cactus_graph_batchnorm(
+            self.h,
+            cactus_node_t(x.id),
+            cactus_node_t(weight.id),
+            cactus_node_t(bias.id),
+            cactus_node_t(running_mean.id),
+            cactus_node_t(running_var.id),
+            ctypes.c_int32(int(axis)),
+            ctypes.c_float(float(eps)),
+            ctypes.byref(out),
+        )
+        if rc != 0:
+            raise RuntimeError("graph_batchnorm failed")
+        return self._tensor_from_node(out.value)
+
+    def batch_norm(self, x, weight, bias, running_mean, running_var, axis=1, eps=1e-5):
+        return self.batchnorm(x, weight, bias, running_mean, running_var, axis=axis, eps=eps)
+
+    def rms_norm(self, x, weight, eps=1e-5):
+        x = self._ensure_tensor(x)
+        weight = self._ensure_tensor(weight)
+        out = cactus_node_t()
+        rc = _lib.cactus_graph_rms_norm(
+            self.h,
+            cactus_node_t(x.id),
+            cactus_node_t(weight.id),
+            ctypes.c_float(float(eps)),
+            ctypes.byref(out),
+        )
+        if rc != 0:
+            raise RuntimeError("graph_rms_norm failed")
+        return self._tensor_from_node(out.value)
+
+    def topk(self, x, k):
+        x = self._ensure_tensor(x)
+        out = cactus_node_t()
+        rc = _lib.cactus_graph_topk(self.h, cactus_node_t(x.id), ctypes.c_size_t(int(k)), ctypes.byref(out))
+        if rc != 0:
+            raise RuntimeError("graph_topk failed")
+        return self._tensor_from_node(out.value)
+
+    def rope(self, x, theta, position_offset=0, backend=CPU):
+        x = self._ensure_tensor(x)
+        out = cactus_node_t()
+        rc = _lib.cactus_graph_rope(
+            self.h, cactus_node_t(x.id), ctypes.c_float(float(theta)), ctypes.c_size_t(int(position_offset)),
+            ctypes.c_int32(int(backend)), ctypes.byref(out)
+        )
+        if rc != 0:
+            raise RuntimeError("graph_rope failed")
+        return self._tensor_from_node(out.value)
+
+    def rope_gptj(self, x, theta, position_offset=0, rot_dim=0, backend=CPU):
+        x = self._ensure_tensor(x)
+        out = cactus_node_t()
+        rc = _lib.cactus_graph_rope_gptj(
+            self.h, cactus_node_t(x.id), ctypes.c_float(float(theta)), ctypes.c_size_t(int(position_offset)),
+            ctypes.c_size_t(int(rot_dim)), ctypes.c_int32(int(backend)), ctypes.byref(out)
+        )
+        if rc != 0:
+            raise RuntimeError("graph_rope_gptj failed")
+        return self._tensor_from_node(out.value)
+
+    def _reduce(self, fn_name, x, axis):
+        x = self._ensure_tensor(x)
+        out = cactus_node_t()
+        rc = getattr(_lib, fn_name)(self.h, cactus_node_t(x.id), ctypes.c_int32(int(axis)), ctypes.byref(out))
+        if rc != 0:
+            raise RuntimeError(f"{fn_name} failed")
+        return self._tensor_from_node(out.value)
+
+    def sum(self, x, axis):
+        return self._reduce("cactus_graph_sum", x, axis)
+
+    def mean(self, x, axis):
+        return self._reduce("cactus_graph_mean", x, axis)
+
+    def variance(self, x, axis):
+        return self._reduce("cactus_graph_variance", x, axis)
+
+    def min(self, x, axis):
+        return self._reduce("cactus_graph_min", x, axis)
+
+    def max(self, x, axis):
+        return self._reduce("cactus_graph_max", x, axis)
     
     def softmax(self, x, axis=-1):
         x = self._ensure_tensor(x)
@@ -201,6 +563,78 @@ class Graph:
         if rc != 0:
             raise RuntimeError("graph_softmax failed")
         return self._tensor_from_node(out.value)
+
+    def attention(self, query, key, value, scale, is_causal=True, position_offset=0, window_size=0,
+                  backend=CPU, mask=None, additive_mask=False):
+        query = self._ensure_tensor(query)
+        key = self._ensure_tensor(key)
+        value = self._ensure_tensor(value)
+        mask_node = cactus_node_t(0)
+        use_mask = mask is not None
+        if use_mask:
+            mask_node = cactus_node_t(self._ensure_tensor(mask).id)
+        out = cactus_node_t()
+        rc = _lib.cactus_graph_attention(
+            self.h,
+            cactus_node_t(query.id),
+            cactus_node_t(key.id),
+            cactus_node_t(value.id),
+            ctypes.c_float(float(scale)),
+            ctypes.c_bool(bool(is_causal)),
+            ctypes.c_size_t(int(position_offset)),
+            ctypes.c_size_t(int(window_size)),
+            ctypes.c_int32(int(backend)),
+            ctypes.c_bool(use_mask),
+            mask_node,
+            ctypes.c_bool(bool(additive_mask)),
+            ctypes.byref(out),
+        )
+        if rc != 0:
+            raise RuntimeError("graph_attention failed")
+        return self._tensor_from_node(out.value)
+
+    def rel_pos_bias(self, query, relative_key, scale):
+        query = self._ensure_tensor(query)
+        relative_key = self._ensure_tensor(relative_key)
+        out = cactus_node_t()
+        rc = _lib.cactus_graph_rel_pos_bias(
+            self.h, cactus_node_t(query.id), cactus_node_t(relative_key.id), ctypes.c_float(float(scale)), ctypes.byref(out)
+        )
+        if rc != 0:
+            raise RuntimeError("graph_rel_pos_bias failed")
+        return self._tensor_from_node(out.value)
+
+    def attention_int8_hybrid(self, query, key_new, value_new, scale, position_offset,
+                              cached_keys, cached_values, k_scales, v_scales,
+                              cache_len, num_kv_heads, head_dim, window_size=0):
+        query = self._ensure_tensor(query)
+        key_new = self._ensure_tensor(key_new)
+        value_new = self._ensure_tensor(value_new)
+        ck = np.ascontiguousarray(cached_keys, dtype=np.int8)
+        cv = np.ascontiguousarray(cached_values, dtype=np.int8)
+        ks = np.ascontiguousarray(k_scales, dtype=np.float32)
+        vs = np.ascontiguousarray(v_scales, dtype=np.float32)
+        out = cactus_node_t()
+        rc = _lib.cactus_graph_attention_int8_hybrid(
+            self.h,
+            cactus_node_t(query.id),
+            cactus_node_t(key_new.id),
+            cactus_node_t(value_new.id),
+            ctypes.c_float(float(scale)),
+            ctypes.c_size_t(int(position_offset)),
+            ck.ctypes.data_as(ctypes.POINTER(ctypes.c_int8)),
+            cv.ctypes.data_as(ctypes.POINTER(ctypes.c_int8)),
+            ks.ctypes.data_as(ctypes.POINTER(ctypes.c_float)),
+            vs.ctypes.data_as(ctypes.POINTER(ctypes.c_float)),
+            ctypes.c_size_t(int(cache_len)),
+            ctypes.c_size_t(int(num_kv_heads)),
+            ctypes.c_size_t(int(head_dim)),
+            ctypes.c_size_t(int(window_size)),
+            ctypes.byref(out),
+        )
+        if rc != 0:
+            raise RuntimeError("graph_attention_int8_hybrid failed")
+        return self._tensor_from_node(out.value)
     
     def relu(self, x):
         x = self._ensure_tensor(x)
@@ -210,12 +644,28 @@ class Graph:
             raise RuntimeError("graph_relu failed")
         return self._tensor_from_node(out.value)
 
+    def silu(self, x):
+        x = self._ensure_tensor(x)
+        out = cactus_node_t()
+        rc = _lib.cactus_graph_silu(self.h, cactus_node_t(x.id), ctypes.byref(out))
+        if rc != 0:
+            raise RuntimeError("graph_silu failed")
+        return self._tensor_from_node(out.value)
+
     def gelu(self, x):
         x = self._ensure_tensor(x)
         out = cactus_node_t()
         rc = _lib.cactus_graph_gelu(self.h, cactus_node_t(x.id), ctypes.byref(out))
         if rc != 0:
             raise RuntimeError("graph_gelu failed")
+        return self._tensor_from_node(out.value)
+
+    def gelu_erf(self, x):
+        x = self._ensure_tensor(x)
+        out = cactus_node_t()
+        rc = _lib.cactus_graph_gelu_erf(self.h, cactus_node_t(x.id), ctypes.byref(out))
+        if rc != 0:
+            raise RuntimeError("graph_gelu_erf failed")
         return self._tensor_from_node(out.value)
 
     def sigmoid(self, x):
@@ -233,6 +683,233 @@ class Graph:
         if rc != 0:
             raise RuntimeError("graph_tanh failed")
         return self._tensor_from_node(out.value)
+
+    def glu(self, x, axis=-1):
+        x = self._ensure_tensor(x)
+        out = cactus_node_t()
+        rc = _lib.cactus_graph_glu(self.h, cactus_node_t(x.id), ctypes.c_int32(int(axis)), ctypes.byref(out))
+        if rc != 0:
+            raise RuntimeError("graph_glu failed")
+        return self._tensor_from_node(out.value)
+
+    def conv1d_causal(self, x, weight, kernel_size, dilation):
+        x = self._ensure_tensor(x)
+        weight = self._ensure_tensor(weight)
+        out = cactus_node_t()
+        rc = _lib.cactus_graph_conv1d_causal(
+            self.h, cactus_node_t(x.id), cactus_node_t(weight.id),
+            ctypes.c_size_t(int(kernel_size)), ctypes.c_size_t(int(dilation)), ctypes.byref(out)
+        )
+        if rc != 0:
+            raise RuntimeError("graph_conv1d_causal failed")
+        return self._tensor_from_node(out.value)
+
+    def conv1d_k3(self, x, weight, stride=1):
+        x = self._ensure_tensor(x)
+        weight = self._ensure_tensor(weight)
+        out = cactus_node_t()
+        rc = _lib.cactus_graph_conv1d_k3(
+            self.h, cactus_node_t(x.id), cactus_node_t(weight.id), ctypes.c_size_t(int(stride)), ctypes.byref(out)
+        )
+        if rc != 0:
+            raise RuntimeError("graph_conv1d_k3 failed")
+        return self._tensor_from_node(out.value)
+
+    def conv1d_k7s3(self, x, weight, bias):
+        x = self._ensure_tensor(x)
+        weight = self._ensure_tensor(weight)
+        bias = self._ensure_tensor(bias)
+        out = cactus_node_t()
+        rc = _lib.cactus_graph_conv1d_k7s3(
+            self.h, cactus_node_t(x.id), cactus_node_t(weight.id), cactus_node_t(bias.id), ctypes.byref(out)
+        )
+        if rc != 0:
+            raise RuntimeError("graph_conv1d_k7s3 failed")
+        return self._tensor_from_node(out.value)
+
+    def conv1d(self, x, weight, bias=None, stride=1):
+        return self._conv_with_optional_bias("cactus_graph_conv1d", x, weight, bias, ctypes.c_size_t(int(stride)))
+
+    def conv1d_same_depthwise_k9(self, x, weight, bias=None):
+        return self._conv_with_optional_bias("cactus_graph_conv1d_same_depthwise_k9", x, weight, bias)
+
+    def conv1d_pointwise(self, x, weight, bias=None):
+        return self._conv_with_optional_bias("cactus_graph_conv1d_pointwise", x, weight, bias)
+
+    def conv2d_k3s2p1(self, x, weight, bias=None):
+        return self._conv_with_optional_bias("cactus_graph_conv2d_k3s2p1", x, weight, bias)
+
+    def conv2d_depthwise_k3s2p1(self, x, weight, bias=None):
+        return self._conv_with_optional_bias("cactus_graph_conv2d_depthwise_k3s2p1", x, weight, bias)
+
+    def conv2d_pointwise_1x1(self, x, weight, bias=None):
+        return self._conv_with_optional_bias("cactus_graph_conv2d_pointwise_1x1", x, weight, bias)
+
+    def _conv_with_optional_bias(self, fn_name, x, weight, bias=None, *extra):
+        x = self._ensure_tensor(x)
+        weight = self._ensure_tensor(weight)
+        has_bias = bias is not None
+        bias_node = cactus_node_t(0 if bias is None else self._ensure_tensor(bias).id)
+        out = cactus_node_t()
+        rc = getattr(_lib, fn_name)(
+            self.h, cactus_node_t(x.id), cactus_node_t(weight.id), ctypes.c_bool(has_bias), bias_node, *extra, ctypes.byref(out)
+        )
+        if rc != 0:
+            raise RuntimeError(f"{fn_name} failed")
+        return self._tensor_from_node(out.value)
+
+    def lstm_cell(self, input, h_prev, c_prev, weight_ih, weight_hh, bias_ih, bias_hh):
+        tensors = [self._ensure_tensor(t) for t in (input, h_prev, c_prev, weight_ih, weight_hh, bias_ih, bias_hh)]
+        out = cactus_node_t()
+        rc = _lib.cactus_graph_lstm_cell(self.h, *(cactus_node_t(t.id) for t in tensors), ctypes.byref(out))
+        if rc != 0:
+            raise RuntimeError("graph_lstm_cell failed")
+        return self._tensor_from_node(out.value)
+
+    def gated_deltanet_decode(self, query, key, value, gate_log, beta, initial_state, scale):
+        tensors = [self._ensure_tensor(t) for t in (query, key, value, gate_log, beta, initial_state)]
+        out = cactus_node_t()
+        rc = _lib.cactus_graph_gated_deltanet_decode(
+            self.h, *(cactus_node_t(t.id) for t in tensors), ctypes.c_float(float(scale)), ctypes.byref(out)
+        )
+        if rc != 0:
+            raise RuntimeError("graph_gated_deltanet_decode failed")
+        return self._tensor_from_node(out.value)
+
+    def gated_deltanet_prefill(self, query, key, value, gate_log, beta, initial_state, chunk_size, scale):
+        tensors = [self._ensure_tensor(t) for t in (query, key, value, gate_log, beta, initial_state)]
+        out = cactus_node_t()
+        rc = _lib.cactus_graph_gated_deltanet_prefill(
+            self.h, *(cactus_node_t(t.id) for t in tensors), ctypes.c_size_t(int(chunk_size)), ctypes.c_float(float(scale)), ctypes.byref(out)
+        )
+        if rc != 0:
+            raise RuntimeError("graph_gated_deltanet_prefill failed")
+        return self._tensor_from_node(out.value)
+
+    def stft(self, x, weight, stride, num_fft_bins):
+        x = self._ensure_tensor(x)
+        weight = self._ensure_tensor(weight)
+        out = cactus_node_t()
+        rc = _lib.cactus_graph_stft(
+            self.h, cactus_node_t(x.id), cactus_node_t(weight.id),
+            ctypes.c_size_t(int(stride)), ctypes.c_size_t(int(num_fft_bins)), ctypes.byref(out)
+        )
+        if rc != 0:
+            raise RuntimeError("graph_stft failed")
+        return self._tensor_from_node(out.value)
+
+    def altup_predict(self, coefs, streams):
+        coefs = self._ensure_tensor(coefs)
+        streams = [self._ensure_tensor(t) for t in streams]
+        ids = (cactus_node_t * len(streams))(*(cactus_node_t(t.id) for t in streams))
+        out = cactus_node_t()
+        rc = _lib.cactus_graph_altup_predict(self.h, cactus_node_t(coefs.id), ids, ctypes.c_size_t(len(streams)), ctypes.byref(out))
+        if rc != 0:
+            raise RuntimeError("graph_altup_predict failed")
+        return self._tensor_from_node(out.value)
+
+    def altup_correct(self, coefs, innovation, predictions):
+        coefs = self._ensure_tensor(coefs)
+        innovation = self._ensure_tensor(innovation)
+        predictions = [self._ensure_tensor(t) for t in predictions]
+        ids = (cactus_node_t * len(predictions))(*(cactus_node_t(t.id) for t in predictions))
+        out = cactus_node_t()
+        rc = _lib.cactus_graph_altup_correct(
+            self.h, cactus_node_t(coefs.id), cactus_node_t(innovation.id), ids, ctypes.c_size_t(len(predictions)), ctypes.byref(out)
+        )
+        if rc != 0:
+            raise RuntimeError("graph_altup_correct failed")
+        return self._tensor_from_node(out.value)
+
+    def gaussian_topk(self, x, ppf):
+        x = self._ensure_tensor(x)
+        out = cactus_node_t()
+        rc = _lib.cactus_graph_gaussian_topk(self.h, cactus_node_t(x.id), ctypes.c_float(float(ppf)), ctypes.byref(out))
+        if rc != 0:
+            raise RuntimeError("graph_gaussian_topk failed")
+        return self._tensor_from_node(out.value)
+
+    def moe_layer_gated(self, hidden, routing_probs, topk_indices, w1_weights, w3_weights, w2_weights,
+                        num_experts, num_experts_per_tok, normalize_routing=True, epsilon=1e-6, routed_scaling_factor=1.0):
+        hidden = self._ensure_tensor(hidden)
+        routing_probs = self._ensure_tensor(routing_probs)
+        topk_indices = self._ensure_tensor(topk_indices)
+        w1 = (cactus_node_t * len(w1_weights))(*(cactus_node_t(self._ensure_tensor(t).id) for t in w1_weights))
+        w3 = (cactus_node_t * len(w3_weights))(*(cactus_node_t(self._ensure_tensor(t).id) for t in w3_weights))
+        w2 = (cactus_node_t * len(w2_weights))(*(cactus_node_t(self._ensure_tensor(t).id) for t in w2_weights))
+        out = cactus_node_t()
+        rc = _lib.cactus_graph_moe_layer_gated(
+            self.h, cactus_node_t(hidden.id), cactus_node_t(routing_probs.id), cactus_node_t(topk_indices.id),
+            w1, w3, w2, ctypes.c_size_t(int(num_experts)), ctypes.c_size_t(int(num_experts_per_tok)),
+            ctypes.c_bool(bool(normalize_routing)), ctypes.c_float(float(epsilon)),
+            ctypes.c_float(float(routed_scaling_factor)), ctypes.byref(out)
+        )
+        if rc != 0:
+            raise RuntimeError("graph_moe_layer_gated failed")
+        return self._tensor_from_node(out.value)
+
+    def moe_layer_ungated(self, hidden, routing_probs, topk_indices, w1_weights, w2_weights,
+                          num_experts, num_experts_per_tok, normalize_routing=True, epsilon=1e-6,
+                          routed_scaling_factor=1.0, activation=ACT_GELU):
+        hidden = self._ensure_tensor(hidden)
+        routing_probs = self._ensure_tensor(routing_probs)
+        topk_indices = self._ensure_tensor(topk_indices)
+        w1 = (cactus_node_t * len(w1_weights))(*(cactus_node_t(self._ensure_tensor(t).id) for t in w1_weights))
+        w2 = (cactus_node_t * len(w2_weights))(*(cactus_node_t(self._ensure_tensor(t).id) for t in w2_weights))
+        out = cactus_node_t()
+        rc = _lib.cactus_graph_moe_layer_ungated(
+            self.h, cactus_node_t(hidden.id), cactus_node_t(routing_probs.id), cactus_node_t(topk_indices.id),
+            w1, w2, ctypes.c_size_t(int(num_experts)), ctypes.c_size_t(int(num_experts_per_tok)),
+            ctypes.c_bool(bool(normalize_routing)), ctypes.c_float(float(epsilon)),
+            ctypes.c_float(float(routed_scaling_factor)), ctypes.c_int32(int(activation)), ctypes.byref(out)
+        )
+        if rc != 0:
+            raise RuntimeError("graph_moe_layer_ungated failed")
+        return self._tensor_from_node(out.value)
+
+    def sample(self, logits, temperature=1.0, top_p=1.0, top_k=0):
+        logits = self._ensure_tensor(logits)
+        out = cactus_node_t()
+        rc = _lib.cactus_graph_sample(
+            self.h, cactus_node_t(logits.id), ctypes.c_float(float(temperature)),
+            ctypes.c_float(float(top_p)), ctypes.c_size_t(int(top_k)), ctypes.byref(out)
+        )
+        if rc != 0:
+            raise RuntimeError("graph_sample failed")
+        return self._tensor_from_node(out.value)
+
+    def scatter_topk(self, indices, values, num_classes):
+        indices = self._ensure_tensor(indices)
+        values = self._ensure_tensor(values)
+        out = cactus_node_t()
+        rc = _lib.cactus_graph_scatter_topk(
+            self.h, cactus_node_t(indices.id), cactus_node_t(values.id), ctypes.c_size_t(int(num_classes)), ctypes.byref(out)
+        )
+        if rc != 0:
+            raise RuntimeError("graph_scatter_topk failed")
+        return self._tensor_from_node(out.value)
+
+    def persistent(self, source_node):
+        source_node = self._ensure_tensor(source_node)
+        out = cactus_node_t()
+        rc = _lib.cactus_graph_persistent(self.h, cactus_node_t(source_node.id), ctypes.byref(out))
+        if rc != 0:
+            raise RuntimeError("graph_persistent failed")
+        return self._tensor_from_node(out.value)
+
+    def is_populated(self, persistent_node):
+        persistent_node = self._ensure_tensor(persistent_node)
+        out_is_populated = ctypes.c_int32()
+        rc = _lib.cactus_graph_is_populated(self.h, cactus_node_t(persistent_node.id), ctypes.byref(out_is_populated))
+        if rc != 0:
+            raise RuntimeError("graph_is_populated failed")
+        return bool(out_is_populated.value)
+
+    def invalidate_persistent(self, persistent_node):
+        persistent_node = self._ensure_tensor(persistent_node)
+        rc = _lib.cactus_graph_invalidate_persistent(self.h, cactus_node_t(persistent_node.id))
+        if rc != 0:
+            raise RuntimeError("graph_invalidate_persistent failed")
 
     def output_info(self, x):
         x = self._ensure_tensor(x)
@@ -315,6 +992,39 @@ class Tensor:
     def pow(self, exponent):
         return self.g.pow(self, exponent)
 
+    def precision_cast(self, dtype):
+        return self.g.precision_cast(self, dtype)
+
+    def quantize_activations(self):
+        return self.g.quantize_activations(self)
+
+    def scalar_add(self, value):
+        return self.g.scalar_add(self, value)
+
+    def scalar_subtract(self, value):
+        return self.g.scalar_subtract(self, value)
+
+    def scalar_multiply(self, value):
+        return self.g.scalar_multiply(self, value)
+
+    def scalar_divide(self, value):
+        return self.g.scalar_divide(self, value)
+
+    def scalar_exp(self):
+        return self.g.scalar_exp(self)
+
+    def scalar_sqrt(self):
+        return self.g.scalar_sqrt(self)
+
+    def scalar_cos(self):
+        return self.g.scalar_cos(self)
+
+    def scalar_sin(self):
+        return self.g.scalar_sin(self)
+
+    def scalar_log(self):
+        return self.g.scalar_log(self)
+
     def relu(self):
         return self.g.relu(self)
 
@@ -327,11 +1037,32 @@ class Tensor:
     def gelu(self):
         return self.g.gelu(self)
 
+    def gelu_erf(self):
+        return self.g.gelu_erf(self)
+
+    def silu(self):
+        return self.g.silu(self)
+
     def view(self, shape):
         return self.g.view(self, shape)
 
+    def reshape(self, shape):
+        return self.g.reshape(self, shape)
+
     def flatten(self, start_dim=0, end_dim=-1):
         return self.g.flatten(self, start_dim=start_dim, end_dim=end_dim)
+
+    def slice(self, axis, start, length=0):
+        return self.g.slice(self, axis, start, length=length)
+
+    def index(self, index_value, axis=0):
+        return self.g.index(self, index_value, axis=axis)
+
+    def transpose(self, backend=Graph.CPU):
+        return self.g.transpose(self, backend=backend)
+
+    def permute(self, permutation, backend=Graph.CPU):
+        return self.g.permute(self, permutation, backend=backend)
 
     def concat(self, other, axis=0):
         return self.g.concat(self, other, axis=axis)
@@ -339,14 +1070,50 @@ class Tensor:
     def cat(self, tensors, axis=0):
         return self.g.cat([self] + tensors, axis=axis)
 
-    def group_norm(self, normalized_shape, eps=1e-5):
-        return self.g.group_norm(self, normalized_shape, eps)
+    def groupnorm(self, weight, bias, num_groups, eps=1e-5):
+        return self.g.groupnorm(self, weight, bias, num_groups, eps=eps)
 
-    def layer_norm(self, normalized_shape, eps=1e-5):
-        return self.g.layer_norm(self, normalized_shape, eps)
+    def layernorm(self, weight, bias=None, eps=1e-5):
+        return self.g.layernorm(self, weight, bias=bias, eps=eps)
+
+    def batchnorm(self, weight, bias, running_mean, running_var, axis=1, eps=1e-5):
+        return self.g.batchnorm(self, weight, bias, running_mean, running_var, axis=axis, eps=eps)
+
+    def group_norm(self, weight, bias, num_groups, eps=1e-5):
+        return self.groupnorm(weight, bias, num_groups, eps=eps)
+
+    def layer_norm(self, weight, bias=None, eps=1e-5):
+        return self.layernorm(weight, bias=bias, eps=eps)
+
+    def batch_norm(self, weight, bias, running_mean, running_var, axis=1, eps=1e-5):
+        return self.batchnorm(weight, bias, running_mean, running_var, axis=axis, eps=eps)
+
+    def rms_norm(self, weight, eps=1e-5):
+        return self.g.rms_norm(self, weight, eps=eps)
     
     def softmax(self, axis=-1):
         return self.g.softmax(self, axis)
+
+    def glu(self, axis=-1):
+        return self.g.glu(self, axis=axis)
+
+    def matmul(self, other, pretransposed_rhs=False, backend=Graph.CPU):
+        return self.g.matmul(self, other, pretransposed_rhs=pretransposed_rhs, backend=backend)
+
+    def sum(self, axis):
+        return self.g.sum(self, axis)
+
+    def mean(self, axis):
+        return self.g.mean(self, axis)
+
+    def variance(self, axis):
+        return self.g.variance(self, axis)
+
+    def min(self, axis):
+        return self.g.min(self, axis)
+
+    def max(self, axis):
+        return self.g.max(self, axis)
 
     def numpy(self):
         info = cactus_tensor_info_t()

--- a/python/tests/test_graph.py
+++ b/python/tests/test_graph.py
@@ -1,4 +1,5 @@
 import unittest
+
 import numpy as np
 import sys
 import tempfile
@@ -135,6 +136,44 @@ class TestGraphTensorOps(unittest.TestCase):
         expected = np.array([1, 2, 3, 4, 5, 6], dtype=np.float16)
         np.testing.assert_allclose(out, expected, atol=1e-2)
 
+    def test_reshape(self):
+        g = Graph()
+        a = g.input((2, 3))
+        y = a.reshape((3, 2))
+
+        g.set_input(a, np.array([[1, 2, 3], [4, 5, 6]], dtype=np.float16))
+        g.execute()
+
+        out = y.numpy()
+        expected = np.array([[1, 2], [3, 4], [5, 6]], dtype=np.float16)
+        np.testing.assert_allclose(out, expected, atol=1e-2)
+
+    def test_transpose(self):
+        g = Graph()
+        a = g.input((2, 3))
+        y = a.transpose()
+
+        data = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.float16)
+        g.set_input(a, data)
+        g.execute()
+
+        out = y.numpy()
+        expected = data.T.astype(np.float16)
+        np.testing.assert_allclose(out, expected, atol=1e-2)
+
+    def test_permute(self):
+        g = Graph()
+        a = g.input((2, 3, 4))
+        y = a.permute((1, 0, 2))
+
+        data = np.arange(24, dtype=np.float16).reshape(2, 3, 4)
+        g.set_input(a, data)
+        g.execute()
+
+        out = y.numpy()
+        expected = np.transpose(data, (1, 0, 2)).astype(np.float16)
+        np.testing.assert_allclose(out, expected, atol=1e-2)
+
     def test_concat(self):
         g = Graph()
         a = g.input((2, 2))
@@ -176,6 +215,182 @@ class TestGraphTensorOps(unittest.TestCase):
         out = y.numpy()
         expected = np.array([[1, 2, 5, 6, 7], [3, 4, 8, 9, 10]], dtype=np.float16)
         np.testing.assert_allclose(out, expected, atol=1e-2)
+
+    def test_matmul(self):
+        g = Graph()
+        a = g.input((2, 3))
+        b = g.input((3, 2))
+        y = a.matmul(b)
+
+        a_data = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.float16)
+        b_data = np.array([[7, 8], [9, 10], [11, 12]], dtype=np.float16)
+        g.set_input(a, a_data)
+        g.set_input(b, b_data)
+        g.execute()
+
+        out = y.numpy()
+        expected = (a_data.astype(np.float32) @ b_data.astype(np.float32)).astype(np.float16)
+        np.testing.assert_allclose(out, expected, atol=1e-2)
+
+    def test_gather(self):
+        g = Graph()
+        embeddings = g.input((4, 2))
+        indices = g.input((3,), dtype=Graph.FP32)
+        y = g.gather(embeddings, indices)
+
+        embedding_data = np.array(
+            [[10, 11], [20, 21], [30, 31], [40, 41]],
+            dtype=np.float16,
+        )
+        index_data = np.array([2, 0, 3], dtype=np.float32)
+        g.set_input(embeddings, embedding_data)
+        g.set_input(indices, index_data, dtype=Graph.FP32)
+        g.execute()
+
+        out = y.numpy()
+        expected = embedding_data[[2, 0, 3]]
+        np.testing.assert_allclose(out, expected, atol=1e-2)
+
+    def test_slice(self):
+        g = Graph()
+        a = g.input((4, 3))
+        y = a.slice(axis=0, start=1, length=2)
+
+        data = np.arange(12, dtype=np.float16).reshape(4, 3)
+        g.set_input(a, data)
+        g.execute()
+
+        out = y.numpy()
+        expected = data[1:3]
+        np.testing.assert_allclose(out, expected, atol=1e-2)
+
+    def test_index(self):
+        g = Graph()
+        a = g.input((4, 3))
+        y = a.index(2, axis=0)
+
+        data = np.arange(12, dtype=np.float16).reshape(4, 3)
+        g.set_input(a, data)
+        g.execute()
+
+        out = y.numpy()
+        expected = data[2]
+        np.testing.assert_allclose(out, expected, atol=1e-2)
+
+    def test_mean(self):
+        g = Graph()
+        a = g.input((2, 3))
+        y = a.mean(axis=1)
+
+        data = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.float16)
+        g.set_input(a, data)
+        g.execute()
+
+        out = y.numpy()
+        expected = data.astype(np.float32).mean(axis=1).astype(np.float16)
+        np.testing.assert_allclose(out, expected, atol=1e-2)
+
+    def test_variance(self):
+        g = Graph()
+        a = g.input((2, 3))
+        y = a.variance(axis=1)
+
+        data = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.float16)
+        g.set_input(a, data)
+        g.execute()
+
+        out = y.numpy()
+        expected = data.astype(np.float32).var(axis=1).astype(np.float16)
+        np.testing.assert_allclose(out, expected, atol=1e-2)
+
+    def test_min(self):
+        g = Graph()
+        a = g.input((2, 3))
+        y = a.min(axis=1)
+
+        data = np.array([[3, 1, 2], [6, 4, 5]], dtype=np.float16)
+        g.set_input(a, data)
+        g.execute()
+
+        out = y.numpy()
+        expected = data.min(axis=1).astype(np.float16)
+        np.testing.assert_allclose(out, expected, atol=1e-2)
+
+    def test_max(self):
+        g = Graph()
+        a = g.input((2, 3))
+        y = a.max(axis=1)
+
+        data = np.array([[3, 1, 2], [6, 4, 5]], dtype=np.float16)
+        g.set_input(a, data)
+        g.execute()
+
+        out = y.numpy()
+        expected = data.max(axis=1).astype(np.float16)
+        np.testing.assert_allclose(out, expected, atol=1e-2)
+
+
+class TestGraphNorms(unittest.TestCase):
+
+    def test_layernorm_matches_alias(self):
+        g = Graph()
+        x = g.input((2, 3))
+        weight = g.input((3,))
+        bias = g.input((3,))
+        y_primary = g.layernorm(x, weight, bias, eps=1e-5)
+        y_alias = g.layer_norm(x, weight, bias, eps=1e-5)
+
+        x_data = np.array([[1.0, 3.0, 5.0], [2.0, 4.0, 8.0]], dtype=np.float16)
+        weight_data = np.array([1.0, 1.5, 0.5], dtype=np.float16)
+        bias_data = np.array([0.25, -0.5, 1.0], dtype=np.float16)
+        g.set_input(x, x_data)
+        g.set_input(weight, weight_data)
+        g.set_input(bias, bias_data)
+        g.execute()
+
+        np.testing.assert_allclose(y_primary.numpy(), y_alias.numpy(), atol=1e-2)
+
+    def test_groupnorm_matches_alias(self):
+        g = Graph()
+        x = g.input((1, 4))
+        weight = g.input((4,))
+        bias = g.input((4,))
+        y_primary = g.groupnorm(x, weight, bias, num_groups=2, eps=1e-5)
+        y_alias = g.group_norm(x, weight, bias, num_groups=2, eps=1e-5)
+
+        x_data = np.array([[1.0, 3.0, 2.0, 4.0]], dtype=np.float16)
+        weight_data = np.array([1.0, 1.0, 0.5, 0.5], dtype=np.float16)
+        bias_data = np.array([0.0, 0.5, 1.0, -1.0], dtype=np.float16)
+        g.set_input(x, x_data)
+        g.set_input(weight, weight_data)
+        g.set_input(bias, bias_data)
+        g.execute()
+
+        np.testing.assert_allclose(y_primary.numpy(), y_alias.numpy(), atol=1e-2)
+
+    def test_batchnorm_matches_alias(self):
+        g = Graph()
+        x = g.input((1, 3))
+        weight = g.input((3,))
+        bias = g.input((3,))
+        running_mean = g.input((3,))
+        running_var = g.input((3,))
+        y_primary = g.batchnorm(x, weight, bias, running_mean, running_var, axis=1, eps=1e-5)
+        y_alias = g.batch_norm(x, weight, bias, running_mean, running_var, axis=1, eps=1e-5)
+
+        x_data = np.array([[1.0, 2.0, 3.0]], dtype=np.float16)
+        weight_data = np.array([1.0, 1.5, 2.0], dtype=np.float16)
+        bias_data = np.array([0.0, -1.0, 0.5], dtype=np.float16)
+        mean_data = np.array([0.5, 1.0, 1.5], dtype=np.float16)
+        var_data = np.array([1.0, 4.0, 9.0], dtype=np.float16)
+        g.set_input(x, x_data)
+        g.set_input(weight, weight_data)
+        g.set_input(bias, bias_data)
+        g.set_input(running_mean, mean_data)
+        g.set_input(running_var, var_data)
+        g.execute()
+
+        np.testing.assert_allclose(y_primary.numpy(), y_alias.numpy(), atol=1e-2)
 
 
 class TestGraphActivations(unittest.TestCase):
@@ -315,6 +530,148 @@ class TestGraphSaveLoad(unittest.TestCase):
             self.assertEqual(info["shape"], expected_info["shape"])
             self.assertEqual(info["precision"], expected_info["precision"])
             np.testing.assert_allclose(out, expected, atol=5e-2)
+
+    def test_save_load_roundtrip_matmul(self):
+        g = Graph()
+
+        a = g.input((2, 3))
+        b = g.input((3, 2))
+        out_node = a.matmul(b)
+
+        a_data = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=np.float16)
+        b_data = np.array([[7.0, 8.0], [9.0, 10.0], [11.0, 12.0]], dtype=np.float16)
+
+        g.set_input(a, a_data)
+        g.set_input(b, b_data)
+        g.execute()
+        expected = out_node.numpy()
+        expected_info = g.output_info(out_node)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "matmul_graph.cg"
+            g.save(path)
+
+            loaded = Graph.load(path)
+            loaded_a = self._rebind_tensor(loaded, a)
+            loaded_b = self._rebind_tensor(loaded, b)
+            loaded_out = self._rebind_tensor(loaded, out_node)
+
+            loaded.set_input(loaded_a, a_data)
+            loaded.set_input(loaded_b, b_data)
+            loaded.execute()
+
+            out = loaded_out.numpy()
+            info = loaded.output_info(loaded_out)
+
+            self.assertEqual(info["shape"], expected_info["shape"])
+            self.assertEqual(info["precision"], expected_info["precision"])
+            np.testing.assert_allclose(out, expected, atol=1e-2)
+
+    def test_save_load_roundtrip_permute(self):
+        g = Graph()
+
+        a = g.input((2, 1, 2))
+        out_node = a.permute((1, 0, 2))
+
+        data = np.array([[[58.0, 64.0]], [[139.0, 154.0]]], dtype=np.float16)
+
+        g.set_input(a, data)
+        g.execute()
+        expected = out_node.numpy()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "permute_graph.cg"
+            g.save(path)
+
+            loaded = Graph.load(path)
+            loaded_a = self._rebind_tensor(loaded, a)
+            loaded_out = self._rebind_tensor(loaded, out_node)
+
+            loaded.set_input(loaded_a, data)
+            loaded.execute()
+
+            out = loaded_out.numpy()
+            np.testing.assert_allclose(out, expected, atol=1e-2)
+
+    def test_save_load_roundtrip_gather(self):
+        g = Graph()
+
+        embeddings = g.input((4, 2))
+        indices = g.input((3,), dtype=Graph.FP32)
+        out_node = g.gather(embeddings, indices)
+
+        embedding_data = np.array(
+            [[10, 11], [20, 21], [30, 31], [40, 41]],
+            dtype=np.float16,
+        )
+        index_data = np.array([2, 0, 3], dtype=np.float32)
+
+        g.set_input(embeddings, embedding_data)
+        g.set_input(indices, index_data, dtype=Graph.FP32)
+        g.execute()
+        expected = out_node.numpy()
+        expected_info = g.output_info(out_node)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "gather_graph.cg"
+            g.save(path)
+
+            loaded = Graph.load(path)
+            loaded_embeddings = self._rebind_tensor(loaded, embeddings)
+            loaded_indices = self._rebind_tensor(loaded, indices)
+            loaded_out = self._rebind_tensor(loaded, out_node)
+
+            loaded.set_input(loaded_embeddings, embedding_data)
+            loaded.set_input(loaded_indices, index_data, dtype=Graph.FP32)
+            loaded.execute()
+
+            out = loaded_out.numpy()
+            info = loaded.output_info(loaded_out)
+
+            self.assertEqual(info["shape"], expected_info["shape"])
+            self.assertEqual(info["precision"], expected_info["precision"])
+            np.testing.assert_allclose(out, expected, atol=1e-2)
+
+    def test_save_load_roundtrip_layernorm(self):
+        g = Graph()
+
+        x = g.input((2, 3))
+        weight = g.input((3,))
+        bias = g.input((3,))
+        out_node = g.layernorm(x, weight, bias, eps=1e-5)
+
+        x_data = np.array([[1.0, 3.0, 5.0], [2.0, 4.0, 8.0]], dtype=np.float16)
+        weight_data = np.array([1.0, 1.5, 0.5], dtype=np.float16)
+        bias_data = np.array([0.25, -0.5, 1.0], dtype=np.float16)
+
+        g.set_input(x, x_data)
+        g.set_input(weight, weight_data)
+        g.set_input(bias, bias_data)
+        g.execute()
+        expected = out_node.numpy()
+        expected_info = g.output_info(out_node)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "layernorm_graph.cg"
+            g.save(path)
+
+            loaded = Graph.load(path)
+            loaded_x = self._rebind_tensor(loaded, x)
+            loaded_weight = self._rebind_tensor(loaded, weight)
+            loaded_bias = self._rebind_tensor(loaded, bias)
+            loaded_out = self._rebind_tensor(loaded, out_node)
+
+            loaded.set_input(loaded_x, x_data)
+            loaded.set_input(loaded_weight, weight_data)
+            loaded.set_input(loaded_bias, bias_data)
+            loaded.execute()
+
+            out = loaded_out.numpy()
+            info = loaded.output_info(loaded_out)
+
+            self.assertEqual(info["shape"], expected_info["shape"])
+            self.assertEqual(info["precision"], expected_info["precision"])
+            np.testing.assert_allclose(out, expected, atol=1e-2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Summary
refactored graph API, implemented all ops supported by cactus graph into the python API. Before, I had a very large bitmask to represent the different parameters of each OpType, and I had separate write functions for each optype, as well as different serialization functions. After implementing the remaining ops, I realized that it would be extremely difficult to update the Python API if a new cactus graph kernel is ever implemented. Thus, I refactored the code. 

I also implemented wrappers for all of the remaining functions supported by the cactus graph into the python API (ex: attention, conv, sample, permute, etc.) 

The process is still kind of lengthy, but it's more streamlined. There is a set table of all ops and their external parameters, and the user just has to update that table and implement all functions for load/save to work correctly. 

### Contributing Graph Operations
1. **Define the op in core graph types** 
Add the new OpType in `cactus/graph/graph.h`
If the op needs additional parameters, add the fields to OpParams in the same file 

2. **Add a graph builder API**  
Add a builder method in `cactus/graph/graph_builder.cpp` and its declaration in 
`cactus/graph/graph.h`
Follow the pattern of existing builder methods, e.g. for a new "relu" op:
```cpp
size_t CactusGraph::relu(size_t input) {
    OpParams params;
    return add_node(OpType::RELU, {input}, params);
}
```
3. **Implement the op in the execution engine**
Implement the krnel or graph op code in the relevant file, usually in `cactus/kernel/`
Register the new op in the dispatch table in `cactus/graph/graph_execute.cpp` for the supported backends (CPU, NPU)

4. **Export op in FFI bindings**
- header: `cactus/ffi/cactus_ffi.h`
- implementation: `cactus/ffi/cactus_ffi.cpp`

5. **Add python ctypes declaration** 
Add `_lib.cactus_graph_my_new_op.argtypes/restype` in `python/src/cactus.py`

6. **Add python graph wrapper** 
Add `Graph.my_new_op(...)` in `python/src/graph.py`, and optionally a Tensor
  convenience method.

7. **Add serialization schema entry if needed**
If your op has extra parameters that need to be saved/loaded that are not in the 
default node, add new ParamField enum values. 

If the op has any graph-persistent params:

- add any new ParamField enum values in cactus/graph/graph_param_io.cpp
- add read/write logic for those fields
- add the op’s schema entry in `op_schema(...)`

If the op has no params, you may not need to touch schema beyond maybe adding an
empty schema entry.

The syntax pattern there is:
```
{OpType::MY_NEW_OP, {
    {ParamField::Alpha, FieldPersistence::Persistent},
    {ParamField::Mode, FieldPersistence::Persistent},
}},
```
8. **Add test coverage**
Add unit tests to `tests/test_graph.cpp` covering the native graph function, and 
add python tests in `python/tests/test_graph.py` covering the Python API and end-to-end execution.

and then support those fields in `write_field(...)` / `read_field(...)`.

If a field is runtime-only, mark it RuntimeOnly instead of Persistent.