### PR TITLE
Split native LLM ownership into Model and Context

### DIFF
--- a/cactus/ffi/cactus_complete.cpp
+++ b/cactus/ffi/cactus_complete.cpp
@@ -40,13 +40,13 @@ std::vector<uint32_t> encode_needle_tools_suffix(Tokenizer* tokenizer, const std
     return tokens;
 }
 
-void inject_rag_context(CactusModelHandle* handle, std::vector<ChatMessage>& messages) {
-    if (!handle->corpus_index) return;
+void inject_rag_context(CactusContextHandle* ctx, std::vector<ChatMessage>& messages) {
+    if (!ctx->parent_model->corpus_index) return;
 
     std::string query = extract_last_user_query(messages);
     if (query.empty()) return;
 
-    std::string rag_context = retrieve_rag_context(handle, query);
+    std::string rag_context = retrieve_rag_context(ctx, query);
     if (rag_context.empty()) return;
 
     if (!messages.empty() && messages[0].role == "system") {
@@ -83,28 +83,28 @@ std::vector<ToolConstraintSpec> build_tool_constraint_specs(const std::vector<To
     return specs;
 }
 
-void strip_thinking_from_cache(CactusModelHandle* handle,
+void strip_thinking_from_cache(CactusContextHandle* ctx,
                                const std::vector<uint32_t>& generated_tokens,
                                size_t prompt_len) {
-    const auto& cfg = handle->model->get_config();
+    const auto& cfg = ctx->model->get_config();
     uint32_t open_id = cfg.channel_open_token_id;
     uint32_t close_id = cfg.channel_close_token_id;
     auto ranges = find_channel_token_ranges(generated_tokens, prompt_len,
                                             open_id, close_id);
     if (ranges.empty()) return;
 
-    handle->model->remove_thinking_tokens(ranges);
+    ctx->model->remove_thinking_tokens(ranges);
     for (auto it = ranges.rbegin(); it != ranges.rend(); ++it) {
-        auto start = handle->processed_tokens.begin() + it->first;
-        handle->processed_tokens.erase(start, start + it->second);
+        auto start = ctx->processed_tokens.begin() + it->first;
+        ctx->processed_tokens.erase(start, start + it->second);
     }
 }
 
-void setup_tool_constraints(CactusModelHandle* handle, const std::vector<ToolFunction>& tools,
+void setup_tool_constraints(CactusContextHandle* ctx, const std::vector<ToolFunction>& tools,
                            bool force_tools, float& temperature) {
     if (!force_tools || tools.empty()) return;
 
-    handle->model->set_tool_constraints(build_tool_constraint_specs(tools));
+    ctx->model->set_tool_constraints(build_tool_constraint_specs(tools));
 
     if (temperature == 0.0f) {
         temperature = 0.01f;
@@ -331,10 +331,10 @@ void trim_stop_suffix(std::vector<uint32_t>& generated_tokens,
     }
 }
 
-void reset_cache(CactusModelHandle* handle) {
-    handle->model->reset_cache();
-    handle->processed_tokens.clear();
-    handle->processed_images.clear();
+void reset_cache(CactusContextHandle* ctx) {
+    ctx->model->reset_cache();
+    ctx->processed_tokens.clear();
+    ctx->processed_images.clear();
 }
 
 struct PrefillResult {
@@ -381,7 +381,7 @@ struct PreparedPrompt {
     std::vector<ToolFunction> tools;
     std::vector<uint32_t> tokens;
     size_t context_token_count = 0;
-    std::vector<std::vector<CactusModelHandle::ProcessedImage>> images;
+    std::vector<std::vector<ProcessedImage>> images;
 
     std::vector<float> audio_features;
     size_t audio_num_frames = 0;
@@ -396,7 +396,7 @@ struct PreparedPrompt {
     }
 };
 
-CactusModelHandle::ProcessedImage image_signature(const std::string& image_path) {
+ProcessedImage image_signature(const std::string& image_path) {
     std::filesystem::path normalized_path(image_path);
     std::error_code ec;
 
@@ -405,7 +405,7 @@ CactusModelHandle::ProcessedImage image_signature(const std::string& image_path)
         normalized_path = absolute_path;
     }
 
-    CactusModelHandle::ProcessedImage image;
+    ProcessedImage image;
     image.path = normalized_path.string();
 
     ec.clear();
@@ -421,12 +421,12 @@ CactusModelHandle::ProcessedImage image_signature(const std::string& image_path)
     return image;
 }
 
-std::vector<std::vector<CactusModelHandle::ProcessedImage>> images_from_message(const std::vector<ChatMessage>& messages) {
-    std::vector<std::vector<CactusModelHandle::ProcessedImage>> message_signatures;
+std::vector<std::vector<ProcessedImage>> images_from_message(const std::vector<ChatMessage>& messages) {
+    std::vector<std::vector<ProcessedImage>> message_signatures;
     message_signatures.reserve(messages.size());
 
     for (const auto& message : messages) {
-        std::vector<CactusModelHandle::ProcessedImage> image_signatures;
+        std::vector<ProcessedImage> image_signatures;
         image_signatures.reserve(message.images.size());
         for (const auto& image_path : message.images) {
             image_signatures.push_back(image_signature(image_path));
@@ -438,39 +438,39 @@ std::vector<std::vector<CactusModelHandle::ProcessedImage>> images_from_message(
 }
 
 bool image_context_prefix_matches(
-    const std::vector<std::vector<CactusModelHandle::ProcessedImage>>& prefix,
-    const std::vector<std::vector<CactusModelHandle::ProcessedImage>>& full
+    const std::vector<std::vector<ProcessedImage>>& prefix,
+    const std::vector<std::vector<ProcessedImage>>& full
 ) {
     return prefix.size() <= full.size() &&
            std::equal(prefix.begin(), prefix.end(), full.begin());
 }
 
 bool prompt_context_matches(
-    const CactusModelHandle* handle,
+    const CactusContextHandle* ctx,
     const PreparedPrompt& prompt
 ) {
-    if (handle->processed_tokens.empty()) {
+    if (ctx->processed_tokens.empty()) {
         return false;
     }
-    if (handle->model &&
-        handle->model->get_config().model_type == Config::ModelType::NEEDLE &&
-        prompt.tokens.size() != handle->processed_tokens.size() + 1) {
+    if (ctx->model &&
+        ctx->model->get_config().model_type == Config::ModelType::NEEDLE &&
+        prompt.tokens.size() != ctx->processed_tokens.size() + 1) {
         return false;
     }
-    if (prompt.context_token_count < handle->processed_tokens.size()) {
+    if (prompt.context_token_count < ctx->processed_tokens.size()) {
         return false;
     }
-    if (!std::equal(handle->processed_tokens.begin(), handle->processed_tokens.end(), prompt.tokens.begin())) {
+    if (!std::equal(ctx->processed_tokens.begin(), ctx->processed_tokens.end(), prompt.tokens.begin())) {
         return false;
     }
     if (prompt.has_images()) {
-        return image_context_prefix_matches(handle->processed_images, prompt.images);
+        return image_context_prefix_matches(ctx->processed_images, prompt.images);
     }
     return !prompt.has_images();
 }
 
 PreparedPrompt prepare_prompt(
-    CactusModelHandle* handle,
+    CactusContextHandle* ctx,
     const char* messages_json,
     const char* options_json,
     const char* tools_json,
@@ -479,7 +479,7 @@ PreparedPrompt prepare_prompt(
     const uint8_t* pcm_buffer = nullptr,
     size_t pcm_buffer_size = 0
 ) {
-    if (!handle || !handle->model) {
+    if (!ctx || !ctx->model) {
         throw std::runtime_error("Invalid model handle");
     }
 
@@ -490,7 +490,7 @@ PreparedPrompt prepare_prompt(
         throw std::runtime_error("No messages provided");
     }
 
-    inject_rag_context(handle, prompt.messages);
+    inject_rag_context(ctx, prompt.messages);
 
     if (tools_json && std::strlen(tools_json) > 0) {
         prompt.tools = parse_tools_json(tools_json);
@@ -499,7 +499,7 @@ PreparedPrompt prepare_prompt(
     if (prompt.options.tool_rag_top_k > 0 && prompt.tools.size() > prompt.options.tool_rag_top_k) {
         std::string query = extract_last_user_query(prompt.messages);
         if (!query.empty()) {
-            prompt.tools = select_relevant_tools(handle, query, prompt.tools, prompt.options.tool_rag_top_k);
+            prompt.tools = select_relevant_tools(ctx, query, prompt.tools, prompt.options.tool_rag_top_k);
         }
     }
 
@@ -508,15 +508,15 @@ PreparedPrompt prepare_prompt(
     }
 
     if (apply_tool_constraints) {
-        setup_tool_constraints(handle, prompt.tools, prompt.options.force_tools, prompt.options.temperature);
+        setup_tool_constraints(ctx, prompt.tools, prompt.options.force_tools, prompt.options.temperature);
     }
 
-    auto* tokenizer = handle->model->get_tokenizer();
+    auto* tokenizer = ctx->model->get_tokenizer();
     if (!tokenizer) {
         throw std::runtime_error("Tokenizer unavailable");
     }
 
-    prompt.model_type = handle->model->get_config().model_type;
+    prompt.model_type = ctx->model->get_config().model_type;
 
     if (prompt.model_type == Config::ModelType::GEMMA4) {
         std::vector<float> audio_samples;
@@ -534,7 +534,7 @@ PreparedPrompt prepare_prompt(
             }
         }
         if (!audio_samples.empty()) {
-            auto audio_prep = cactus::audio::preprocess_audio_for_gemma4(audio_samples, handle->model->get_config());
+            auto audio_prep = cactus::audio::preprocess_audio_for_gemma4(audio_samples, ctx->model->get_config());
             prompt.audio_features = std::move(audio_prep.features);
             prompt.audio_num_frames = audio_prep.num_frames;
             for (auto it = prompt.messages.rbegin(); it != prompt.messages.rend(); ++it) {
@@ -580,16 +580,16 @@ PreparedPrompt prepare_prompt(
 }
 
 PrefillResult do_prefill(
-    CactusModelHandle* handle,
+    CactusContextHandle* ctx,
     const PreparedPrompt& prompt,
     const std::vector<uint32_t>& target_tokens
 ) {
     PrefillResult result = {};
     bool has_images = prompt.has_images();
 
-    result.was_prefix = prompt_context_matches(handle, prompt);
+    result.was_prefix = prompt_context_matches(ctx, prompt);
     result.was_exact_match = result.was_prefix &&
-        target_tokens.size() == handle->processed_tokens.size();
+        target_tokens.size() == ctx->processed_tokens.size();
 
     if (result.was_exact_match) {
         return result;
@@ -597,11 +597,11 @@ PrefillResult do_prefill(
 
     std::vector<uint32_t> tokens_to_process;
     if (!result.was_prefix) {
-        reset_cache(handle);
+        reset_cache(ctx);
         tokens_to_process = target_tokens;
     } else {
         tokens_to_process.assign(
-            target_tokens.begin() + handle->processed_tokens.size(),
+            target_tokens.begin() + ctx->processed_tokens.size(),
             target_tokens.end()
         );
     }
@@ -613,7 +613,7 @@ PrefillResult do_prefill(
             std::vector<std::string> delta_image_paths;
             if (result.was_prefix) {
                 size_t cached_image_count = 0;
-                for (const auto& msg_imgs : handle->processed_images) {
+                for (const auto& msg_imgs : ctx->processed_images) {
                     cached_image_count += msg_imgs.size();
                 }
                 delta_image_paths.assign(
@@ -623,9 +623,9 @@ PrefillResult do_prefill(
             } else {
                 delta_image_paths = prompt.image_paths;
             }
-            handle->model->prefill_with_images(prefill_tokens, delta_image_paths);
+            ctx->model->prefill_with_images(prefill_tokens, delta_image_paths);
         } else {
-            handle->model->prefill(prefill_tokens, handle->model->get_prefill_chunk_size());
+            ctx->model->prefill(prefill_tokens, ctx->model->get_prefill_chunk_size());
         }
         result.remaining_tokens = {tokens_to_process.back()};
     } else {
@@ -646,18 +646,18 @@ uint32_t decode(
 }
 
 uint32_t generate_first_token(
-    CactusModelHandle* handle,
+    CactusContextHandle* ctx,
     const PrefillResult& prefill_result,
     const PreparedPrompt& prompt,
     float* first_token_entropy
 ) {
     if (prefill_result.was_exact_match || prefill_result.remaining_tokens.empty()) {
-        if (handle->processed_tokens.empty()) {
+        if (ctx->processed_tokens.empty()) {
             throw std::runtime_error("Cannot generate from empty prompt");
         }
-        return decode(handle->model, {handle->processed_tokens.back()}, prompt.options, first_token_entropy);
+        return decode(ctx->model, {ctx->processed_tokens.back()}, prompt.options, first_token_entropy);
     }
-    return decode(handle->model, prefill_result.remaining_tokens, prompt.options, first_token_entropy);
+    return decode(ctx->model, prefill_result.remaining_tokens, prompt.options, first_token_entropy);
 }
 
 std::string construct_prefill_response_json(
@@ -685,10 +685,11 @@ std::string construct_prefill_response_json(
 
 } // anonymous namespace
 
-extern "C" {
+// --- _impl functions: shared by model API and context API ---
 
-int cactus_complete(
-    cactus_model_t model,
+int cactus_complete_impl(
+    CactusContextHandle* ctx,
+    const char* model_name,
     const char* messages_json,
     char* response_buffer,
     size_t buffer_size,
@@ -699,7 +700,7 @@ int cactus_complete(
     const uint8_t* pcm_buffer,
     size_t pcm_buffer_size
 ) {
-    if (!model) {
+    if (!ctx || !ctx->model) {
         std::string error_msg = last_error_message.empty() ?
             "Model not initialized. Check model path and files." : last_error_message;
         CACTUS_LOG_ERROR("complete", error_msg);
@@ -713,13 +714,14 @@ int cactus_complete(
         return -1;
     }
 
+    const char* telemetry_name = model_name ? model_name : "unknown";
+
     try {
         auto start_time = std::chrono::high_resolution_clock::now();
 
-        auto* handle = static_cast<CactusModelHandle*>(model);
-        handle->should_stop = false;
-        auto* tokenizer = handle->model->get_tokenizer();
-        auto prompt = prepare_prompt(handle, messages_json, options_json, tools_json, true, true, pcm_buffer, pcm_buffer_size);
+        ctx->should_stop = false;
+        auto* tokenizer = ctx->model->get_tokenizer();
+        auto prompt = prepare_prompt(ctx, messages_json, options_json, tools_json, true, true, pcm_buffer, pcm_buffer_size);
 
         CACTUS_LOG_DEBUG("complete", "Prompt tokens: " << prompt.tokens.size()
             << ", max_tokens: " << prompt.options.max_tokens);
@@ -737,19 +739,19 @@ int cactus_complete(
 
         if (has_audio) {
             prompt_tokens = prompt.tokens.size();
-            next_token = handle->model->decode_with_audio(
+            next_token = ctx->model->decode_with_audio(
                 prompt.tokens, prompt.audio_features,
                 prompt.options.temperature, prompt.options.top_p, prompt.options.top_k,
                 "", &first_token_entropy,
                 prompt.options.min_p, prompt.options.repetition_penalty);
         } else {
-            auto prefill_result = do_prefill(handle, prompt, prompt.tokens);
+            auto prefill_result = do_prefill(ctx, prompt, prompt.tokens);
             prompt_tokens = prefill_result.prefilled_count + prefill_result.remaining_tokens.size();
-            next_token = generate_first_token(handle, prefill_result, prompt, &first_token_entropy);
+            next_token = generate_first_token(ctx, prefill_result, prompt, &first_token_entropy);
         }
 
-        handle->processed_tokens = prompt.tokens;
-        handle->processed_images = prompt.images;
+        ctx->processed_tokens = prompt.tokens;
+        ctx->processed_images = prompt.images;
 
         auto token_end = std::chrono::high_resolution_clock::now();
         time_to_first_token = std::chrono::duration_cast<std::chrono::microseconds>(token_end - start_time).count() / 1000.0;
@@ -785,10 +787,10 @@ int cactus_complete(
         }
 
         generated_tokens.push_back(next_token);
-        handle->processed_tokens.push_back(next_token);
+        ctx->processed_tokens.push_back(next_token);
 
         if (prompt.options.force_tools && !prompt.tools.empty()) {
-            handle->model->update_tool_constraints(next_token);
+            ctx->model->update_tool_constraints(next_token);
         }
 
         EntropyState entropy;
@@ -801,19 +803,19 @@ int cactus_complete(
             }
 
             for (size_t i = 1; i < prompt.options.max_tokens; i++) {
-                if (handle->should_stop) break;
+                if (ctx->should_stop) break;
 
                 float token_entropy = 0.0f;
                 if (has_audio) {
-                    next_token = handle->model->decode_with_audio(
-                        handle->processed_tokens, prompt.audio_features,
+                    next_token = ctx->model->decode_with_audio(
+                        ctx->processed_tokens, prompt.audio_features,
                         prompt.options.temperature, prompt.options.top_p, prompt.options.top_k,
                         "", &token_entropy,
                         prompt.options.min_p, prompt.options.repetition_penalty);
                 } else {
-                    next_token = decode(handle->model, {next_token}, prompt.options, &token_entropy);
+                    next_token = decode(ctx->model, {next_token}, prompt.options, &token_entropy);
                 }
-                handle->processed_tokens.push_back(next_token);
+                ctx->processed_tokens.push_back(next_token);
                 generated_tokens.push_back(next_token);
 
                 entropy.add(token_entropy);
@@ -824,7 +826,7 @@ int cactus_complete(
                 }
 
                 if (prompt.options.force_tools && !prompt.tools.empty()) {
-                    handle->model->update_tool_constraints(next_token);
+                    ctx->model->update_tool_constraints(next_token);
                 }
 
                 if (matches_stop_sequence(generated_tokens, stop_token_sequences)) {
@@ -844,15 +846,15 @@ int cactus_complete(
         confidence = entropy.mean_confidence();
 
         if (prompt.options.force_tools && !prompt.tools.empty()) {
-            handle->model->clear_tool_constraints();
+            ctx->model->clear_tool_constraints();
         }
 
         if (prompt.model_type == Config::ModelType::GEMMA4 && prompt.options.enable_thinking_if_supported && !generated_tokens.empty()) {
-            strip_thinking_from_cache(handle, generated_tokens, prompt.tokens.size());
+            strip_thinking_from_cache(ctx, generated_tokens, prompt.tokens.size());
         }
 
         if (prompt.model_type == Config::ModelType::GEMMA4) {
-            handle->model->compact_kv_cache();
+            ctx->model->compact_kv_cache();
         }
 
         auto end_time = std::chrono::high_resolution_clock::now();
@@ -939,7 +941,7 @@ int cactus_complete(
         metrics.decode_tokens = completion_tokens;
         metrics.error_message = nullptr;
         metrics.function_calls_json = nullptr;
-        cactus::telemetry::recordCompletion(handle->model_name.c_str(), metrics);
+        cactus::telemetry::recordCompletion(telemetry_name, metrics);
 
         return static_cast<int>(result.length());
 
@@ -960,8 +962,7 @@ int cactus_complete(
         metrics.decode_tokens = 0;
         metrics.error_message = e.what();
         metrics.function_calls_json = nullptr;
-        auto* h = static_cast<CactusModelHandle*>(model);
-        cactus::telemetry::recordCompletion(h ? h->model_name.c_str() : "unknown", metrics);
+        cactus::telemetry::recordCompletion(telemetry_name, metrics);
 
         return -1;
     } catch (...) {
@@ -981,15 +982,15 @@ int cactus_complete(
         metrics.decode_tokens = 0;
         metrics.error_message = "Unknown error during completion";
         metrics.function_calls_json = nullptr;
-        auto* h = static_cast<CactusModelHandle*>(model);
-        cactus::telemetry::recordCompletion(h ? h->model_name.c_str() : "unknown", metrics);
+        cactus::telemetry::recordCompletion(telemetry_name, metrics);
 
         return -1;
     }
 }
 
-int cactus_prefill(
-    cactus_model_t model,
+int cactus_prefill_impl(
+    CactusContextHandle* ctx,
+    const char* model_name,
     const char* messages_json,
     char* response_buffer,
     size_t buffer_size,
@@ -998,7 +999,9 @@ int cactus_prefill(
     const uint8_t* pcm_buffer,
     size_t pcm_buffer_size
 ) {
-    if (!model) {
+    (void)model_name; // reserved for future telemetry
+
+    if (!ctx || !ctx->model) {
         std::string error_msg = last_error_message.empty()
             ? "Model not initialized. Check model path and files."
             : last_error_message;
@@ -1025,19 +1028,18 @@ int cactus_prefill(
     try {
         auto start_time = std::chrono::high_resolution_clock::now();
 
-        auto* handle = static_cast<CactusModelHandle*>(model);
-        auto prompt = prepare_prompt(handle, messages_json, options_json, tools_json, false, false, pcm_buffer, pcm_buffer_size);
+        auto prompt = prepare_prompt(ctx, messages_json, options_json, tools_json, false, false, pcm_buffer, pcm_buffer_size);
 
         std::vector<uint32_t> context_tokens(prompt.tokens.begin(), prompt.tokens.begin() + prompt.context_token_count);
-        auto prefill_result = do_prefill(handle, prompt, context_tokens);
+        auto prefill_result = do_prefill(ctx, prompt, context_tokens);
 
         if (!prefill_result.was_exact_match) {
-            handle->processed_tokens = context_tokens;
-            if (!handle->processed_tokens.empty()) {
-                handle->processed_tokens.pop_back();
+            ctx->processed_tokens = context_tokens;
+            if (!ctx->processed_tokens.empty()) {
+                ctx->processed_tokens.pop_back();
             }
         }
-        handle->processed_images = prompt.images;
+        ctx->processed_images = prompt.images;
 
         auto end_time = std::chrono::high_resolution_clock::now();
         double elapsed_ms = std::chrono::duration_cast<std::chrono::microseconds>(end_time - start_time).count() / 1000.0;
@@ -1074,6 +1076,63 @@ int cactus_prefill(
     }
 }
 
+// --- C API wrappers delegating to _impl ---
+
+extern "C" {
+
+int cactus_complete(
+    cactus_model_t model,
+    const char* messages_json,
+    char* response_buffer,
+    size_t buffer_size,
+    const char* options_json,
+    const char* tools_json,
+    cactus_token_callback callback,
+    void* user_data,
+    const uint8_t* pcm_buffer,
+    size_t pcm_buffer_size
+) {
+    if (!model) {
+        std::string error_msg = last_error_message.empty() ?
+            "Model not initialized. Check model path and files." : last_error_message;
+        CACTUS_LOG_ERROR("complete", error_msg);
+        handle_error_response(error_msg, response_buffer, buffer_size);
+        return -1;
+    }
+    auto* handle = static_cast<CactusModelHandle*>(model);
+    return cactus_complete_impl(&handle->default_context, handle->model_name.c_str(),
+        messages_json, response_buffer, buffer_size, options_json, tools_json,
+        callback, user_data, pcm_buffer, pcm_buffer_size);
+}
+
+int cactus_prefill(
+    cactus_model_t model,
+    const char* messages_json,
+    char* response_buffer,
+    size_t buffer_size,
+    const char* options_json,
+    const char* tools_json,
+    const uint8_t* pcm_buffer,
+    size_t pcm_buffer_size
+) {
+    if (!model) {
+        std::string error_msg = last_error_message.empty()
+            ? "Model not initialized. Check model path and files."
+            : last_error_message;
+        if (response_buffer && buffer_size > 0) {
+            std::string result = construct_prefill_response_json(false, &error_msg, 0, 0.0, 0.0);
+            if (result.size() < buffer_size) {
+                std::strcpy(response_buffer, result.c_str());
+            }
+        }
+        return -1;
+    }
+    auto* handle = static_cast<CactusModelHandle*>(model);
+    return cactus_prefill_impl(&handle->default_context, handle->model_name.c_str(),
+        messages_json, response_buffer, buffer_size, options_json, tools_json,
+        pcm_buffer, pcm_buffer_size);
+}
+
 int cactus_tokenize(
     cactus_model_t model,
     const char* text,
@@ -1085,7 +1144,7 @@ int cactus_tokenize(
 
     try {
         auto* handle = static_cast<CactusModelHandle*>(model);
-        auto* tokenizer = handle->model->get_tokenizer();
+        auto* tokenizer = handle->default_context.model->get_tokenizer();
 
         std::vector<uint32_t> toks = tokenizer->encode(std::string(text));
         *out_token_len = toks.size();
@@ -1121,7 +1180,7 @@ int cactus_score_window(
         std::vector<uint32_t> vec(tokens, tokens + token_len);
 
         size_t scored = 0;
-        double logprob = handle->model->score_tokens_window_logprob(vec, start, end, context, &scored);
+        double logprob = handle->default_context.model->score_tokens_window_logprob(vec, start, end, context, &scored);
 
         std::ostringstream oss;
         oss << "{"

--- a/cactus/ffi/cactus_context.cpp
+++ b/cactus/ffi/cactus_context.cpp
@@ -1,0 +1,136 @@
+#include "cactus_ffi.h"
+#include "cactus_utils.h"
+#include <string>
+
+using namespace cactus::engine;
+using namespace cactus::ffi;
+
+static constexpr size_t DEFAULT_CONTEXT_SIZE = 512;
+
+extern "C" {
+
+cactus_context_t cactus_context_create(cactus_model_t model) {
+    if (!model) {
+        last_error_message = "Cannot create context: model is null";
+        CACTUS_LOG_ERROR("context", last_error_message);
+        return nullptr;
+    }
+
+    auto* parent = static_cast<CactusModelHandle*>(model);
+
+    try {
+        auto ctx = std::make_unique<CactusContextHandle>();
+        ctx->parent_model = parent;
+        ctx->model = create_model(parent->model_path);
+
+        if (!ctx->model) {
+            last_error_message = "Failed to create model for context - check config.txt at: " + parent->model_path;
+            CACTUS_LOG_ERROR("context", last_error_message);
+            return nullptr;
+        }
+
+        if (!ctx->model->init(parent->model_path, DEFAULT_CONTEXT_SIZE)) {
+            last_error_message = "Failed to initialize model for context - check weight files at: " + parent->model_path;
+            CACTUS_LOG_ERROR("context", last_error_message);
+            return nullptr;
+        }
+
+        CACTUS_LOG_INFO("context", "Created new context for model: " << parent->model_name);
+        return ctx.release();
+    } catch (const std::exception& e) {
+        last_error_message = "Exception creating context: " + std::string(e.what());
+        CACTUS_LOG_ERROR("context", last_error_message);
+        return nullptr;
+    } catch (...) {
+        last_error_message = "Unknown exception creating context";
+        CACTUS_LOG_ERROR("context", last_error_message);
+        return nullptr;
+    }
+}
+
+void cactus_context_destroy(cactus_context_t ctx) {
+    if (ctx) delete static_cast<CactusContextHandle*>(ctx);
+}
+
+void cactus_context_reset(cactus_context_t ctx) {
+    if (!ctx) return;
+    auto* handle = static_cast<CactusContextHandle*>(ctx);
+    handle->model->reset_cache();
+    handle->processed_tokens.clear();
+    handle->processed_images.clear();
+}
+
+void cactus_context_stop(cactus_context_t ctx) {
+    if (!ctx) return;
+    auto* handle = static_cast<CactusContextHandle*>(ctx);
+    handle->should_stop = true;
+}
+
+int cactus_context_complete(
+    cactus_context_t ctx,
+    const char* messages_json,
+    char* response_buffer,
+    size_t buffer_size,
+    const char* options_json,
+    const char* tools_json,
+    cactus_token_callback callback,
+    void* user_data,
+    const uint8_t* pcm_buffer,
+    size_t pcm_buffer_size
+) {
+    if (!ctx) {
+        handle_error_response("Context is null", response_buffer, buffer_size);
+        return -1;
+    }
+    auto* handle = static_cast<CactusContextHandle*>(ctx);
+    const char* model_name = handle->parent_model ? handle->parent_model->model_name.c_str() : "unknown";
+    return cactus_complete_impl(handle, model_name,
+        messages_json, response_buffer, buffer_size, options_json, tools_json,
+        callback, user_data, pcm_buffer, pcm_buffer_size);
+}
+
+int cactus_context_prefill(
+    cactus_context_t ctx,
+    const char* messages_json,
+    char* response_buffer,
+    size_t buffer_size,
+    const char* options_json,
+    const char* tools_json,
+    const uint8_t* pcm_buffer,
+    size_t pcm_buffer_size
+) {
+    if (!ctx) {
+        handle_error_response("Context is null", response_buffer, buffer_size);
+        return -1;
+    }
+    auto* handle = static_cast<CactusContextHandle*>(ctx);
+    const char* model_name = handle->parent_model ? handle->parent_model->model_name.c_str() : "unknown";
+    return cactus_prefill_impl(handle, model_name,
+        messages_json, response_buffer, buffer_size, options_json, tools_json,
+        pcm_buffer, pcm_buffer_size);
+}
+
+int cactus_context_transcribe(
+    cactus_context_t ctx,
+    const char* audio_file_path,
+    const char* prompt,
+    char* response_buffer,
+    size_t buffer_size,
+    const char* options_json,
+    cactus_token_callback callback,
+    void* user_data,
+    const uint8_t* pcm_buffer,
+    size_t pcm_buffer_size
+) {
+    if (!ctx) {
+        handle_error_response("Context is null", response_buffer, buffer_size);
+        return -1;
+    }
+    auto* handle = static_cast<CactusContextHandle*>(ctx);
+    const char* model_name = handle->parent_model ? handle->parent_model->model_name.c_str() : "unknown";
+    return cactus_transcribe_impl(handle, handle->parent_model, model_name,
+        audio_file_path, prompt, response_buffer, buffer_size, options_json,
+        callback, user_data, pcm_buffer, pcm_buffer_size);
+}
+
+}

--- a/cactus/ffi/cactus_diarize.cpp
+++ b/cactus/ffi/cactus_diarize.cpp
@@ -117,7 +117,7 @@ int cactus_diarize(
     try {
         auto start_time = std::chrono::high_resolution_clock::now();
         auto* handle = static_cast<CactusModelHandle*>(model);
-        auto* pyannote = dynamic_cast<PyAnnoteModel*>(handle->model.get());
+        auto* pyannote = dynamic_cast<PyAnnoteModel*>(handle->default_context.model.get());
         if (!pyannote) {
             CACTUS_LOG_ERROR("diarize", "Model is not a PyAnnote diarization model");
             handle_error_response("Model is not a PyAnnote diarization model", response_buffer, buffer_size);

--- a/cactus/ffi/cactus_embed.cpp
+++ b/cactus/ffi/cactus_embed.cpp
@@ -65,7 +65,7 @@ int cactus_embed(
 
     try {
         auto* handle = static_cast<CactusModelHandle*>(model);
-        auto* tokenizer = handle->model->get_tokenizer();
+        auto* tokenizer = handle->default_context.model->get_tokenizer();
 
         std::vector<uint32_t> tokens = tokenizer->encode(text);
         if (tokens.empty()) {
@@ -73,7 +73,7 @@ int cactus_embed(
             return -1;
         }
 
-        std::vector<float> embeddings = handle->model->get_embeddings(tokens, true, normalize);
+        std::vector<float> embeddings = handle->default_context.model->get_embeddings(tokens, true, normalize);
         if (embeddings.size() * sizeof(float) > buffer_size) {
             CACTUS_LOG_ERROR("embed", "Buffer too small: need " << embeddings.size() * sizeof(float) << " bytes, got " << buffer_size);
             return -2;
@@ -111,7 +111,7 @@ int cactus_image_embed(
         auto* handle = static_cast<CactusModelHandle*>(model);
 
         CACTUS_LOG_DEBUG("image_embed", "Processing image: " << image_path);
-        std::vector<float> embeddings = handle->model->get_image_embeddings(image_path);
+        std::vector<float> embeddings = handle->default_context.model->get_image_embeddings(image_path);
         if (embeddings.empty()) {
             CACTUS_LOG_ERROR("image_embed", "Image embedding returned empty result");
             return -1;
@@ -154,16 +154,16 @@ int cactus_audio_embed(
 
         CACTUS_LOG_DEBUG("audio_embed", "Processing audio: " << audio_path);
         const bool is_parakeet =
-            handle->model->get_config().model_type == cactus::engine::Config::ModelType::PARAKEET ||
-            handle->model->get_config().model_type == cactus::engine::Config::ModelType::PARAKEET_TDT;
-        auto mel_bins = compute_mel_from_wav(audio_path, is_parakeet, handle->model->get_config().num_mel_bins);
+            handle->default_context.model->get_config().model_type == cactus::engine::Config::ModelType::PARAKEET ||
+            handle->default_context.model->get_config().model_type == cactus::engine::Config::ModelType::PARAKEET_TDT;
+        auto mel_bins = compute_mel_from_wav(audio_path, is_parakeet, handle->default_context.model->get_config().num_mel_bins);
         if (mel_bins.empty()) {
             last_error_message = "Failed to compute mel spectrogram";
             CACTUS_LOG_ERROR("audio_embed", last_error_message << " for: " << audio_path);
             return -1;
         }
 
-        std::vector<float> embeddings = handle->model->get_audio_embeddings(mel_bins);
+        std::vector<float> embeddings = handle->default_context.model->get_audio_embeddings(mel_bins);
         if (embeddings.empty()) {
             CACTUS_LOG_ERROR("audio_embed", "Audio embedding returned empty result");
             return -1;

--- a/cactus/ffi/cactus_embed_speaker.cpp
+++ b/cactus/ffi/cactus_embed_speaker.cpp
@@ -29,7 +29,7 @@ int cactus_embed_speaker(
     try {
         auto start_time = std::chrono::high_resolution_clock::now();
         auto* handle = static_cast<CactusModelHandle*>(model);
-        auto* wespeaker = dynamic_cast<WeSpeakerModel*>(handle->model.get());
+        auto* wespeaker = dynamic_cast<WeSpeakerModel*>(handle->default_context.model.get());
         if (!wespeaker) {
             CACTUS_LOG_ERROR("embed_speaker", "Model is not a WeSpeaker embedding model");
             handle_error_response("Model is not a WeSpeaker embedding model", response_buffer, buffer_size);

--- a/cactus/ffi/cactus_ffi.h
+++ b/cactus/ffi/cactus_ffi.h
@@ -18,10 +18,63 @@ extern "C" {
 #endif
 
 typedef void* cactus_model_t;
+typedef void* cactus_context_t;
 typedef void* cactus_index_t;
 typedef void* cactus_stream_transcribe_t;
 
 typedef void (*cactus_token_callback)(const char* token, uint32_t token_id, void* user_data);
+
+// Context API — explicit session lifecycle, preferred for new callers.
+// Each context owns its own KV cache and session state.
+// Destroying a context cleans up all session state by construction.
+CACTUS_FFI_EXPORT cactus_context_t cactus_context_create(cactus_model_t model);
+CACTUS_FFI_EXPORT void cactus_context_destroy(cactus_context_t ctx);
+CACTUS_FFI_EXPORT void cactus_context_reset(cactus_context_t ctx);
+CACTUS_FFI_EXPORT void cactus_context_stop(cactus_context_t ctx);
+
+CACTUS_FFI_EXPORT int cactus_context_complete(
+    cactus_context_t ctx,
+    const char* messages_json,
+    char* response_buffer,
+    size_t buffer_size,
+    const char* options_json,
+    const char* tools_json,
+    cactus_token_callback callback,
+    void* user_data,
+    const uint8_t* pcm_buffer,
+    size_t pcm_buffer_size
+);
+
+CACTUS_FFI_EXPORT int cactus_context_prefill(
+    cactus_context_t ctx,
+    const char* messages_json,
+    char* response_buffer,
+    size_t buffer_size,
+    const char* options_json,
+    const char* tools_json,
+    const uint8_t* pcm_buffer,
+    size_t pcm_buffer_size
+);
+
+CACTUS_FFI_EXPORT int cactus_context_transcribe(
+    cactus_context_t ctx,
+    const char* audio_file_path,
+    const char* prompt,
+    char* response_buffer,
+    size_t buffer_size,
+    const char* options_json,
+    cactus_token_callback callback,
+    void* user_data,
+    const uint8_t* pcm_buffer,
+    size_t pcm_buffer_size
+);
+
+CACTUS_FFI_EXPORT cactus_stream_transcribe_t cactus_context_stream_transcribe_start(
+    cactus_context_t ctx,
+    const char* options_json                // optional
+);
+
+// Model API — backwards-compatible, uses an internal default context.
 
 CACTUS_FFI_EXPORT cactus_model_t cactus_init(
     const char* model_path,

--- a/cactus/ffi/cactus_init.cpp
+++ b/cactus/ffi/cactus_init.cpp
@@ -214,7 +214,7 @@ static std::vector<std::pair<std::string, std::string>> chunk_corpus(
 static bool build_corpus_index(CactusModelHandle* handle, const std::string& corpus_dir) {
     CACTUS_LOG_INFO("init", "Building corpus index from: " << corpus_dir);
 
-    auto* tokenizer = handle->model->get_tokenizer();
+    auto* tokenizer = handle->default_context.model->get_tokenizer();
     if (!tokenizer) {
         CACTUS_LOG_ERROR("init", "No tokenizer available for corpus indexing");
         return false;
@@ -237,7 +237,7 @@ static bool build_corpus_index(CactusModelHandle* handle, const std::string& cor
     CACTUS_LOG_INFO("init", "Generated " << chunks.size() << " chunks from corpus");
 
     std::vector<uint32_t> test_tokens = tokenizer->encode("test");
-    std::vector<float> test_embedding = handle->model->get_embeddings(test_tokens, true, true);
+    std::vector<float> test_embedding = handle->default_context.model->get_embeddings(test_tokens, true, true);
     if (test_embedding.empty()) {
         CACTUS_LOG_ERROR("init", "Failed to get embedding dimension");
         return false;
@@ -267,7 +267,7 @@ static bool build_corpus_index(CactusModelHandle* handle, const std::string& cor
         const auto& [chunk_text, source_file] = chunks[i];
 
         std::vector<uint32_t> tokens = tokenizer->encode(chunk_text);
-        std::vector<float> embedding = handle->model->get_embeddings(tokens, true, true);
+        std::vector<float> embedding = handle->default_context.model->get_embeddings(tokens, true, true);
 
         if (embedding.size() != embedding_dim) {
             CACTUS_LOG_WARN("init", "Skipping chunk " << i << " - embedding dimension mismatch");
@@ -315,9 +315,9 @@ static bool load_corpus_index(CactusModelHandle* handle, const std::string& corp
         return false;
     }
 
-    auto* tokenizer = handle->model->get_tokenizer();
+    auto* tokenizer = handle->default_context.model->get_tokenizer();
     std::vector<uint32_t> test_tokens = tokenizer->encode("test");
-    std::vector<float> test_embedding = handle->model->get_embeddings(test_tokens, true, true);
+    std::vector<float> test_embedding = handle->default_context.model->get_embeddings(test_tokens, true, true);
     if (test_embedding.empty()) {
         CACTUS_LOG_ERROR("init", "Failed to get embedding dimension for index loading");
         return false;
@@ -375,10 +375,11 @@ cactus_model_t cactus_init(const char* model_path, const char* corpus_dir, bool 
 
     try {
         auto* handle = new CactusModelHandle();
-        handle->model = create_model(model_path);
+        handle->model_path = model_path_str;
+        handle->default_context.model = create_model(model_path);
         handle->model_name = model_name;
 
-        if (!handle->model) {
+        if (!handle->default_context.model) {
             last_error_message = "Failed to create model - check config.txt exists at: " + model_path_str;
             CACTUS_LOG_ERROR("init", last_error_message);
             {
@@ -389,7 +390,7 @@ cactus_model_t cactus_init(const char* model_path, const char* corpus_dir, bool 
             return nullptr;
         }
 
-        if (!handle->model->init(model_path, DEFAULT_CONTEXT_SIZE)) {
+        if (!handle->default_context.model->init(model_path, DEFAULT_CONTEXT_SIZE)) {
             last_error_message = "Failed to initialize model - check weight files at: " + model_path_str;
             CACTUS_LOG_ERROR("init", last_error_message);
             {
@@ -400,7 +401,7 @@ cactus_model_t cactus_init(const char* model_path, const char* corpus_dir, bool 
             return nullptr;
         }
 
-        auto model_type = handle->model->get_config().model_type;
+        auto model_type = handle->default_context.model->get_config().model_type;
         if (model_type == Config::ModelType::WHISPER ||
             model_type == Config::ModelType::MOONSHINE ||
             model_type == Config::ModelType::PARAKEET ||
@@ -470,15 +471,15 @@ void cactus_destroy(cactus_model_t model) {
 void cactus_reset(cactus_model_t model) {
     if (!model) return;
     auto* handle = static_cast<CactusModelHandle*>(model);
-    handle->model->reset_cache();
-    handle->processed_tokens.clear();
-    handle->processed_images.clear();
+    handle->default_context.model->reset_cache();
+    handle->default_context.processed_tokens.clear();
+    handle->default_context.processed_images.clear();
 }
 
 void cactus_stop(cactus_model_t model) {
     if (!model) return;
     auto* handle = static_cast<CactusModelHandle*>(model);
-    handle->should_stop = true;
+    handle->default_context.should_stop = true;
 }
 
 }

--- a/cactus/ffi/cactus_rag.cpp
+++ b/cactus/ffi/cactus_rag.cpp
@@ -113,18 +113,19 @@ static float compute_bm25_score(
     return score;
 }
 
-std::string retrieve_rag_context(CactusModelHandle* handle, const std::string& query) {
+std::string retrieve_rag_context(CactusContextHandle* ctx, const std::string& query) {
+    auto* handle = ctx->parent_model;
     if (!handle->corpus_index || handle->corpus_embedding_dim == 0) {
         return "";
     }
 
-    auto* tokenizer = handle->model->get_tokenizer();
+    auto* tokenizer = ctx->model->get_tokenizer();
     if (!tokenizer) return "";
 
     std::vector<uint32_t> query_tokens = tokenizer->encode(query);
     if (query_tokens.empty()) return "";
 
-    std::vector<float> query_embedding = handle->model->get_embeddings(query_tokens, true, true);
+    std::vector<float> query_embedding = ctx->model->get_embeddings(query_tokens, true, true);
     if (query_embedding.size() != handle->corpus_embedding_dim) {
         CACTUS_LOG_WARN("rag", "Query embedding dimension mismatch");
         return "";
@@ -221,28 +222,28 @@ static float cosine_similarity(const std::vector<float>& a, const std::vector<fl
 }
 
 std::vector<cactus::ffi::ToolFunction> select_relevant_tools(
-    CactusModelHandle* handle,
+    CactusContextHandle* ctx,
     const std::string& query,
     const std::vector<cactus::ffi::ToolFunction>& all_tools,
     size_t top_k
 ) {
     using cactus::ffi::ToolFunction;
-    if (!handle || all_tools.empty() || top_k == 0) return all_tools;
+    if (!ctx || all_tools.empty() || top_k == 0) return all_tools;
 
     // If we have fewer tools than top_k, just return all
     if (all_tools.size() <= top_k) return all_tools;
 
-    auto* tokenizer = handle->model->get_tokenizer();
+    auto* tokenizer = ctx->model->get_tokenizer();
     if (!tokenizer) {
         CACTUS_LOG_WARN("tool_rag", "No tokenizer available, returning all tools");
         return all_tools;
     }
 
     // Build tool texts and embeddings if not cached or tool set changed
-    bool need_recompute = (handle->tool_texts.size() != all_tools.size());
+    bool need_recompute = (ctx->tool_texts.size() != all_tools.size());
     if (!need_recompute) {
         for (size_t i = 0; i < all_tools.size(); ++i) {
-            if (tool_to_text(all_tools[i]) != handle->tool_texts[i]) {
+            if (tool_to_text(all_tools[i]) != ctx->tool_texts[i]) {
                 need_recompute = true;
                 break;
             }
@@ -251,21 +252,21 @@ std::vector<cactus::ffi::ToolFunction> select_relevant_tools(
 
     if (need_recompute) {
         CACTUS_LOG_DEBUG("tool_rag", "Computing embeddings for " << all_tools.size() << " tools");
-        handle->tool_texts.clear();
-        handle->tool_embeddings.clear();
-        handle->tool_texts.reserve(all_tools.size());
-        handle->tool_embeddings.reserve(all_tools.size());
+        ctx->tool_texts.clear();
+        ctx->tool_embeddings.clear();
+        ctx->tool_texts.reserve(all_tools.size());
+        ctx->tool_embeddings.reserve(all_tools.size());
 
         for (const auto& tool : all_tools) {
             std::string text = tool_to_text(tool);
-            handle->tool_texts.push_back(text);
+            ctx->tool_texts.push_back(text);
 
             std::vector<uint32_t> tokens = tokenizer->encode(text);
             if (!tokens.empty()) {
-                std::vector<float> emb = handle->model->get_embeddings(tokens, true, true);
-                handle->tool_embeddings.push_back(std::move(emb));
+                std::vector<float> emb = ctx->model->get_embeddings(tokens, true, true);
+                ctx->tool_embeddings.push_back(std::move(emb));
             } else {
-                handle->tool_embeddings.push_back({});
+                ctx->tool_embeddings.push_back({});
             }
         }
     }
@@ -277,7 +278,7 @@ std::vector<cactus::ffi::ToolFunction> select_relevant_tools(
         return all_tools;
     }
 
-    std::vector<float> query_embedding = handle->model->get_embeddings(query_tokens, true, true);
+    std::vector<float> query_embedding = ctx->model->get_embeddings(query_tokens, true, true);
     if (query_embedding.empty()) {
         CACTUS_LOG_WARN("tool_rag", "Failed to get query embedding, returning all tools");
         return all_tools;
@@ -287,7 +288,7 @@ std::vector<cactus::ffi::ToolFunction> select_relevant_tools(
 
     float total_len = 0.0f;
     std::unordered_map<std::string, int> doc_freqs;
-    for (const auto& text : handle->tool_texts) {
+    for (const auto& text : ctx->tool_texts) {
         auto words = tokenize_words(text);
         total_len += words.size();
         std::unordered_set<std::string> unique_words(words.begin(), words.end());
@@ -295,18 +296,18 @@ std::vector<cactus::ffi::ToolFunction> select_relevant_tools(
             doc_freqs[w]++;
         }
     }
-    float avg_doc_len = total_len / handle->tool_texts.size();
+    float avg_doc_len = total_len / ctx->tool_texts.size();
 
     std::vector<std::pair<float, size_t>> emb_ranked;
-    for (size_t i = 0; i < handle->tool_embeddings.size(); ++i) {
-        float sim = cosine_similarity(query_embedding, handle->tool_embeddings[i]);
+    for (size_t i = 0; i < ctx->tool_embeddings.size(); ++i) {
+        float sim = cosine_similarity(query_embedding, ctx->tool_embeddings[i]);
         emb_ranked.emplace_back(sim, i);
     }
 
     std::vector<std::pair<float, size_t>> bm25_ranked;
-    for (size_t i = 0; i < handle->tool_texts.size(); ++i) {
+    for (size_t i = 0; i < ctx->tool_texts.size(); ++i) {
         float bm25 = compute_bm25_score(
-            query_words, handle->tool_texts[i], avg_doc_len, doc_freqs, handle->tool_texts.size()
+            query_words, ctx->tool_texts[i], avg_doc_len, doc_freqs, ctx->tool_texts.size()
         );
         bm25_ranked.emplace_back(bm25, i);
     }
@@ -347,7 +348,7 @@ int cactus_rag_query(
     }
 
     try {
-        auto* tokenizer = handle->model->get_tokenizer();
+        auto* tokenizer = handle->default_context.model->get_tokenizer();
         if (!tokenizer) {
             std::strcpy(response_buffer, "{\"chunks\":[],\"error\":\"No tokenizer\"}");
             return 0;
@@ -359,7 +360,7 @@ int cactus_rag_query(
             return 0;
         }
 
-        std::vector<float> query_embedding = handle->model->get_embeddings(query_tokens, true, true);
+        std::vector<float> query_embedding = handle->default_context.model->get_embeddings(query_tokens, true, true);
         if (query_embedding.size() != handle->corpus_embedding_dim) {
             std::strcpy(response_buffer, "{\"chunks\":[],\"error\":\"Embedding dimension mismatch\"}");
             return 0;

--- a/cactus/ffi/cactus_stream.cpp
+++ b/cactus/ffi/cactus_stream.cpp
@@ -213,6 +213,12 @@ static size_t parakeet_tdt_pcm_bytes_to_encoder_frames(
 
 struct CactusStreamTranscribeHandle {
     CactusModelHandle* model_handle;
+    CactusContextHandle* context_override = nullptr;  // if set, use this context instead of default_context
+
+    // Returns the active context — either the explicit context or the model's default.
+    CactusContextHandle* active_context() const {
+        return context_override ? context_override : &model_handle->default_context;
+    }
 
     struct CactusStreamTranscribeOptions {
         double confirmation_threshold;
@@ -340,7 +346,7 @@ static bool run_stream_window_transcribe(
         return false;
     }
 
-    const auto model_type = handle->model_handle->model->get_config().model_type;
+    const auto model_type = handle->active_context()->model->get_config().model_type;
     const bool use_model_stream_mode =
         model_type != cactus::engine::Config::ModelType::PARAKEET_TDT;
     cactus::telemetry::setStreamMode(use_model_stream_mode);
@@ -381,7 +387,7 @@ static bool run_parakeet_tdt_chunk_decode(
     size_t chunk_end_bytes,
     cactus::engine::ParakeetTDTModel::ChunkStreamResult& out,
     cactus::engine::ParakeetTDTModel::ChunkStreamState& out_state) {
-    if (!handle || !handle->model_handle || !handle->model_handle->model) {
+    if (!handle || !handle->model_handle || !handle->active_context()->model) {
         return false;
     }
     if (chunk_end_bytes <= chunk_start_bytes ||
@@ -393,7 +399,7 @@ static bool run_parakeet_tdt_chunk_decode(
     }
 
     auto* model = static_cast<cactus::engine::ParakeetTDTModel*>(
-        handle->model_handle->model.get());
+        handle->active_context()->model.get());
     size_t replay_start_bytes = window_start_bytes;
     cactus::engine::ParakeetTDTModel::ChunkStreamState base_state;
     bool found_checkpoint = false;
@@ -922,7 +928,7 @@ cactus_stream_transcribe_t cactus_stream_transcribe_start(cactus_model_t model, 
 
     try {
         auto* model_handle = static_cast<CactusModelHandle*>(model);
-        if (!model_handle->model) {
+        if (!model_handle->default_context.model) {
             last_error_message = "Invalid model handle.";
             CACTUS_LOG_ERROR("stream_transcribe_start", last_error_message);
             return nullptr;
@@ -958,27 +964,27 @@ cactus_stream_transcribe_t cactus_stream_transcribe_start(cactus_model_t model, 
         stream_handle->options = { confirmation_threshold, min_chunk_size, language };
         stream_handle->transcribe_options_json = options_json ? options_json : "";
         stream_handle->parakeet_tdt_chunked_stream =
-            model_handle->model->get_config().model_type ==
+            model_handle->default_context.model->get_config().model_type ==
                 cactus::engine::Config::ModelType::PARAKEET_TDT;
         {
             float vocabulary_boost = 5.0f;
             parse_custom_vocabulary_options(stream_handle->transcribe_options_json,
                                            stream_handle->custom_vocabulary, vocabulary_boost);
             auto vocab_bias = build_custom_vocabulary_bias(
-                model_handle->model->get_tokenizer(),
+                model_handle->default_context.model->get_tokenizer(),
                 stream_handle->custom_vocabulary,
                 vocabulary_boost
             );
             stream_handle->has_custom_vocabulary_bias = !vocab_bias.empty();
             if (stream_handle->has_custom_vocabulary_bias) {
-                model_handle->model->set_vocab_bias(vocab_bias);
+                model_handle->default_context.model->set_vocab_bias(vocab_bias);
             }
         }
 
         if (stream_handle->parakeet_tdt_chunked_stream) {
             auto& ctx = stream_handle->parakeet_tdt_decode_context;
             ctx.mel_bins = std::max<size_t>(
-                1, static_cast<size_t>(model_handle->model->get_config().num_mel_bins));
+                1, static_cast<size_t>(model_handle->default_context.model->get_config().num_mel_bins));
             auto cfg = get_parakeet_spectrogram_config();
             ctx.audio_processor.init_mel_filters(
                 cfg.n_fft / 2 + 1,
@@ -1002,6 +1008,53 @@ cactus_stream_transcribe_t cactus_stream_transcribe_start(cactus_model_t model, 
         CACTUS_LOG_ERROR("stream_transcribe_start", last_error_message);
         return nullptr;
     }
+}
+
+cactus_stream_transcribe_t cactus_context_stream_transcribe_start(cactus_context_t ctx, const char* options_json) {
+    if (!ctx) {
+        last_error_message = "Context not initialized.";
+        CACTUS_LOG_ERROR("context_stream_transcribe_start", last_error_message);
+        return nullptr;
+    }
+
+    auto* context = static_cast<CactusContextHandle*>(ctx);
+    if (!context->parent_model || !context->model) {
+        last_error_message = "Invalid context handle.";
+        CACTUS_LOG_ERROR("context_stream_transcribe_start", last_error_message);
+        return nullptr;
+    }
+
+    // Delegate to the model-based start, then override the context.
+    auto* stream = static_cast<CactusStreamTranscribeHandle*>(
+        cactus_stream_transcribe_start(context->parent_model, options_json));
+    if (!stream) return nullptr;
+
+    stream->context_override = context;
+
+    // Re-apply vocab bias to the context's model (the model-based start applied it to default_context)
+    if (stream->has_custom_vocabulary_bias) {
+        context->parent_model->default_context.model->clear_vocab_bias();
+        float vocabulary_boost = 5.0f;
+        std::vector<std::string> custom_vocabulary;
+        parse_custom_vocabulary_options(stream->transcribe_options_json, custom_vocabulary, vocabulary_boost);
+        auto vocab_bias = build_custom_vocabulary_bias(
+            context->model->get_tokenizer(), custom_vocabulary, vocabulary_boost);
+        if (!vocab_bias.empty()) {
+            context->model->set_vocab_bias(vocab_bias);
+        }
+    }
+
+    // Re-initialize parakeet TDT context with the overridden model's config
+    if (stream->parakeet_tdt_chunked_stream) {
+        auto& tdt_ctx = stream->parakeet_tdt_decode_context;
+        tdt_ctx.mel_bins = std::max<size_t>(
+            1, static_cast<size_t>(context->model->get_config().num_mel_bins));
+    }
+
+    CACTUS_LOG_INFO("context_stream_transcribe_start",
+        "Stream transcription initialized for context on model: " << context->parent_model->model_name);
+
+    return stream;
 }
 
 int cactus_stream_transcribe_process(
@@ -1034,7 +1087,7 @@ int cactus_stream_transcribe_process(
 
     try {
         auto* handle = static_cast<CactusStreamTranscribeHandle*>(stream);
-        const auto model_type = handle->model_handle->model->get_config().model_type;
+        const auto model_type = handle->active_context()->model->get_config().model_type;
         bool is_moonshine = model_type == cactus::engine::Config::ModelType::MOONSHINE;
         bool is_parakeet_tdt =
             model_type == cactus::engine::Config::ModelType::PARAKEET_TDT;
@@ -1049,7 +1102,7 @@ int cactus_stream_transcribe_process(
             handle->parakeet_tdt_decode_context.initialized) {
             auto& ctx = handle->parakeet_tdt_decode_context;
             auto* tdt_model = static_cast<cactus::engine::ParakeetTDTModel*>(
-                handle->model_handle->model.get());
+                handle->active_context()->model.get());
             auto new_samples = cactus::audio::pcm_buffer_to_float_samples(
                 pcm_buffer, pcm_buffer_size);
             ctx.audio_samples.insert(ctx.audio_samples.end(), new_samples.begin(), new_samples.end());
@@ -1113,7 +1166,7 @@ int cactus_stream_transcribe_process(
             trim_mel_frames(window_audio, ctx.mel_bins, valid_frames);
 
             const uint32_t subsampling =
-                std::max<uint32_t>(1, handle->model_handle->model->get_config().subsampling_factor);
+                std::max<uint32_t>(1, handle->active_context()->model->get_config().subsampling_factor);
             const size_t samples_per_enc_frame = cfg.hop_length * subsampling;
             const size_t context_samples = ctx.samples_decoded_up_to - window_start_sample;
             const size_t decode_start_frame = context_samples / samples_per_enc_frame;
@@ -1323,7 +1376,7 @@ int cactus_stream_transcribe_process(
                 !handle->parakeet_committed_text.empty()) {
                 const size_t encoder_frame_bytes =
                     get_parakeet_spectrogram_config().hop_length *
-                    std::max<uint32_t>(1, handle->model_handle->model->get_config().subsampling_factor) *
+                    std::max<uint32_t>(1, handle->active_context()->model->get_config().subsampling_factor) *
                     sizeof(int16_t);
                 std::string confirmed;
                 size_t confirmed_audio_bytes = 0;
@@ -2334,8 +2387,8 @@ int cactus_stream_transcribe_stop(
     auto clear_stream_vocab_bias = [&]() {
         if (handle->has_custom_vocabulary_bias &&
             handle->model_handle &&
-            handle->model_handle->model) {
-            handle->model_handle->model->clear_vocab_bias();
+            handle->active_context()->model) {
+            handle->active_context()->model->clear_vocab_bias();
         }
     };
 
@@ -2346,7 +2399,7 @@ int cactus_stream_transcribe_stop(
     }
 
     try {
-        const auto model_type = handle->model_handle->model->get_config().model_type;
+        const auto model_type = handle->active_context()->model->get_config().model_type;
         bool is_moonshine = model_type == cactus::engine::Config::ModelType::MOONSHINE;
         bool is_parakeet_tdt =
             model_type == cactus::engine::Config::ModelType::PARAKEET_TDT;
@@ -2382,7 +2435,7 @@ int cactus_stream_transcribe_stop(
             handle->parakeet_tdt_decode_context.initialized) {
             auto& ctx = handle->parakeet_tdt_decode_context;
             auto* tdt_model = static_cast<cactus::engine::ParakeetTDTModel*>(
-                handle->model_handle->model.get());
+                handle->active_context()->model.get());
             const size_t total_samples = ctx.audio_samples.size();
             if (total_samples > ctx.samples_decoded_up_to) {
                 constexpr size_t kTdtLeftContextSamples = 8 * 16000;
@@ -2403,7 +2456,7 @@ int cactus_stream_transcribe_stop(
                 trim_mel_frames(window_audio, ctx.mel_bins, valid_frames);
 
                 const uint32_t subsampling =
-                    std::max<uint32_t>(1, handle->model_handle->model->get_config().subsampling_factor);
+                    std::max<uint32_t>(1, handle->active_context()->model->get_config().subsampling_factor);
                 const size_t samples_per_enc_frame = cfg.hop_length * subsampling;
                 const size_t context_samples = ctx.samples_decoded_up_to - window_start_sample;
                 const size_t decode_start_frame = context_samples / samples_per_enc_frame;

--- a/cactus/ffi/cactus_transcribe.cpp
+++ b/cactus/ffi/cactus_transcribe.cpp
@@ -65,10 +65,18 @@ static bool is_terminal_transcription_piece(const std::string& piece) {
            piece == "<pad>";
 }
 
-extern "C" {
+// --- transcribe_impl: shared by model API and context API ---
 
-int cactus_transcribe(
-    cactus_model_t model,
+static void reset_context(CactusContextHandle* ctx) {
+    ctx->model->reset_cache();
+    ctx->processed_tokens.clear();
+    ctx->processed_images.clear();
+}
+
+int cactus_transcribe_impl(
+    CactusContextHandle* ctx,
+    CactusModelHandle* parent,
+    const char* model_name,
     const char* audio_file_path,
     const char* prompt,
     char* response_buffer,
@@ -79,16 +87,31 @@ int cactus_transcribe(
     const uint8_t* pcm_buffer,
     size_t pcm_buffer_size
 ) {
-    if (validate_audio_params("transcribe", model, response_buffer, buffer_size, audio_file_path, pcm_buffer, pcm_buffer_size) != 0)
+    if (!ctx || !ctx->model) {
+        std::string err = last_error_message.empty() ? "Model not initialized." : last_error_message;
+        CACTUS_LOG_ERROR("transcribe", err);
+        handle_error_response(err, response_buffer, buffer_size);
         return -1;
+    }
+    if (!response_buffer || buffer_size == 0) {
+        CACTUS_LOG_ERROR("transcribe", "Invalid parameters: response_buffer or buffer_size");
+        handle_error_response("Invalid parameters", response_buffer, buffer_size);
+        return -1;
+    }
+    if (!audio_file_path && (!pcm_buffer || pcm_buffer_size == 0)) {
+        CACTUS_LOG_ERROR("transcribe", "No audio input provided");
+        handle_error_response("Either audio_file_path or pcm_buffer must be provided", response_buffer, buffer_size);
+        return -1;
+    }
+
+    const char* telemetry_name = model_name ? model_name : "unknown";
 
     try {
         auto start_time = std::chrono::high_resolution_clock::now();
-        auto* handle = static_cast<CactusModelHandle*>(model);
-        std::lock_guard<std::mutex> lock(handle->model_mutex);
-        handle->should_stop = false;
+        std::lock_guard<std::mutex> lock(ctx->context_mutex);
+        ctx->should_stop = false;
 
-        float cloud_handoff_threshold = handle->model->get_config().default_cloud_handoff_threshold;
+        float cloud_handoff_threshold = ctx->model->get_config().default_cloud_handoff_threshold;
         const std::string opts = options_json ? options_json : "";
         InferenceOptions options = parse_inference_options_json(opts);
         {
@@ -114,7 +137,7 @@ int cactus_transcribe(
             opts.find("\"custom_vocabulary\"") != std::string::npos ||
             opts.find("\"vocabulary_boost\"") != std::string::npos;
         const bool apply_request_scoped_vocabulary_bias =
-            request_has_custom_vocabulary_options && !handle->model->has_vocab_bias();
+            request_has_custom_vocabulary_options && !ctx->model->has_vocab_bias();
 
         struct ScopedVocabularyBiasReset {
             Model* model;
@@ -125,7 +148,7 @@ int cactus_transcribe(
                 }
             }
         } scoped_vocabulary_bias_reset{
-            handle->model.get(),
+            ctx->model.get(),
             apply_request_scoped_vocabulary_bias
         };
         std::vector<std::string> custom_vocabulary;
@@ -133,7 +156,7 @@ int cactus_transcribe(
         parse_custom_vocabulary_options(opts, custom_vocabulary, vocabulary_boost_unused);
 
         if (apply_request_scoped_vocabulary_bias) {
-            apply_custom_vocabulary_options(handle->model.get(), opts);
+            apply_custom_vocabulary_options(ctx->model.get(), opts);
         }
 
         if (request_has_custom_vocabulary_options &&
@@ -142,13 +165,13 @@ int cactus_transcribe(
             options.top_k = 1;
         }
 
-        bool is_whisper = handle->model->get_config().model_type == cactus::engine::Config::ModelType::WHISPER;
-        bool is_moonshine = handle->model->get_config().model_type == cactus::engine::Config::ModelType::MOONSHINE;
-        bool is_parakeet_tdt = handle->model->get_config().model_type == cactus::engine::Config::ModelType::PARAKEET_TDT;
+        bool is_whisper = ctx->model->get_config().model_type == cactus::engine::Config::ModelType::WHISPER;
+        bool is_moonshine = ctx->model->get_config().model_type == cactus::engine::Config::ModelType::MOONSHINE;
+        bool is_parakeet_tdt = ctx->model->get_config().model_type == cactus::engine::Config::ModelType::PARAKEET_TDT;
         bool is_parakeet =
-            handle->model->get_config().model_type == cactus::engine::Config::ModelType::PARAKEET ||
-            handle->model->get_config().model_type == cactus::engine::Config::ModelType::PARAKEET_TDT;
-        bool is_gemma4 = handle->model->get_config().model_type == cactus::engine::Config::ModelType::GEMMA4;
+            ctx->model->get_config().model_type == cactus::engine::Config::ModelType::PARAKEET ||
+            ctx->model->get_config().model_type == cactus::engine::Config::ModelType::PARAKEET_TDT;
+        bool is_gemma4 = ctx->model->get_config().model_type == cactus::engine::Config::ModelType::GEMMA4;
 
         std::vector<float> audio_samples;
         if (audio_file_path == nullptr) {
@@ -169,11 +192,11 @@ int cactus_transcribe(
         if (is_gemma4) {
             if (audio_samples.empty()) {
                 handle_error_response("No audio input provided", response_buffer, buffer_size);
-                cactus::telemetry::recordTranscription(handle->model_name.c_str(), false, 0.0, 0.0, 0.0, 0, 0.0, "No audio input");
+                cactus::telemetry::recordTranscription(telemetry_name, false, 0.0, 0.0, 0.0, 0, 0.0, "No audio input");
                 return -1;
             }
 
-            const auto& model_config = handle->model->get_config();
+            const auto& model_config = ctx->model->get_config();
             uint32_t audio_token_id = model_config.audio_token_id;
             if (audio_token_id == 0) {
                 CACTUS_LOG_WARN("transcribe", "audio_token_id not set in config, using default 258881");
@@ -184,11 +207,11 @@ int cactus_transcribe(
             std::vector<float>& audio_features = audio_prep.features;
             size_t num_soft_tokens = audio_prep.num_soft_tokens;
 
-            auto* tokenizer = handle->model->get_tokenizer();
+            auto* tokenizer = ctx->model->get_tokenizer();
             if (!tokenizer) {
                 CACTUS_LOG_ERROR("transcribe", "Tokenizer unavailable");
                 handle_error_response("Tokenizer unavailable", response_buffer, buffer_size);
-                cactus::telemetry::recordTranscription(handle->model_name.c_str(), false, 0.0, 0.0, 0.0, 0, 0.0, "Tokenizer unavailable");
+                cactus::telemetry::recordTranscription(telemetry_name, false, 0.0, 0.0, 0.0, 0, 0.0, "Tokenizer unavailable");
                 return -1;
             }
 
@@ -223,10 +246,10 @@ int cactus_transcribe(
             generated_tokens.reserve(options.max_tokens);
 
             for (size_t i = 0; i < options.max_tokens; ++i) {
-                if (handle->should_stop) break;
+                if (ctx->should_stop) break;
 
                 float token_entropy = 0.0f;
-                uint32_t next_token = handle->model->decode_with_audio(
+                uint32_t next_token = ctx->model->decode_with_audio(
                     tokens, audio_features,
                     options.temperature, options.top_p, options.top_k,
                     "", &token_entropy,
@@ -252,7 +275,7 @@ int cactus_transcribe(
                 if (callback) callback(piece.c_str(), next_token, user_data);
             }
 
-            cactus_reset(model);
+            reset_context(ctx);
 
             float mean_entropy = completion_tokens > 0 ? total_entropy_sum / static_cast<float>(completion_tokens) : 0.0f;
             float confidence = 1.0f - mean_entropy;
@@ -285,11 +308,11 @@ int cactus_transcribe(
 
             if (json.size() >= buffer_size) {
                 handle_error_response("Response buffer too small", response_buffer, buffer_size);
-                cactus::telemetry::recordTranscription(handle->model_name.c_str(), false, 0.0, 0.0, 0.0, 0, 0.0, "Response buffer too small");
+                cactus::telemetry::recordTranscription(telemetry_name, false, 0.0, 0.0, 0.0, 0, 0.0, "Response buffer too small");
                 return -1;
             }
 
-            cactus::telemetry::recordTranscription(handle->model_name.c_str(), true, time_to_first_token, decode_tps, total_time_ms, static_cast<int>(completion_tokens), get_ram_usage_mb(), "");
+            cactus::telemetry::recordTranscription(telemetry_name, true, time_to_first_token, decode_tps, total_time_ms, static_cast<int>(completion_tokens), get_ram_usage_mb(), "");
             std::strcpy(response_buffer, json.c_str());
             return static_cast<int>(json.size());
         }
@@ -307,7 +330,7 @@ int cactus_transcribe(
         std::vector<AudioChunk> audio_chunks;
 
         if (options.use_vad) {
-            auto* vad = static_cast<SileroVADModel*>(handle->vad_model.get());
+            auto* vad = static_cast<SileroVADModel*>(parent->vad_model.get());
             auto vad_segments = vad->get_speech_timestamps(audio_samples, {});
             audio_chunks.reserve(vad_segments.size());
 
@@ -346,10 +369,10 @@ int cactus_transcribe(
                 std::string json = construct_response_json("", {}, 0.0, vad_total_time_ms, 0.0, 0.0, 0, 0, 1.0f);
                 if (json.size() >= buffer_size) {
                     handle_error_response("Response buffer too small", response_buffer, buffer_size);
-                    cactus::telemetry::recordTranscription(handle->model_name.c_str(), false, 0.0, 0.0, 0.0, 0, 0.0, "Response buffer too small");
+                    cactus::telemetry::recordTranscription(telemetry_name, false, 0.0, 0.0, 0.0, 0, 0.0, "Response buffer too small");
                     return -1;
                 }
-                cactus::telemetry::recordTranscription(handle->model_name.c_str(), true, 0.0, 0.0, vad_total_time_ms, 0, get_ram_usage_mb(), "");
+                cactus::telemetry::recordTranscription(telemetry_name, true, 0.0, 0.0, vad_total_time_ms, 0, get_ram_usage_mb(), "");
                 std::strcpy(response_buffer, json.c_str());
                 return static_cast<int>(json.size());
             }
@@ -362,7 +385,7 @@ int cactus_transcribe(
         }
 
         auto cfg = is_parakeet ? get_parakeet_spectrogram_config() : get_whisper_spectrogram_config();
-        size_t mel_bins = std::max<size_t>(1, static_cast<size_t>(handle->model->get_config().num_mel_bins));
+        size_t mel_bins = std::max<size_t>(1, static_cast<size_t>(ctx->model->get_config().num_mel_bins));
         const bool is_whisper_v3 = is_whisper && mel_bins > 80;
         AudioProcessor ap;
         if (is_parakeet) {
@@ -371,11 +394,11 @@ int cactus_transcribe(
             init_whisper_mel_filters(ap, cfg, mel_bins);
         }
 
-        auto* tokenizer = handle->model->get_tokenizer();
+        auto* tokenizer = ctx->model->get_tokenizer();
         if (!tokenizer) {
             CACTUS_LOG_ERROR("transcribe", "Tokenizer unavailable");
             handle_error_response("Tokenizer unavailable", response_buffer, buffer_size);
-            cactus::telemetry::recordTranscription(handle->model_name.c_str(), false, 0.0, 0.0, 0.0, 0, 0.0, "Tokenizer unavailable");
+            cactus::telemetry::recordTranscription(telemetry_name, false, 0.0, 0.0, 0.0, 0, 0.0, "Tokenizer unavailable");
             return -1;
         }
 
@@ -387,11 +410,11 @@ int cactus_transcribe(
         if (initial_tokens.empty() && !is_moonshine && !is_parakeet) {
             CACTUS_LOG_ERROR("transcribe", "Decoder input tokens empty after encoding prompt");
             handle_error_response("Decoder input tokens empty", response_buffer, buffer_size);
-            cactus::telemetry::recordTranscription(handle->model_name.c_str(), false, 0.0, 0.0, 0.0, 0, 0.0, "Decoder input tokens empty");
+            cactus::telemetry::recordTranscription(telemetry_name, false, 0.0, 0.0, 0.0, 0, 0.0, "Decoder input tokens empty");
             return -1;
         }
 
-        float max_tps = handle->model->get_config().default_max_tps;
+        float max_tps = ctx->model->get_config().default_max_tps;
         if (max_tps < 0) max_tps = 100;
 
         std::vector<std::vector<uint32_t>> stop_token_sequences = {{ tokenizer->get_eos_token() }};
@@ -426,7 +449,7 @@ int cactus_transcribe(
         const auto sot_begin = sot_it != initial_tokens.end() ? sot_it : initial_tokens.begin();
 
         for (auto& audio_chunk : audio_chunks) {
-            if (handle->should_stop || completion_tokens >= options.max_tokens) break;
+            if (ctx->should_stop || completion_tokens >= options.max_tokens) break;
 
             std::vector<float> chunk_audio = std::move(audio_chunk.audio);
             const float audio_chunk_length_sec = static_cast<float>(chunk_audio.size()) / static_cast<float>(WHISPER_SAMPLE_RATE);
@@ -493,12 +516,12 @@ int cactus_transcribe(
             std::string segment_text;
 
             for (size_t i = 0; i < chunk_max_tokens; ++i) {
-                if (handle->should_stop) break;
+                if (ctx->should_stop) break;
 
                 float token_entropy = 0.0f;
                 float tok_time_start = 0.0f;
                 float tok_time_end = 0.0f;
-                uint32_t next_token = handle->model->decode_with_audio(
+                uint32_t next_token = ctx->model->decode_with_audio(
                     tokens,
                     chunk_audio,
                     options.temperature,
@@ -592,7 +615,7 @@ int cactus_transcribe(
                 );
             }
 
-            cactus_reset(model);
+            reset_context(ctx);
         }
 
         float mean_entropy = completion_tokens > 0 ? total_entropy_sum / static_cast<float>(completion_tokens) : 0.0f;
@@ -621,11 +644,11 @@ int cactus_transcribe(
 
         if (json.size() >= buffer_size) {
             handle_error_response("Response buffer too small", response_buffer, buffer_size);
-            cactus::telemetry::recordTranscription(handle->model_name.c_str(), false, 0.0, 0.0, 0.0, 0, 0.0, "Response buffer too small");
+            cactus::telemetry::recordTranscription(telemetry_name, false, 0.0, 0.0, 0.0, 0, 0.0, "Response buffer too small");
             return -1;
         }
 
-        cactus::telemetry::recordTranscription(handle->model_name.c_str(), true, time_to_first_token, decode_tps, total_time_ms, static_cast<int>(completion_tokens), get_ram_usage_mb(), "");
+        cactus::telemetry::recordTranscription(telemetry_name, true, time_to_first_token, decode_tps, total_time_ms, static_cast<int>(completion_tokens), get_ram_usage_mb(), "");
 
         std::strcpy(response_buffer, json.c_str());
 
@@ -634,15 +657,43 @@ int cactus_transcribe(
     catch (const std::exception& e) {
         CACTUS_LOG_ERROR("transcribe", "Exception: " << e.what());
         handle_error_response(e.what(), response_buffer, buffer_size);
-        cactus::telemetry::recordTranscription(model ? static_cast<CactusModelHandle*>(model)->model_name.c_str() : nullptr, false, 0.0, 0.0, 0.0, 0, 0.0, e.what());
+        cactus::telemetry::recordTranscription(telemetry_name, false, 0.0, 0.0, 0.0, 0, 0.0, e.what());
         return -1;
     }
     catch (...) {
         CACTUS_LOG_ERROR("transcribe", "Unknown exception during transcription");
         handle_error_response("Unknown error in transcribe", response_buffer, buffer_size);
-        cactus::telemetry::recordTranscription(model ? static_cast<CactusModelHandle*>(model)->model_name.c_str() : nullptr, false, 0.0, 0.0, 0.0, 0, 0.0, "Unknown error in transcribe");
+        cactus::telemetry::recordTranscription(telemetry_name, false, 0.0, 0.0, 0.0, 0, 0.0, "Unknown error in transcribe");
         return -1;
     }
+}
+
+// --- C API wrappers ---
+
+extern "C" {
+
+int cactus_transcribe(
+    cactus_model_t model,
+    const char* audio_file_path,
+    const char* prompt,
+    char* response_buffer,
+    size_t buffer_size,
+    const char* options_json,
+    cactus_token_callback callback,
+    void* user_data,
+    const uint8_t* pcm_buffer,
+    size_t pcm_buffer_size
+) {
+    if (!model) {
+        std::string err = last_error_message.empty() ? "Model not initialized." : last_error_message;
+        CACTUS_LOG_ERROR("transcribe", err);
+        handle_error_response(err, response_buffer, buffer_size);
+        return -1;
+    }
+    auto* handle = static_cast<CactusModelHandle*>(model);
+    return cactus_transcribe_impl(&handle->default_context, handle, handle->model_name.c_str(),
+        audio_file_path, prompt, response_buffer, buffer_size, options_json,
+        callback, user_data, pcm_buffer, pcm_buffer_size);
 }
 
 int cactus_detect_language(
@@ -684,10 +735,11 @@ int cactus_detect_language(
     try {
         auto start_time = std::chrono::high_resolution_clock::now();
         auto* handle = static_cast<CactusModelHandle*>(model);
+        auto* ctx = &handle->default_context;
         std::lock_guard<std::mutex> lock(handle->model_mutex);
-        handle->should_stop = false;
+        ctx->should_stop = false;
 
-        if (handle->model->get_config().model_type != cactus::engine::Config::ModelType::WHISPER) {
+        if (ctx->model->get_config().model_type != cactus::engine::Config::ModelType::WHISPER) {
             handle_error_response("Language detection currently requires a Whisper model", response_buffer, buffer_size);
             return -1;
         }
@@ -731,7 +783,7 @@ int cactus_detect_language(
 
         AudioProcessor ap;
         auto cfg = get_whisper_spectrogram_config();
-        const size_t mel_bins = std::max<size_t>(1, static_cast<size_t>(handle->model->get_config().num_mel_bins));
+        const size_t mel_bins = std::max<size_t>(1, static_cast<size_t>(ctx->model->get_config().num_mel_bins));
         init_whisper_mel_filters(ap, cfg, mel_bins);
         std::vector<float> mel = ap.compute_spectrogram(audio_buffer, cfg);
         std::vector<float> features = normalize_whisper_mel(mel, mel_bins, mel_bins > 80);
@@ -740,7 +792,7 @@ int cactus_detect_language(
             return -1;
         }
 
-        auto* tokenizer = handle->model->get_tokenizer();
+        auto* tokenizer = ctx->model->get_tokenizer();
         if (!tokenizer) {
             handle_error_response("Tokenizer unavailable", response_buffer, buffer_size);
             return -1;
@@ -752,7 +804,7 @@ int cactus_detect_language(
             return -1;
         }
 
-        handle->model->reset_cache();
+        ctx->model->reset_cache();
         float entropy = 1.0f;
         uint32_t token_id = 0;
         std::string token_text;
@@ -763,7 +815,7 @@ int cactus_detect_language(
         constexpr size_t kMaxLanguageProbeSteps = 4;
         for (size_t step = 0; step < kMaxLanguageProbeSteps; ++step) {
             float step_entropy = 1.0f;
-            const uint32_t step_token_id = handle->model->decode_with_audio(
+            const uint32_t step_token_id = ctx->model->decode_with_audio(
                 decode_tokens, features, 0.0f, 0.0f, 0, "", &step_entropy,
                 0.0f, 1.0f
             );
@@ -781,7 +833,7 @@ int cactus_detect_language(
 
             decode_tokens.push_back(step_token_id);
         }
-        handle->model->reset_cache();
+        ctx->model->reset_cache();
 
         if (language.empty()) {
             language = "unknown";

--- a/cactus/ffi/cactus_utils.h
+++ b/cactus/ffi/cactus_utils.h
@@ -1,6 +1,7 @@
 #ifndef CACTUS_UTILS_H
 #define CACTUS_UTILS_H
 
+#include "cactus_ffi.h"
 #include "../engine/engine.h"
 #include "../models/model.h"
 #include <string>
@@ -59,30 +60,45 @@ inline double get_ram_usage_mb() {
     return get_memory_footprint_bytes() / (1024.0 * 1024.0);
 }
 
-struct CactusModelHandle {
+struct ProcessedImage {
+    std::string path;
+    long long last_modified_timestamp = 0;
+
+    bool operator==(const ProcessedImage& other) const {
+        return path == other.path && last_modified_timestamp == other.last_modified_timestamp;
+    }
+};
+
+struct CactusModelHandle;
+
+struct CactusContextHandle {
+    CactusModelHandle* parent_model = nullptr;  // non-owning back-reference to shared state
     std::unique_ptr<cactus::engine::Model> model;
-    std::unique_ptr<cactus::engine::Model> vad_model;
-    std::atomic<bool> should_stop;
+    std::atomic<bool> should_stop{false};
     std::vector<uint32_t> processed_tokens;
-    struct ProcessedImage {
-        std::string path;
-        long long last_modified_timestamp = 0;
-
-        bool operator==(const ProcessedImage& other) const {
-            return path == other.path && last_modified_timestamp == other.last_modified_timestamp;
-        }
-    };
-
     std::vector<std::vector<ProcessedImage>> processed_images;
+    std::mutex context_mutex;
+    std::vector<std::vector<float>> tool_embeddings;
+    std::vector<std::string> tool_texts;
+};
+
+struct CactusModelHandle {
+    // Default context — holds session state for the backwards-compatible model-based API.
+    // New callers should use cactus_context_create() for explicit session management.
+    CactusContextHandle default_context;
+
+    // Shared/immutable after init
+    std::unique_ptr<cactus::engine::Model> vad_model;
     std::mutex model_mutex;
+    std::string model_path;     // stored for context creation
     std::string model_name;
     std::unique_ptr<cactus::engine::index::Index> corpus_index;
     std::string corpus_dir;
     size_t corpus_embedding_dim = 0;
-    std::vector<std::vector<float>> tool_embeddings;
-    std::vector<std::string> tool_texts;
 
-    CactusModelHandle() : should_stop(false) {}
+    CactusModelHandle() {
+        default_context.parent_model = this;
+    }
 };
 
 extern std::string last_error_message;
@@ -90,7 +106,50 @@ extern std::string last_error_message;
 bool matches_stop_sequence(const std::vector<uint32_t>& generated_tokens,
                            const std::vector<std::vector<uint32_t>>& stop_sequences);
 
-std::string retrieve_rag_context(CactusModelHandle* handle, const std::string& query);
+std::string retrieve_rag_context(CactusContextHandle* ctx, const std::string& query);
+
+// Internal _impl functions shared by the model API (default_context) and context API.
+// These take a CactusContextHandle* so both paths share one implementation.
+int cactus_complete_impl(
+    CactusContextHandle* ctx,
+    const char* model_name,
+    const char* messages_json,
+    char* response_buffer,
+    size_t buffer_size,
+    const char* options_json,
+    const char* tools_json,
+    cactus_token_callback callback,
+    void* user_data,
+    const uint8_t* pcm_buffer,
+    size_t pcm_buffer_size
+);
+
+int cactus_prefill_impl(
+    CactusContextHandle* ctx,
+    const char* model_name,
+    const char* messages_json,
+    char* response_buffer,
+    size_t buffer_size,
+    const char* options_json,
+    const char* tools_json,
+    const uint8_t* pcm_buffer,
+    size_t pcm_buffer_size
+);
+
+int cactus_transcribe_impl(
+    CactusContextHandle* ctx,
+    CactusModelHandle* parent,
+    const char* model_name,
+    const char* audio_file_path,
+    const char* prompt,
+    char* response_buffer,
+    size_t buffer_size,
+    const char* options_json,
+    cactus_token_callback callback,
+    void* user_data,
+    const uint8_t* pcm_buffer,
+    size_t pcm_buffer_size
+);
 
 namespace cactus {
 namespace audio {
@@ -421,7 +480,7 @@ struct InferenceOptions {
 } // namespace cactus
 
 std::vector<cactus::ffi::ToolFunction> select_relevant_tools(
-    CactusModelHandle* handle,
+    CactusContextHandle* ctx,
     const std::string& query,
     const std::vector<cactus::ffi::ToolFunction>& all_tools,
     size_t top_k);

--- a/cactus/ffi/cactus_vad.cpp
+++ b/cactus/ffi/cactus_vad.cpp
@@ -106,7 +106,7 @@ int cactus_vad(
     try {
         auto start_time = std::chrono::high_resolution_clock::now();
         auto* handle = static_cast<CactusModelHandle*>(model);
-        auto* vad_model = static_cast<SileroVADModel*>(handle->model.get());
+        auto* vad_model = static_cast<SileroVADModel*>(handle->default_context.model.get());
 
         SileroVADModel::SpeechTimestampsOptions options = parse_speech_timestamps_options(options_json ? options_json : "");
 

--- a/tests/test_gemma4_thinking.cpp
+++ b/tests/test_gemma4_thinking.cpp
@@ -109,7 +109,7 @@ bool test_prompt_gemma4_thinking_injection() {
     if (!model) { std::cout << "  [SKIP] Could not load model\n"; return true; }
 
     auto* handle = static_cast<CactusModelHandle*>(model);
-    auto* tok = handle->model->get_tokenizer();
+    auto* tok = handle->default_context.model->get_tokenizer();
     std::vector<ChatMessage> msgs = {{"user", "hello", "", {}, {}}};
 
     std::string enabled = tok->format_chat_prompt(msgs, true, "", true);
@@ -136,7 +136,7 @@ bool test_prompt_gemma4_assistant_stripping() {
     if (!model) { std::cout << "  [SKIP] Could not load model\n"; return true; }
 
     auto* handle = static_cast<CactusModelHandle*>(model);
-    auto* tok = handle->model->get_tokenizer();
+    auto* tok = handle->default_context.model->get_tokenizer();
 
     std::vector<ChatMessage> msgs = {
         {"user", "hello", "", {}, {}},
@@ -167,7 +167,7 @@ bool test_complete_gemma4_thinking_toggle() {
     if (!model) return false;
 
     auto* handle = static_cast<CactusModelHandle*>(model);
-    auto mtype = handle->model->get_config().model_type;
+    auto mtype = handle->default_context.model->get_config().model_type;
     if (mtype != Config::ModelType::GEMMA4) {
         std::cout << "  [SKIP] Not a Gemma4 model\n";
         cactus_destroy(model);
@@ -183,8 +183,8 @@ bool test_complete_gemma4_thinking_toggle() {
     std::string resp1(buf);
     bool ok1 = r1 > 0 && resp1.find("\"success\":true") != std::string::npos;
 
-    handle->model->reset_cache();
-    handle->processed_tokens.clear();
+    handle->default_context.model->reset_cache();
+    handle->default_context.processed_tokens.clear();
 
     int r2 = cactus_complete(model, msgs, buf, sizeof(buf),
         R"({"max_tokens":128,"enable_thinking_if_supported":false,"telemetry_enabled":false})",
@@ -209,7 +209,7 @@ bool test_complete_gemma4_tool_call() {
     if (!model) return false;
 
     auto* handle = static_cast<CactusModelHandle*>(model);
-    auto mtype = handle->model->get_config().model_type;
+    auto mtype = handle->default_context.model->get_config().model_type;
     if (mtype != Config::ModelType::GEMMA4) {
         std::cout << "  [SKIP] Not a Gemma4 model\n";
         cactus_destroy(model);
@@ -244,13 +244,13 @@ bool test_multiturn_cache_reuse() {
     if (!model) { std::cerr << "  Failed to load model\n"; return false; }
 
     auto* handle = static_cast<CactusModelHandle*>(model);
-    if (handle->model->get_config().model_type != Config::ModelType::GEMMA4) {
+    if (handle->default_context.model->get_config().model_type != Config::ModelType::GEMMA4) {
         std::cout << "  [SKIP] Not a Gemma4 model\n";
         cactus_destroy(model);
         return true;
     }
 
-    auto* tokenizer = handle->model->get_tokenizer();
+    auto* tokenizer = handle->default_context.model->get_tokenizer();
     const char* options = R"({"max_tokens":128,"temperature":0,"top_k":1,"enable_thinking_if_supported":true,"telemetry_enabled":false,"auto_handoff":false})";
     const char* turn1_msgs = R"([{"role": "user", "content": "My name is Alice. Please remember this."}])";
     char buf[16384];
@@ -258,7 +258,7 @@ bool test_multiturn_cache_reuse() {
     int r1 = cactus_complete(model, turn1_msgs, buf, sizeof(buf), options, nullptr, nullptr, nullptr, nullptr, 0);
     if (r1 <= 0) { std::cerr << "  Turn 1 failed\n"; cactus_destroy(model); return false; }
 
-    std::vector<uint32_t> processed_after_t1 = handle->processed_tokens;
+    std::vector<uint32_t> processed_after_t1 = handle->default_context.processed_tokens;
 
     std::vector<ChatMessage> t1_chat = {{"user", "My name is Alice. Please remember this.", "", {}, {}}};
     std::vector<uint32_t> t1_prompt_tokens = tokenizer->encode(tokenizer->format_chat_prompt(t1_chat, true, "", true));


### PR DESCRIPTION
Addresses issue #572 

Split session state (KV cache, processed tokens/images, stop flag, tool embeddings) out of CactusModelHandle into a new CactusContextHandle that owns its lifetime. Added cactus_context_* C API but legacy model-level entrypoints forward to default_context so existing callers are unaffected.

caveat: cactus_context_create calls create_model(parent->model_path) and model->init(...) for every new context. That reloads weights per context — unlike llama.cpp where the context shares the model's weights.