### PR TITLE
Gemma4 tool calling and RoPE fixes

### DIFF
--- a/cactus/engine/engine.h
+++ b/cactus/engine/engine.h
@@ -293,6 +293,26 @@ TokenizerRuntimeConfig load_tokenizer_runtime_config(const std::string& config_f
 void load_special_tokens_map(const std::string& config_file, std::unordered_map<std::string, uint32_t>& special_tokens);
 std::vector<std::string> split_with_special_tokens(const std::string& text, const std::unordered_map<std::string, uint32_t>& special_tokens);
 
+inline std::string extract_json_string(const std::string& json, size_t& pos) {
+    std::string value;
+    while (pos < json.size() && json[pos] != '"') {
+        if (json[pos] == '\\' && pos + 1 < json.size()) {
+            pos++;
+            if (json[pos] == 'n') value += '\n';
+            else if (json[pos] == 't') value += '\t';
+            else if (json[pos] == 'r') value += '\r';
+            else if (json[pos] == '"') value += '"';
+            else if (json[pos] == '\\') value += '\\';
+            else value += json[pos];
+        } else {
+            value += json[pos];
+        }
+        pos++;
+    }
+    if (pos < json.size()) pos++;
+    return value;
+}
+
 class Tokenizer {
 public:
     virtual ~Tokenizer() = default;
@@ -673,6 +693,7 @@ private:
     void compute_bias();
     void tokenize_grammar_elements();
     void add_tokens_for_string(const std::string& str, std::unordered_set<uint32_t>& token_set);
+    void add_tokens_containing(char needle, std::unordered_set<uint32_t>& token_set);
     void tokenize_function_names(bool quote_names);
     void init_common_tokens();
     void init_needle_constraints();
@@ -754,9 +775,9 @@ public:
     virtual void remove_thinking_tokens(const std::vector<std::pair<size_t, size_t>>& ranges);
     virtual void compact_kv_cache() {}
 
-    void set_tool_constraints(const std::vector<ToolConstraintSpec>& tools);
-    void clear_tool_constraints();
-    void update_tool_constraints(uint32_t token_id);
+    virtual void set_tool_constraints(const std::vector<ToolConstraintSpec>& tools);
+    virtual void clear_tool_constraints();
+    virtual void update_tool_constraints(uint32_t token_id);
 
     void* graph_handle_;
 

--- a/cactus/engine/engine_tokenizer.cpp
+++ b/cactus/engine/engine_tokenizer.cpp
@@ -120,10 +120,9 @@ void load_special_tokens_map(const std::string& config_file, std::unordered_map<
         uint32_t token_id = static_cast<uint32_t>(std::stoul(id_part.substr(id_start + 1, id_end - id_start - 1)));
 
         size_t token_start = token_part.find("\"");
-        size_t token_end = token_part.rfind("\"");
-        if (token_start == std::string::npos || token_end == std::string::npos || token_start >= token_end) continue;
-
-        std::string token_content = token_part.substr(token_start + 1, token_end - token_start - 1);
+        if (token_start == std::string::npos) continue;
+        size_t value_pos = token_start + 1;
+        std::string token_content = extract_json_string(token_part, value_pos);
         special_tokens[token_content] = token_id;
     }
 }

--- a/cactus/ffi/cactus_utils.h
+++ b/cactus/ffi/cactus_utils.h
@@ -900,6 +900,7 @@ inline std::vector<ToolFunction> parse_tools_json(const std::string& json) {
     pos = json.find("\"function\"", pos);
     while (pos != std::string::npos) {
         ToolFunction tool;
+        size_t next_search = pos + 1;
         
         size_t name_pos = json.find("\"name\"", pos);
         if (name_pos != std::string::npos) {
@@ -927,12 +928,13 @@ inline std::vector<ToolFunction> parse_tools_json(const std::string& json) {
                     params_end++;
                 }
                 tool.parameters["schema"] = json.substr(params_start, params_end - params_start);
+                next_search = params_end;
             }
         }
-        
+
         tools.push_back(tool);
-        
-        pos = json.find("\"function\"", name_pos);
+
+        pos = json.find("\"function\"", next_search);
     }
 
     return tools;

--- a/cactus/ffi/gemma_tools.h
+++ b/cactus/ffi/gemma_tools.h
@@ -7,11 +7,7 @@
 #include <map>
 #include <set>
 
-#include "../engine/engine.h"
-
 namespace gemma {
-
-using cactus::engine::extract_json_string;
 
 inline std::string to_upper(const std::string& s) {
     std::string result = s;
@@ -19,19 +15,38 @@ inline std::string to_upper(const std::string& s) {
     return result;
 }
 
-inline std::string escape(const std::string& s, bool use_pipe_tags = false) {
-    const char* tag = use_pipe_tags ? "<|\"|>" : "<escape>";
-    return std::string(tag) + s + tag;
+inline std::string escape(const std::string& s) {
+    return "<escape>" + s + "<escape>";
 }
 
 inline void skip_whitespace(const std::string& json, size_t& pos) {
     while (pos < json.length() && std::isspace(json[pos])) pos++;
 }
 
-std::string format_argument(const std::string& json, size_t& pos, bool escape_keys, bool use_pipe_tags);
-std::string format_parameters(const std::string& properties_json, const std::string& /*required_json*/, bool use_pipe_tags);
+inline std::string extract_json_string(const std::string& json, size_t& pos) {
+    std::string value;
+    while (pos < json.length() && json[pos] != '"') {
+        if (json[pos] == '\\' && pos + 1 < json.length()) {
+            pos++;
+            if (json[pos] == 'n') value += '\n';
+            else if (json[pos] == 't') value += '\t';
+            else if (json[pos] == 'r') value += '\r';
+            else if (json[pos] == '"') value += '"';
+            else if (json[pos] == '\\') value += '\\';
+            else value += json[pos];
+        } else {
+            value += json[pos];
+        }
+        pos++;
+    }
+    if (pos < json.length()) pos++; 
+    return value;
+}
 
-inline std::string format_argument(const std::string& json, size_t& pos, bool escape_keys = true, bool use_pipe_tags = false) {
+std::string format_argument(const std::string& json, size_t& pos, bool escape_keys);
+std::string format_parameters(const std::string& properties_json, const std::string& /*required_json*/);
+
+inline std::string format_argument(const std::string& json, size_t& pos, bool escape_keys = true) {
     skip_whitespace(json, pos);
     if (pos >= json.length()) return "";
 
@@ -40,10 +55,10 @@ inline std::string format_argument(const std::string& json, size_t& pos, bool es
     if (c == '"') {
         pos++;
         std::string value = extract_json_string(json, pos);
-        return escape(value, use_pipe_tags);
+        return escape(value);
     } else if (c == '{') {
         std::string result = "{";
-        pos++;
+        pos++; 
         bool first = true;
 
         while (pos < json.length()) {
@@ -58,12 +73,12 @@ inline std::string format_argument(const std::string& json, size_t& pos, bool es
             skip_whitespace(json, pos);
             if (pos < json.length() && json[pos] == ':') pos++;
 
-            std::string value = format_argument(json, pos, escape_keys, use_pipe_tags);
+            std::string value = format_argument(json, pos, escape_keys);
 
             if (!first) result += ",";
             first = false;
             if (escape_keys) {
-                result += escape(key, use_pipe_tags) + ":" + value;
+                result += escape(key) + ":" + value;
             } else {
                 result += key + ":" + value;
             }
@@ -72,7 +87,7 @@ inline std::string format_argument(const std::string& json, size_t& pos, bool es
         return result;
     } else if (c == '[') {
         std::string result = "[";
-        pos++;
+        pos++; 
         bool first = true;
 
         while (pos < json.length()) {
@@ -80,7 +95,7 @@ inline std::string format_argument(const std::string& json, size_t& pos, bool es
             if (pos >= json.length() || json[pos] == ']') { pos++; break; }
             if (json[pos] == ',') { pos++; continue; }
 
-            std::string value = format_argument(json, pos, escape_keys, use_pipe_tags);
+            std::string value = format_argument(json, pos, escape_keys);
 
             if (!first) result += ",";
             first = false;
@@ -181,7 +196,7 @@ inline std::string get_json_string_value(const std::string& json, size_t pos) {
     return "";
 }
 
-inline std::string format_parameters(const std::string& properties_json, const std::string& /*required_json*/, bool use_pipe_tags = false) {
+inline std::string format_parameters(const std::string& properties_json, const std::string& /*required_json*/) {
     static const std::set<std::string> standard_keys = {"description", "type", "properties", "required", "nullable"};
 
     size_t pos = 0;
@@ -203,7 +218,7 @@ inline std::string format_parameters(const std::string& properties_json, const s
 
         if (prop_obj.count("description")) {
             std::string desc = get_json_string_value(prop_obj["description"], 0);
-            result += "description:" + escape(desc, use_pipe_tags);
+            result += "description:" + escape(desc);
         }
 
         std::string type_val;
@@ -214,7 +229,7 @@ inline std::string format_parameters(const std::string& properties_json, const s
         if (to_upper(type_val) == "STRING") {
             if (prop_obj.count("enum")) {
                 size_t enum_pos = 0;
-                std::string enum_formatted = format_argument(prop_obj["enum"], enum_pos, true, use_pipe_tags);
+                std::string enum_formatted = format_argument(prop_obj["enum"], enum_pos, true);
                 result += ",enum:" + enum_formatted;
             }
         } else if (to_upper(type_val) == "OBJECT") {
@@ -223,7 +238,7 @@ inline std::string format_parameters(const std::string& properties_json, const s
                 if (prop_obj.count("required")) {
                     nested_required = prop_obj["required"];
                 }
-                result += ",properties:{" + format_parameters(prop_obj["properties"], nested_required, use_pipe_tags) + "}";
+                result += ",properties:{" + format_parameters(prop_obj["properties"], nested_required) + "}";
             }
             if (prop_obj.count("required")) {
                 std::string req_items;
@@ -241,7 +256,7 @@ inline std::string format_parameters(const std::string& properties_json, const s
                             std::string req_item = extract_json_string(prop_obj["required"], req_pos);
                             if (!req_first) req_items += ",";
                             req_first = false;
-                            req_items += escape(req_item, use_pipe_tags);
+                            req_items += escape(req_item);
                         }
                     }
                 }
@@ -265,7 +280,7 @@ inline std::string format_parameters(const std::string& properties_json, const s
                         if (items_obj.count("required")) {
                             items_required = items_obj["required"];
                         }
-                        result += "properties:{" + format_parameters(item_value, items_required, use_pipe_tags) + "}";
+                        result += "properties:{" + format_parameters(item_value, items_required) + "}";
                     } else if (item_key == "required") {
                         result += "required:[";
                         size_t req_pos = 0;
@@ -282,17 +297,17 @@ inline std::string format_parameters(const std::string& properties_json, const s
                                     std::string req_item = extract_json_string(item_value, req_pos);
                                     if (!req_first) result += ",";
                                     req_first = false;
-                                    result += escape(req_item, use_pipe_tags);
+                                    result += escape(req_item);
                                 }
                             }
                         }
                         result += "]";
                     } else if (item_key == "type") {
                         std::string item_type = get_json_string_value(item_value, 0);
-                        result += "type:" + escape(to_upper(item_type), use_pipe_tags);
+                        result += "type:" + escape(to_upper(item_type));
                     } else {
                         size_t val_pos = 0;
-                        result += item_key + ":" + format_argument(item_value, val_pos, true, use_pipe_tags);
+                        result += item_key + ":" + format_argument(item_value, val_pos, true);
                     }
                 }
                 result += "}";
@@ -300,7 +315,7 @@ inline std::string format_parameters(const std::string& properties_json, const s
         }
 
         if (!type_val.empty()) {
-            result += ",type:" + escape(to_upper(type_val), use_pipe_tags);
+            result += ",type:" + escape(to_upper(type_val));
         }
 
         result += "}";
@@ -311,10 +326,9 @@ inline std::string format_parameters(const std::string& properties_json, const s
 
 inline std::string format_function_declaration(const std::string& name,
                                                 const std::string& description,
-                                                const std::string& params_json,
-                                                bool use_pipe_tags = false) {
+                                                const std::string& params_json) {
     std::string result = "declaration:" + name + "{";
-    result += "description:" + escape(description, use_pipe_tags);
+    result += "description:" + escape(description);
 
     if (!params_json.empty()) {
         result += ",parameters:{";
@@ -327,7 +341,7 @@ inline std::string format_function_declaration(const std::string& name,
             if (params.count("required")) {
                 required_json = params["required"];
             }
-            result += "properties:{" + format_parameters(params["properties"], required_json, use_pipe_tags) + "}";
+            result += "properties:{" + format_parameters(params["properties"], required_json) + "}";
         }
 
         if (params.count("required")) {
@@ -346,7 +360,7 @@ inline std::string format_function_declaration(const std::string& name,
                         std::string item = extract_json_string(params["required"], req_pos);
                         if (!first) req_items += ",";
                         first = false;
-                        req_items += escape(item, use_pipe_tags);
+                        req_items += escape(item);
                     }
                 }
             }
@@ -357,7 +371,7 @@ inline std::string format_function_declaration(const std::string& name,
 
         if (params.count("type")) {
             std::string type_val = get_json_string_value(params["type"], 0);
-            result += ",type:" + escape(to_upper(type_val), use_pipe_tags);
+            result += ",type:" + escape(to_upper(type_val));
         }
 
         result += "}";
@@ -383,7 +397,7 @@ inline std::string format_tools(const std::vector<ToolFunction>& tools, bool use
             params_json = it->second;
         }
 
-        result += format_function_declaration(tool.name, tool.description, params_json, use_pipe_tags);
+        result += format_function_declaration(tool.name, tool.description, params_json);
         result += decl_end;
     }
     return result;

--- a/cactus/ffi/gemma_tools.h
+++ b/cactus/ffi/gemma_tools.h
@@ -7,7 +7,11 @@
 #include <map>
 #include <set>
 
+#include "../engine/engine.h"
+
 namespace gemma {
+
+using cactus::engine::extract_json_string;
 
 inline std::string to_upper(const std::string& s) {
     std::string result = s;
@@ -15,38 +19,19 @@ inline std::string to_upper(const std::string& s) {
     return result;
 }
 
-inline std::string escape(const std::string& s) {
-    return "<escape>" + s + "<escape>";
+inline std::string escape(const std::string& s, bool use_pipe_tags = false) {
+    const char* tag = use_pipe_tags ? "<|\"|>" : "<escape>";
+    return std::string(tag) + s + tag;
 }
 
 inline void skip_whitespace(const std::string& json, size_t& pos) {
     while (pos < json.length() && std::isspace(json[pos])) pos++;
 }
 
-inline std::string extract_json_string(const std::string& json, size_t& pos) {
-    std::string value;
-    while (pos < json.length() && json[pos] != '"') {
-        if (json[pos] == '\\' && pos + 1 < json.length()) {
-            pos++;
-            if (json[pos] == 'n') value += '\n';
-            else if (json[pos] == 't') value += '\t';
-            else if (json[pos] == 'r') value += '\r';
-            else if (json[pos] == '"') value += '"';
-            else if (json[pos] == '\\') value += '\\';
-            else value += json[pos];
-        } else {
-            value += json[pos];
-        }
-        pos++;
-    }
-    if (pos < json.length()) pos++; 
-    return value;
-}
+std::string format_argument(const std::string& json, size_t& pos, bool escape_keys, bool use_pipe_tags);
+std::string format_parameters(const std::string& properties_json, const std::string& /*required_json*/, bool use_pipe_tags);
 
-std::string format_argument(const std::string& json, size_t& pos, bool escape_keys);
-std::string format_parameters(const std::string& properties_json, const std::string& /*required_json*/);
-
-inline std::string format_argument(const std::string& json, size_t& pos, bool escape_keys = true) {
+inline std::string format_argument(const std::string& json, size_t& pos, bool escape_keys = true, bool use_pipe_tags = false) {
     skip_whitespace(json, pos);
     if (pos >= json.length()) return "";
 
@@ -55,10 +40,10 @@ inline std::string format_argument(const std::string& json, size_t& pos, bool es
     if (c == '"') {
         pos++;
         std::string value = extract_json_string(json, pos);
-        return escape(value);
+        return escape(value, use_pipe_tags);
     } else if (c == '{') {
         std::string result = "{";
-        pos++; 
+        pos++;
         bool first = true;
 
         while (pos < json.length()) {
@@ -73,12 +58,12 @@ inline std::string format_argument(const std::string& json, size_t& pos, bool es
             skip_whitespace(json, pos);
             if (pos < json.length() && json[pos] == ':') pos++;
 
-            std::string value = format_argument(json, pos, escape_keys);
+            std::string value = format_argument(json, pos, escape_keys, use_pipe_tags);
 
             if (!first) result += ",";
             first = false;
             if (escape_keys) {
-                result += escape(key) + ":" + value;
+                result += escape(key, use_pipe_tags) + ":" + value;
             } else {
                 result += key + ":" + value;
             }
@@ -87,7 +72,7 @@ inline std::string format_argument(const std::string& json, size_t& pos, bool es
         return result;
     } else if (c == '[') {
         std::string result = "[";
-        pos++; 
+        pos++;
         bool first = true;
 
         while (pos < json.length()) {
@@ -95,7 +80,7 @@ inline std::string format_argument(const std::string& json, size_t& pos, bool es
             if (pos >= json.length() || json[pos] == ']') { pos++; break; }
             if (json[pos] == ',') { pos++; continue; }
 
-            std::string value = format_argument(json, pos, escape_keys);
+            std::string value = format_argument(json, pos, escape_keys, use_pipe_tags);
 
             if (!first) result += ",";
             first = false;
@@ -196,7 +181,7 @@ inline std::string get_json_string_value(const std::string& json, size_t pos) {
     return "";
 }
 
-inline std::string format_parameters(const std::string& properties_json, const std::string& /*required_json*/) {
+inline std::string format_parameters(const std::string& properties_json, const std::string& /*required_json*/, bool use_pipe_tags = false) {
     static const std::set<std::string> standard_keys = {"description", "type", "properties", "required", "nullable"};
 
     size_t pos = 0;
@@ -218,7 +203,7 @@ inline std::string format_parameters(const std::string& properties_json, const s
 
         if (prop_obj.count("description")) {
             std::string desc = get_json_string_value(prop_obj["description"], 0);
-            result += "description:" + escape(desc);
+            result += "description:" + escape(desc, use_pipe_tags);
         }
 
         std::string type_val;
@@ -229,7 +214,7 @@ inline std::string format_parameters(const std::string& properties_json, const s
         if (to_upper(type_val) == "STRING") {
             if (prop_obj.count("enum")) {
                 size_t enum_pos = 0;
-                std::string enum_formatted = format_argument(prop_obj["enum"], enum_pos, true);
+                std::string enum_formatted = format_argument(prop_obj["enum"], enum_pos, true, use_pipe_tags);
                 result += ",enum:" + enum_formatted;
             }
         } else if (to_upper(type_val) == "OBJECT") {
@@ -238,7 +223,7 @@ inline std::string format_parameters(const std::string& properties_json, const s
                 if (prop_obj.count("required")) {
                     nested_required = prop_obj["required"];
                 }
-                result += ",properties:{" + format_parameters(prop_obj["properties"], nested_required) + "}";
+                result += ",properties:{" + format_parameters(prop_obj["properties"], nested_required, use_pipe_tags) + "}";
             }
             if (prop_obj.count("required")) {
                 std::string req_items;
@@ -256,7 +241,7 @@ inline std::string format_parameters(const std::string& properties_json, const s
                             std::string req_item = extract_json_string(prop_obj["required"], req_pos);
                             if (!req_first) req_items += ",";
                             req_first = false;
-                            req_items += escape(req_item);
+                            req_items += escape(req_item, use_pipe_tags);
                         }
                     }
                 }
@@ -280,7 +265,7 @@ inline std::string format_parameters(const std::string& properties_json, const s
                         if (items_obj.count("required")) {
                             items_required = items_obj["required"];
                         }
-                        result += "properties:{" + format_parameters(item_value, items_required) + "}";
+                        result += "properties:{" + format_parameters(item_value, items_required, use_pipe_tags) + "}";
                     } else if (item_key == "required") {
                         result += "required:[";
                         size_t req_pos = 0;
@@ -297,17 +282,17 @@ inline std::string format_parameters(const std::string& properties_json, const s
                                     std::string req_item = extract_json_string(item_value, req_pos);
                                     if (!req_first) result += ",";
                                     req_first = false;
-                                    result += escape(req_item);
+                                    result += escape(req_item, use_pipe_tags);
                                 }
                             }
                         }
                         result += "]";
                     } else if (item_key == "type") {
                         std::string item_type = get_json_string_value(item_value, 0);
-                        result += "type:" + escape(to_upper(item_type));
+                        result += "type:" + escape(to_upper(item_type), use_pipe_tags);
                     } else {
                         size_t val_pos = 0;
-                        result += item_key + ":" + format_argument(item_value, val_pos, true);
+                        result += item_key + ":" + format_argument(item_value, val_pos, true, use_pipe_tags);
                     }
                 }
                 result += "}";
@@ -315,7 +300,7 @@ inline std::string format_parameters(const std::string& properties_json, const s
         }
 
         if (!type_val.empty()) {
-            result += ",type:" + escape(to_upper(type_val));
+            result += ",type:" + escape(to_upper(type_val), use_pipe_tags);
         }
 
         result += "}";
@@ -326,9 +311,10 @@ inline std::string format_parameters(const std::string& properties_json, const s
 
 inline std::string format_function_declaration(const std::string& name,
                                                 const std::string& description,
-                                                const std::string& params_json) {
+                                                const std::string& params_json,
+                                                bool use_pipe_tags = false) {
     std::string result = "declaration:" + name + "{";
-    result += "description:" + escape(description);
+    result += "description:" + escape(description, use_pipe_tags);
 
     if (!params_json.empty()) {
         result += ",parameters:{";
@@ -341,7 +327,7 @@ inline std::string format_function_declaration(const std::string& name,
             if (params.count("required")) {
                 required_json = params["required"];
             }
-            result += "properties:{" + format_parameters(params["properties"], required_json) + "}";
+            result += "properties:{" + format_parameters(params["properties"], required_json, use_pipe_tags) + "}";
         }
 
         if (params.count("required")) {
@@ -360,7 +346,7 @@ inline std::string format_function_declaration(const std::string& name,
                         std::string item = extract_json_string(params["required"], req_pos);
                         if (!first) req_items += ",";
                         first = false;
-                        req_items += escape(item);
+                        req_items += escape(item, use_pipe_tags);
                     }
                 }
             }
@@ -371,7 +357,7 @@ inline std::string format_function_declaration(const std::string& name,
 
         if (params.count("type")) {
             std::string type_val = get_json_string_value(params["type"], 0);
-            result += ",type:" + escape(to_upper(type_val));
+            result += ",type:" + escape(to_upper(type_val), use_pipe_tags);
         }
 
         result += "}";
@@ -397,7 +383,7 @@ inline std::string format_tools(const std::vector<ToolFunction>& tools, bool use
             params_json = it->second;
         }
 
-        result += format_function_declaration(tool.name, tool.description, params_json);
+        result += format_function_declaration(tool.name, tool.description, params_json, use_pipe_tags);
         result += decl_end;
     }
     return result;

--- a/cactus/models/gemma4/model_gemma4.cpp
+++ b/cactus/models/gemma4/model_gemma4.cpp
@@ -227,10 +227,23 @@ size_t Gemma4Model::build_per_layer_input(CactusGraph* gb, size_t hidden, size_t
 size_t Gemma4Model::apply_partial_rope(CactusGraph* gb, size_t tensor, size_t head_dim, size_t rot_dim,
                                            float rope_freq, size_t position_offset) {
     if (rot_dim < head_dim) {
+        size_t half_dim = head_dim / 2;
+        size_t half_rot = rot_dim / 2;
+        size_t pass_len = half_dim - half_rot;
         float adjusted_theta = std::pow(rope_freq, static_cast<float>(rot_dim) / static_cast<float>(head_dim));
-        auto rot_part = gb->slice(tensor, 3, 0, rot_dim);
-        auto pass_part = gb->slice(tensor, 3, rot_dim, head_dim - rot_dim);
-        return gb->concat(gb->rope(rot_part, adjusted_theta, position_offset), pass_part, 3);
+
+        auto left_rot   = gb->slice(tensor, 3, 0,                   half_rot);
+        auto left_pass  = gb->slice(tensor, 3, half_rot,            pass_len);
+        auto right_rot  = gb->slice(tensor, 3, half_dim,            half_rot);
+        auto right_pass = gb->slice(tensor, 3, half_dim + half_rot, pass_len);
+
+        auto rotated = gb->rope(gb->concat(left_rot, right_rot, 3), adjusted_theta, position_offset);
+        auto rotated_left  = gb->slice(rotated, 3, 0,        half_rot);
+        auto rotated_right = gb->slice(rotated, 3, half_rot, half_rot);
+
+        auto new_left  = gb->concat(rotated_left,  left_pass,  3);
+        auto new_right = gb->concat(rotated_right, right_pass, 3);
+        return gb->concat(new_left, new_right, 3);
     }
     return gb->rope(tensor, rope_freq, position_offset);
 }

--- a/cactus/models/gemma4/model_gemma4.h
+++ b/cactus/models/gemma4/model_gemma4.h
@@ -352,6 +352,10 @@ public:
     void compact_kv_cache() override;
     void remove_thinking_tokens(const std::vector<std::pair<size_t, size_t>>& ranges) override;
 
+    void set_tool_constraints(const std::vector<ToolConstraintSpec>& tools) override;
+    void clear_tool_constraints() override;
+    void update_tool_constraints(uint32_t token_id) override;
+
 protected:
     size_t build_attention(CactusGraph*, size_t, uint32_t, ComputeBackend, bool, size_t) override;
     size_t build_mlp(CactusGraph*, size_t, uint32_t, ComputeBackend) const override;

--- a/cactus/models/gemma4/model_gemma4_mm.cpp
+++ b/cactus/models/gemma4/model_gemma4_mm.cpp
@@ -67,6 +67,18 @@ void Gemma4MmModel::remove_thinking_tokens(const std::vector<std::pair<size_t, s
     language_model_.remove_thinking_tokens(ranges);
 }
 
+void Gemma4MmModel::set_tool_constraints(const std::vector<ToolConstraintSpec>& tools) {
+    language_model_.set_tool_constraints(tools);
+}
+
+void Gemma4MmModel::clear_tool_constraints() {
+    language_model_.clear_tool_constraints();
+}
+
+void Gemma4MmModel::update_tool_constraints(uint32_t token_id) {
+    language_model_.update_tool_constraints(token_id);
+}
+
 void Gemma4MmModel::load_weights_to_graph(CactusGraph*) {
     output_weight_node_id_ = 0;
 }


### PR DESCRIPTION
## Summary
- Fix Gemma4 partial RoPE to rotate interleaved halves (pair index `i` with `i + head_dim/2`) instead of a contiguous prefix, matching the reference implementation.
- Fix tool-calling constraints in Gemma4: make `set_tool_constraints` / `clear_tool_constraints` / `update_tool_constraints` virtual on the base model and forward them through `Gemma4MmModel` so multimodal instances actually apply constraints.
- Fix tool JSON parsing: advance the `"function"` search cursor past the parsed `parameters` block so multiple tools in a single payload are no longer dropped or re-parsed.
- Fix special-tokens map loading to honor escape sequences via a shared `extract_json_string` helper (previously `rfind("\"")` could pull in trailing quoted content).

## Test plan
- [ ] Build and run existing Gemma4 unit tests
- [ ] Verify tool-calling end-to-end on a multimodal Gemma4 prompt with multiple tools
- [ ] Sanity-check RoPE output against reference for a partial-rotation config