### PR TITLE
Gemma4 multimodal multi-turn fixes

### DIFF
--- a/cactus/engine/engine.h
+++ b/cactus/engine/engine.h
@@ -768,6 +768,7 @@ public:
 
 
     void set_cache_window(size_t window_size, size_t sink_size = 4) { kv_cache_.set_window_size(window_size, sink_size); }
+    size_t get_cache_size() const { return kv_cache_.current_seq_len; }
 
     bool load_npu_prefill(const std::string& model_path);
     bool has_npu_prefill() const;

--- a/cactus/engine/engine_bpe.cpp
+++ b/cactus/engine/engine_bpe.cpp
@@ -156,6 +156,34 @@ bool BPETokenizer::load_vocabulary_mmap(const std::string& vocab_file, const std
             priority++;
         }
     }
+    
+    auto is_whitespace_only = [](const std::string& s) {
+        if (s.empty()) return false;
+        for (char c : s) {
+            if (c != ' ' && c != '\n' && c != '\t' && c != '\r') return false;
+        }
+        return true;
+    };
+    std::vector<std::string> ws_tokens;
+    for (const auto& tok : id_to_token_) {
+        if (tok.size() >= 2 && is_whitespace_only(tok)) ws_tokens.push_back(tok);
+    }
+    std::sort(ws_tokens.begin(), ws_tokens.end(),
+              [](const std::string& a, const std::string& b) { return a.size() < b.size(); });
+    for (const auto& tok : ws_tokens) {
+        for (size_t i = 1; i < tok.size(); i++) {
+            std::string first = tok.substr(0, i);
+            std::string second = tok.substr(i);
+            if (!token_to_id_.count(first) || !token_to_id_.count(second)) continue;
+            std::string key = first + "\x00" + second;
+            if (merge_map_.find(key) == merge_map_.end()) {
+                merge_rules_.emplace_back(first, second, tok, priority);
+                merge_map_[key] = priority;
+                priority++;
+            }
+            break;
+        }
+    }
 
     std::sort(merge_rules_.begin(), merge_rules_.end(),
               [](const MergeRule& a, const MergeRule& b) {

--- a/cactus/ffi/cactus_complete.cpp
+++ b/cactus/ffi/cactus_complete.cpp
@@ -335,6 +335,7 @@ void reset_cache(CactusModelHandle* handle) {
     handle->model->reset_cache();
     handle->processed_tokens.clear();
     handle->processed_images.clear();
+    handle->user_audio_counts.clear();
 }
 
 struct PrefillResult {
@@ -539,16 +540,24 @@ PreparedPrompt prepare_prompt(
                 }
             }
         }
-        if (!audio_samples.empty()) {
+        std::vector<size_t> user_indices;
+        for (size_t i = 0; i < prompt.messages.size(); i++) {
+            if (prompt.messages[i].role == "user") user_indices.push_back(i);
+        }
+        auto& counts = handle->user_audio_counts;
+        for (size_t u = 0; u + 1 < user_indices.size(); u++) {
+            if (u < counts.size() && counts[u] > 0) {
+                prompt.messages[user_indices[u]].audio_soft_token_count = counts[u];
+            }
+        }
+        if (!audio_samples.empty() && !user_indices.empty()) {
             auto audio_prep = cactus::audio::preprocess_audio_for_gemma4(audio_samples, handle->model->get_config());
             prompt.audio_features = std::move(audio_prep.features);
             prompt.audio_num_frames = audio_prep.num_frames;
-            for (auto it = prompt.messages.rbegin(); it != prompt.messages.rend(); ++it) {
-                if (it->role == "user") {
-                    it->audio_soft_token_count = audio_prep.num_soft_tokens;
-                    break;
-                }
-            }
+            size_t u = user_indices.size() - 1;
+            prompt.messages[user_indices[u]].audio_soft_token_count = audio_prep.num_soft_tokens;
+            if (counts.size() <= u) counts.resize(u + 1, 0);
+            counts[u] = audio_prep.num_soft_tokens;
         }
     }
 
@@ -755,6 +764,22 @@ int cactus_complete(
         float first_token_entropy = 0.0f;
         uint32_t next_token;
         size_t prompt_tokens;
+
+        if ((has_gemma4_mixed_media || has_audio) && !handle->processed_tokens.empty()) {
+            auto& cache = handle->processed_tokens;
+            size_t common = 0;
+            size_t limit = std::min(cache.size(), prompt.tokens.size());
+            while (common < limit && cache[common] == prompt.tokens[common]) common++;
+            if (common < cache.size()) {
+                CACTUS_LOG_WARN("complete", "KV cache diverges from new prompt at position " << common
+                    << "/" << cache.size() << "; trimming and re-prefilling the divergent suffix");
+                size_t kv_len = handle->model->get_cache_size();
+                if (kv_len > common) {
+                    handle->model->remove_thinking_tokens({{common, kv_len - common}});
+                }
+                cache.resize(common);
+            }
+        }
 
         if (has_gemma4_mixed_media) {
             prompt_tokens = prompt.tokens.size();

--- a/cactus/ffi/cactus_init.cpp
+++ b/cactus/ffi/cactus_init.cpp
@@ -473,6 +473,7 @@ void cactus_reset(cactus_model_t model) {
     handle->model->reset_cache();
     handle->processed_tokens.clear();
     handle->processed_images.clear();
+    handle->user_audio_counts.clear();
 }
 
 void cactus_stop(cactus_model_t model) {

--- a/cactus/ffi/cactus_utils.h
+++ b/cactus/ffi/cactus_utils.h
@@ -74,6 +74,7 @@ struct CactusModelHandle {
     };
 
     std::vector<std::vector<ProcessedImage>> processed_images;
+    std::vector<size_t> user_audio_counts;
     std::mutex model_mutex;
     std::string model_name;
     std::unique_ptr<cactus::engine::index::Index> corpus_index;

--- a/cactus/models/gemma4/model_gemma4.h
+++ b/cactus/models/gemma4/model_gemma4.h
@@ -407,9 +407,6 @@ private:
     Gemma4VisionModel vision_encoder_;
     Gemma4AudioModel audio_encoder_;
     Gemma4Model language_model_;
-
-    bool prefill_completed_ = false;
-    size_t last_token_count_ = 0;
 };
 
 }

--- a/cactus/models/gemma4/model_gemma4_mm.cpp
+++ b/cactus/models/gemma4/model_gemma4_mm.cpp
@@ -55,8 +55,6 @@ bool Gemma4MmModel::init(const std::string& model_folder, size_t context_size,
 void Gemma4MmModel::reset_cache() {
     Model::reset_cache();
     language_model_.reset_cache();
-    prefill_completed_ = false;
-    last_token_count_ = 0;
 }
 
 void Gemma4MmModel::compact_kv_cache() {
@@ -264,8 +262,6 @@ uint32_t Gemma4MmModel::decode_multimodal(
     bool has_media = !image_paths.empty() || (audio_features && !audio_features->empty());
 
     if (!has_media) {
-        prefill_completed_ = false;
-        last_token_count_ = tokens.size();
         return language_model_.decode(tokens, temperature, top_p, top_k, profile_file, out_entropy, min_p, repetition_penalty);
     }
 
@@ -276,31 +272,31 @@ uint32_t Gemma4MmModel::decode_multimodal(
     auto* gb = static_cast<CactusGraph*>(graph_handle_);
     gb->soft_reset();
     auto backend = config_.default_backend == Config::Backend::CPU ? ComputeBackend::CPU : ComputeBackend::NPU;
-    bool cache_empty = language_model_.kv_cache_.is_empty();
-    bool need_prefill = cache_empty || !prefill_completed_;
 
-    if (!need_prefill && tokens.size() <= last_token_count_) {
+    size_t cached_len = language_model_.kv_cache_.current_seq_len;
+    if (cached_len >= tokens.size()) {
         reset_cache();
-        need_prefill = true;
+        cached_len = 0;
     }
+    std::vector<uint32_t> forward_tokens = cached_len == 0
+        ? tokens
+        : std::vector<uint32_t>(tokens.end() - (tokens.size() - cached_len), tokens.end());
 
-    size_t seq_len_for_updates = 0;
+    bool delta_has_media = std::any_of(forward_tokens.begin(), forward_tokens.end(), [&](uint32_t t) {
+        return (config_.image_token_id != 0 && t == config_.image_token_id) ||
+               (config_.audio_token_id != 0 && t == config_.audio_token_id);
+    });
+
     size_t final_hidden_node = 0;
-
-    if (need_prefill) {
-        auto result = forward_multimodal(gb, tokens, image_paths, audio_features,
+    size_t seq_len_for_updates = 0;
+    if (delta_has_media) {
+        auto result = forward_multimodal(gb, forward_tokens, image_paths, audio_features,
                                           audio_num_frames, backend, true);
         final_hidden_node = result.final_hidden_node;
         seq_len_for_updates = result.seq_len;
-        prefill_completed_ = true;
-        last_token_count_ = tokens.size();
     } else {
-        size_t delta = tokens.size() - last_token_count_;
-        if (delta == 0) delta = 1;
-        std::vector<uint32_t> incremental_tokens(tokens.end() - delta, tokens.end());
-        final_hidden_node = language_model_.forward(incremental_tokens, true);
-        seq_len_for_updates = incremental_tokens.size();
-        last_token_count_ = tokens.size();
+        final_hidden_node = language_model_.forward(forward_tokens, true);
+        seq_len_for_updates = forward_tokens.size();
     }
 
     auto last_hidden = gb->index(final_hidden_node, seq_len_for_updates - 1, 0);
@@ -345,8 +341,6 @@ uint32_t Gemma4MmModel::decode(const std::vector<uint32_t>& tokens,
                                    float min_p, float repetition_penalty) {
     if (!initialized_ || !graph_handle_)
         throw std::runtime_error("Model not initialized - call init() first");
-    prefill_completed_ = false;
-    last_token_count_ = tokens.size();
     return language_model_.decode(tokens, temperature, top_p, top_k, profile_file, out_entropy, min_p, repetition_penalty);
 }
 
@@ -354,8 +348,6 @@ void Gemma4MmModel::prefill(const std::vector<uint32_t>& tokens, size_t chunk_si
                                 const std::string& profile_file) {
     if (!initialized_ || !graph_handle_)
         throw std::runtime_error("Model not initialized - call init() first");
-    prefill_completed_ = false;
-    last_token_count_ = tokens.size();
     language_model_.prefill(tokens, chunk_size, profile_file);
 }
 
@@ -383,9 +375,6 @@ void Gemma4MmModel::prefill_with_images(const std::vector<uint32_t>& tokens,
 
     language_model_.post_execute_updates(gb, result.seq_len);
     language_model_.update_kv_cache(gb, result.seq_len);
-
-    prefill_completed_ = true;
-    last_token_count_ = tokens.size();
 }
 
 uint32_t Gemma4MmModel::decode_with_images(

--- a/tests/chat.cpp
+++ b/tests/chat.cpp
@@ -402,6 +402,7 @@ int main(int argc, char* argv[]) {
     std::vector<std::string> history_images;
     std::vector<std::string> history_audio;
     std::vector<uint8_t> current_pcm;
+    bool image_committed = false;
     TokenPrinter printer;
     g_printer = &printer;
 
@@ -438,6 +439,7 @@ int main(int argc, char* argv[]) {
             history_audio.clear();
             current_image.clear();
             current_audio.clear();
+            image_committed = false;
             cactus_reset(model);
             std::cout << colored("Conversation reset.\n", Color::YELLOW);
             print_header(system_prompt, current_image, has_vision);
@@ -447,6 +449,7 @@ int main(int argc, char* argv[]) {
         if (input == "/clear") {
             current_image.clear();
             current_audio.clear();
+            image_committed = false;
             std::cout << colored("Image/audio cleared.\n", Color::YELLOW);
             continue;
         }
@@ -479,6 +482,7 @@ int main(int argc, char* argv[]) {
                 continue;
             }
             current_image = path;
+            image_committed = false;
             if (msg.empty()) continue;
             input = msg;
         }
@@ -519,7 +523,8 @@ int main(int argc, char* argv[]) {
         }
 
         history.push_back(input);
-        history_images.push_back(current_image);
+        history_images.push_back(image_committed ? std::string() : current_image);
+        if (!current_image.empty()) image_committed = true;
         history_audio.push_back(current_audio);
 
         // Build messages JSON

--- a/tests/test_gemma4_audio_image_audio.cpp
+++ b/tests/test_gemma4_audio_image_audio.cpp
@@ -1,0 +1,196 @@
+#include "../cactus/ffi/cactus_ffi.h"
+#include "../libs/audio/wav.h"
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+static std::string escape_json(const std::string& s) {
+    std::string out;
+    out.reserve(s.size() + 8);
+    for (char c : s) {
+        switch (c) {
+            case '"': out += "\\\""; break;
+            case '\\': out += "\\\\"; break;
+            case '\b': out += "\\b"; break;
+            case '\f': out += "\\f"; break;
+            case '\n': out += "\\n"; break;
+            case '\r': out += "\\r"; break;
+            case '\t': out += "\\t"; break;
+            default:
+                if (static_cast<unsigned char>(c) < 0x20) {
+                    char buf[8];
+                    std::snprintf(buf, sizeof(buf), "\\u%04x", c);
+                    out += buf;
+                } else {
+                    out += c;
+                }
+        }
+    }
+    return out;
+}
+
+static std::string unescape_json(const std::string& s) {
+    std::string out;
+    out.reserve(s.size());
+    for (size_t i = 0; i < s.size(); i++) {
+        if (s[i] == '\\' && i + 1 < s.size()) {
+            switch (s[i + 1]) {
+                case '"':  out += '"'; i++; break;
+                case '\\': out += '\\'; i++; break;
+                case 'n':  out += '\n'; i++; break;
+                case 'r':  out += '\r'; i++; break;
+                case 't':  out += '\t'; i++; break;
+                case 'b':  out += '\b'; i++; break;
+                case 'f':  out += '\f'; i++; break;
+                default:   out += s[i]; break;
+            }
+        } else {
+            out += s[i];
+        }
+    }
+    return out;
+}
+
+static std::string extract_response_field(const std::string& json) {
+    const std::string key = "\"response\":\"";
+    size_t start = json.find(key);
+    if (start == std::string::npos) return "";
+    start += key.size();
+    size_t end = start;
+    while (end < json.size()) {
+        end = json.find('"', end);
+        if (end == std::string::npos) return "";
+        size_t back = 0;
+        for (size_t i = end; i > start && json[i - 1] == '\\'; i--) back++;
+        if (back % 2 == 0) break;
+        end++;
+    }
+    return unescape_json(json.substr(start, end - start));
+}
+
+static std::string ensure_wav_from_mp3(const std::string& mp3_path) {
+    fs::path src(mp3_path);
+    fs::path out = fs::temp_directory_path() / (src.stem().string() + "_cactus_test_16k.wav");
+    if (fs::exists(out)) return out.string();
+    std::string cmd = "afconvert -f WAVE -d LEI16@16000 -c 1 "
+                      "'" + mp3_path + "' '" + out.string() + "' >/dev/null 2>&1";
+    if (std::system(cmd.c_str()) != 0) return "";
+    return fs::exists(out) ? out.string() : "";
+}
+
+static std::vector<uint8_t> wav_to_pcm16(const std::string& wav_path) {
+    AudioFP32 wav = load_wav(wav_path);
+    std::vector<int16_t> pcm(wav.samples.size());
+    for (size_t i = 0; i < wav.samples.size(); i++) {
+        float s = wav.samples[i];
+        if (s > 1.0f) s = 1.0f;
+        if (s < -1.0f) s = -1.0f;
+        pcm[i] = static_cast<int16_t>(s * 32767.0f);
+    }
+    std::vector<uint8_t> bytes(pcm.size() * sizeof(int16_t));
+    std::memcpy(bytes.data(), pcm.data(), bytes.size());
+    return bytes;
+}
+
+struct TurnResult {
+    bool ok = false;
+    std::string response;
+};
+
+static TurnResult run_turn(cactus_model_t model,
+                           const std::string& messages_json,
+                           const std::vector<uint8_t>& pcm) {
+    const char* options = R"({"max_tokens":128,"temperature":0.0,"top_p":1.0,"top_k":1,"auto_handoff":false,"telemetry_enabled":false})";
+    std::vector<char> buf(64 * 1024, 0);
+    int rc = cactus_complete(
+        model, messages_json.c_str(), buf.data(), buf.size(),
+        options, nullptr, nullptr, nullptr,
+        pcm.empty() ? nullptr : pcm.data(), pcm.size()
+    );
+    TurnResult r;
+    if (rc < 0) {
+        std::cerr << "  cactus_complete failed: " << buf.data() << "\n";
+        return r;
+    }
+    r.response = extract_response_field(std::string(buf.data()));
+    r.ok = !r.response.empty();
+    return r;
+}
+
+int main() {
+    const char* model_path = std::getenv("CACTUS_TEST_GEMMA4_MODEL");
+    if (!model_path) {
+        std::cerr << "SKIP: CACTUS_TEST_GEMMA4_MODEL not set\n";
+        return 0;
+    }
+    const char* repo_root_env = std::getenv("CACTUS_TEST_REPO_ROOT");
+    fs::path repo_root = repo_root_env ? fs::path(repo_root_env) : fs::current_path() / "..";
+
+    fs::path who_mp3 = repo_root / "who_are_you.mp3";
+    fs::path math_mp3 = repo_root / "2+2.mp3";
+    fs::path banner = repo_root / "assets" / "banner.jpg";
+
+    for (const auto& p : {who_mp3, math_mp3, banner}) {
+        if (!fs::exists(p)) {
+            std::cerr << "SKIP: missing asset " << p << "\n";
+            return 0;
+        }
+    }
+
+    std::string who_wav = ensure_wav_from_mp3(who_mp3.string());
+    std::string math_wav = ensure_wav_from_mp3(math_mp3.string());
+    if (who_wav.empty() || math_wav.empty()) {
+        std::cerr << "SKIP: afconvert failed (needed to transcode mp3 -> wav)\n";
+        return 0;
+    }
+
+    auto who_pcm = wav_to_pcm16(who_wav);
+    auto math_pcm = wav_to_pcm16(math_wav);
+
+    cactus_model_t model = cactus_init(model_path, nullptr, false);
+    if (!model) {
+        std::cerr << "FAIL: cactus_init\n";
+        return 1;
+    }
+
+    std::string m1 = R"([{"role":"user","content":""}])";
+    std::cout << "Turn 1 (audio who_are_you.mp3):\n";
+    auto t1 = run_turn(model, m1, who_pcm);
+    if (!t1.ok) { cactus_destroy(model); return 1; }
+    std::cout << "  -> " << t1.response << "\n";
+
+    std::string m2 =
+        std::string(R"([{"role":"user","content":""},)") +
+        R"({"role":"assistant","content":")" + escape_json(t1.response) + R"("},)" +
+        R"({"role":"user","content":"describe this","images":[")" + escape_json(banner.string()) + R"("]}])";
+    std::cout << "Turn 2 (image + 'describe this'):\n";
+    auto t2 = run_turn(model, m2, {});
+    if (!t2.ok) { cactus_destroy(model); return 1; }
+    std::cout << "  -> " << t2.response << "\n";
+
+    std::string m3 =
+        std::string(R"([{"role":"user","content":""},)") +
+        R"({"role":"assistant","content":")" + escape_json(t1.response) + R"("},)" +
+        R"({"role":"user","content":"describe this","images":[")" + escape_json(banner.string()) + R"("]},)" +
+        R"({"role":"assistant","content":")" + escape_json(t2.response) + R"("},)" +
+        R"({"role":"user","content":"","images":[")" + escape_json(banner.string()) + R"("]}])";
+    std::cout << "Turn 3 (audio 2+2.mp3, image still attached):\n";
+    auto t3 = run_turn(model, m3, math_pcm);
+    if (!t3.ok) { cactus_destroy(model); return 1; }
+    std::cout << "  -> " << t3.response << "\n";
+
+    cactus_destroy(model);
+
+    if (t3.response == t2.response) {
+        std::cerr << "FAIL: turn 3 response identical to turn 2 — new audio is being ignored\n";
+        return 1;
+    }
+    std::cout << "PASS\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary

Fixes multi-turn multimodal chat for Gemma 4 so audio asked *after* an image turn actually reaches the model (earlier it kept describing the image instead of answering).

## What changed

- **Audio placeholder restoration.** Cache each user turn's audio soft-token count on the handle; the template re-emits the same placeholder block on subsequent turns without reloading or re-encoding prior audio.
- **`decode_multimodal` cleanup.** Dropped the `prefill_completed_` / `last_token_count_` bookkeeping (which the text/image decode path was silently invalidating). Now uses `kv_cache_.current_seq_len` as the single source of truth and dispatches to `forward_multimodal` only when the delta actually contains image or audio placeholder tokens.
- **BPE whitespace-only merges.** `merges.txt` uses `\n` as both line terminator and merge content, so merges like `\n + \n = \n\n` can't be encoded in that format and were silently dropped. Recover them by scanning the vocabulary after load for pure-whitespace tokens and synthesizing the corresponding merge rules. This restores `encode(decode(tokens)) == tokens` for the common markdown/paragraph cases.
- **chat.cpp image behaviour.** The persistent ``current_image`` was being re-attached to *every* subsequent user turn, creating a duplicate image placeholder block in the cache and biasing the model toward describing the image. Now it's only attached on the first turn after `/image`.
- **Cache divergence recovery.** For any residual tokenizer roundtrip gap (e.g. code blocks with mixed indent+newline tokens), trim the cache to the longest common prefix with the new prompt and re-prefill the divergent suffix — logs a `WARN` so the remaining roundtrip work remains visible.
- **Test.** ``tests/test_gemma4_audio_image_audio.cpp`` reproduces the bug end-to-end: feeds ``who_are_you.mp3`` (audio-only), then ``banner.jpg`` + ``"describe this"``, then ``2+2.mp3`` with the image still attached, and asserts turn 3's response differs from turn 2's.

## Test plan

- [x] ``tests/build/test_gemma4_audio_image_audio`` passes (turn 3 answers ``"2 plus 2 equals 4."``)
- [x] ``chat`` manually: primary audio → image+describe → audio sequence answers ``"4"`` 3/3 runs
- [x] ``chat`` manually: audio → image+describe → text follow-up still describes correctly
- [x] ``chat`` manually: audio-only multi-turn unchanged (`"Four."`)
- [x] ``chat`` manually: ``/clear`` between image and audio recovers cleanly
- [x] Stress: 4 turns alternating audio / image+text / audio / audio, no regressions
- [x] Code-example prompt (previously tripped a hard error) now recovers via partial cache trim + `WARN` log

Run locally:
```sh
CACTUS_TEST_GEMMA4_MODEL=/path/to/gemma-4-e2b-it \
CACTUS_TEST_REPO_ROOT=/path/to/repo \
./tests/build/test_gemma4_audio_image_audio
```