### PR TITLE
apple: ship dSYMs and preserve macOS framework structure

### DIFF
--- a/apple/build.sh
+++ b/apple/build.sh
@@ -30,12 +30,27 @@ echo "XCFramework: $BUILD_XCFRAMEWORK"
 echo "Vendored libcurl root: $CACTUS_CURL_ROOT"
 
 function cp_headers() {
-    mkdir -p "$ROOT_DIR/apple/$1/$2/cactus.framework/Headers"
-    cp "$ROOT_DIR/cactus/ffi/"*.h "$ROOT_DIR/apple/$1/$2/cactus.framework/Headers/" 2>/dev/null || true
-    cp "$ROOT_DIR/cactus/engine/"*.h "$ROOT_DIR/apple/$1/$2/cactus.framework/Headers/" 2>/dev/null || true
-    cp "$ROOT_DIR/cactus/graph/"*.h "$ROOT_DIR/apple/$1/$2/cactus.framework/Headers/" 2>/dev/null || true
-    cp "$ROOT_DIR/cactus/kernel/"*.h "$ROOT_DIR/apple/$1/$2/cactus.framework/Headers/" 2>/dev/null || true
-    cp "$ROOT_DIR/cactus/"*.h "$ROOT_DIR/apple/$1/$2/cactus.framework/Headers/" 2>/dev/null || true
+    local fw_root="$ROOT_DIR/apple/$1/$2/cactus.framework"
+    local headers_dir
+
+    # macOS frameworks have a versioned bundle layout (Versions/A/Headers with
+    # a top-level Headers symlink). iOS frameworks are flat (Headers at top).
+    if [ -d "$fw_root/Versions/A" ]; then
+        headers_dir="$fw_root/Versions/A/Headers"
+        mkdir -p "$headers_dir"
+        if [ ! -e "$fw_root/Headers" ]; then
+            (cd "$fw_root" && ln -s "Versions/Current/Headers" "Headers")
+        fi
+    else
+        headers_dir="$fw_root/Headers"
+        mkdir -p "$headers_dir"
+    fi
+
+    cp "$ROOT_DIR/cactus/ffi/"*.h    "$headers_dir/" 2>/dev/null || true
+    cp "$ROOT_DIR/cactus/engine/"*.h "$headers_dir/" 2>/dev/null || true
+    cp "$ROOT_DIR/cactus/graph/"*.h  "$headers_dir/" 2>/dev/null || true
+    cp "$ROOT_DIR/cactus/kernel/"*.h "$headers_dir/" 2>/dev/null || true
+    cp "$ROOT_DIR/cactus/"*.h        "$headers_dir/" 2>/dev/null || true
 }
 
 function create_ios_xcframework_info_plist() {
@@ -47,6 +62,8 @@ function create_ios_xcframework_info_plist() {
 	<key>AvailableLibraries</key>
 	<array>
 		<dict>
+			<key>DebugSymbolsPath</key>
+			<string>dSYMs</string>
 			<key>LibraryIdentifier</key>
 			<string>ios-arm64</string>
 			<key>LibraryPath</key>
@@ -59,6 +76,8 @@ function create_ios_xcframework_info_plist() {
 			<string>ios</string>
 		</dict>
 		<dict>
+			<key>DebugSymbolsPath</key>
+			<string>dSYMs</string>
 			<key>LibraryIdentifier</key>
 			<string>ios-arm64-simulator</string>
 			<key>LibraryPath</key>
@@ -91,6 +110,8 @@ function create_macos_xcframework_info_plist() {
 	<key>AvailableLibraries</key>
 	<array>
 		<dict>
+			<key>DebugSymbolsPath</key>
+			<string>dSYMs</string>
 			<key>LibraryIdentifier</key>
 			<string>macos-arm64</string>
 			<key>LibraryPath</key>
@@ -182,12 +203,13 @@ function build_framework() {
         -DBUILD_SHARED_LIBS=ON \
         -DCACTUS_CURL_ROOT="$CACTUS_CURL_ROOT" \
         -DCMAKE_XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH=NO \
+        -DCMAKE_XCODE_ATTRIBUTE_DEBUG_INFORMATION_FORMAT=dwarf-with-dsym \
         -DCMAKE_IOS_INSTALL_COMBINED=YES >/dev/null
 
     cmake --build . --config "$CMAKE_BUILD_TYPE" -j "$n_cpu" >/dev/null 2>&1
 
     DEST_DIR="$ROOT_DIR/apple/$6/$4"
-    
+
     # Try different possible framework locations
     FRAMEWORK_SRC=""
     if [ -d "$CMAKE_BUILD_TYPE-$3/cactus.framework" ]; then
@@ -198,20 +220,43 @@ function build_framework() {
         # Find the framework in any subdirectory
         FRAMEWORK_SRC=$(find . -name "cactus.framework" -type d | head -n 1)
     fi
-    
+
+    # Locate the matching .dSYM produced alongside the framework. cmake's Xcode
+    # generator only emits dSYMs when DEBUG_INFORMATION_FORMAT=dwarf-with-dsym.
+    DSYM_SRC=""
+    if [ -d "$CMAKE_BUILD_TYPE-$3/cactus.framework.dSYM" ]; then
+        DSYM_SRC="$CMAKE_BUILD_TYPE-$3/cactus.framework.dSYM"
+    elif [ -d "$CMAKE_BUILD_TYPE/cactus.framework.dSYM" ]; then
+        DSYM_SRC="$CMAKE_BUILD_TYPE/cactus.framework.dSYM"
+    else
+        DSYM_SRC=$(find . -name "cactus.framework.dSYM" -type d | head -n 1)
+    fi
+
     FRAMEWORK_DEST="$DEST_DIR/cactus.framework"
+    DSYMS_DEST_DIR="$DEST_DIR/dSYMs"
 
     rm -rf "$DEST_DIR"
     mkdir -p "$DEST_DIR"
 
     if [ -n "$FRAMEWORK_SRC" ] && [ -d "$FRAMEWORK_SRC" ]; then
-        cp -R "$FRAMEWORK_SRC" "$FRAMEWORK_DEST"
+        # ditto preserves the macOS framework's Versions/A symlink layout.
+        # cp -R follows symlinks and produces a malformed bundle that fails App
+        # Store validation with "Multiple binaries share the same codesign path".
+        ditto "$FRAMEWORK_SRC" "$FRAMEWORK_DEST"
         echo "Framework copied from $FRAMEWORK_SRC to $FRAMEWORK_DEST"
     else
         echo "Error: Framework not found in build directory"
         echo "Available files:"
         find . -name "*.framework" -o -name "libcactus*" 2>/dev/null || true
         exit 1
+    fi
+
+    if [ -n "$DSYM_SRC" ] && [ -d "$DSYM_SRC" ]; then
+        mkdir -p "$DSYMS_DEST_DIR"
+        ditto "$DSYM_SRC" "$DSYMS_DEST_DIR/cactus.framework.dSYM"
+        echo "dSYM copied from $DSYM_SRC to $DSYMS_DEST_DIR/cactus.framework.dSYM"
+    else
+        echo "Warning: cactus.framework.dSYM not found; xcframework will lack debug symbols for $4"
     fi
 
     cp_headers $6 $4


### PR DESCRIPTION
## Summary

Two distinct bugs in `apple/build.sh` cause App Store / TestFlight distribution to fail or warn when the cactus xcframeworks are embedded into a Mac app archive. Both are root-caused and fixed in this PR.

### Bug 1 — Malformed macOS framework bundle (blocks archive)

`build_framework` copies the cmake-built framework with `cp -R`. On macOS, cmake's Xcode generator produces a proper bundle layout:

```
cactus.framework/
├── cactus            -> Versions/Current/cactus    (symlink)
├── Resources         -> Versions/Current/Resources (symlink)
└── Versions/
    ├── Current       -> A                          (symlink)
    └── A/
        ├── cactus
        └── Resources/
```

`cp -R` resolves symlinks, so the destination ends up with **two real binaries** — one at the top level *and* one inside `Versions/A/`. Apple's archive validator rejects this with:

> Multiple binaries share the same codesign path:
> /Applications/<app>.app/Contents/Frameworks/cactus.framework/Versions/Current
> Binaries:
>   .../Versions/Current/cactus
>   .../cactus
> This can happen if your build process copies frameworks by following symlinks.

**Fix:** switch to `ditto`, which is bundle-aware on macOS and preserves the symlink layout intact. `cp_headers` was also writing top-level `Headers/` regardless of platform; updated it to write `Versions/A/Headers` and create the top-level symlink on macOS while keeping iOS's flat layout.

### Bug 2 — No dSYMs in the xcframeworks (warnings, unsymbolicated crashes)

cmake's Xcode generator defaults `DEBUG_INFORMATION_FORMAT` to `dwarf` for Release configurations. The shipped binary is stripped of debug info — confirmed via `dwarfdump --uuid` + `dsymutil` (`warning: no debug symbols in executable`). Consumers see two warnings during App Store upload:

> Upload Symbols Failed
> The archive did not include a dSYM for the cactus with the UUIDs [...].
> Ensure that the archive's dSYM folder includes a DWARF file for cactus with the expected UUIDs.

Crash reports inside cactus frames also show unsymbolicated hex addresses.

**Fix:**
- Add `-DCMAKE_XCODE_ATTRIBUTE_DEBUG_INFORMATION_FORMAT=dwarf-with-dsym` so cmake emits `cactus.framework.dSYM` next to each built framework.
- Copy the resulting `.dSYM` into each xcframework slice under `<slice>/dSYMs/cactus.framework.dSYM/`.
- Declare `DebugSymbolsPath` in the xcframework `Info.plist` for every `AvailableLibraries` entry. Without this key, xcodebuild ignores dSYMs sitting in the xcframework even when present.

## Resulting xcframework layout

```
cactus-macos.xcframework/
├── Info.plist          # AvailableLibraries[].DebugSymbolsPath = "dSYMs"
└── macos-arm64/
    ├── cactus.framework/   # proper symlinks preserved by ditto
    └── dSYMs/
        └── cactus.framework.dSYM/
```

## Test plan

- [ ] Run `bash apple/build.sh` on macOS arm64 with Xcode + cmake installed
- [ ] Verify `cactus-macos.xcframework/macos-arm64/cactus.framework/Versions/Current` is a symlink to `A`
- [ ] Verify `cactus-macos.xcframework/macos-arm64/dSYMs/cactus.framework.dSYM/` exists and contains DWARF data
- [ ] Embed the xcframework in a sample Mac app, archive, and confirm App Store validation passes (no "Multiple binaries share the same codesign path" error, no "Upload Symbols Failed" warnings for cactus)
- [ ] Same checks against `cactus-ios.xcframework` for an iOS app

## Notes

- I have not been able to test the build end-to-end locally (would need full cmake + vendored libcurl setup). The shell changes are bash-syntax-clean and the cmake/Info.plist patterns are standard. Happy to iterate if CI surfaces anything.
- The published `cactus` Flutter package on pub.dev also bundles a separate `cactus_util.xcframework` with the same structural bug. That binary is built somewhere outside this repo (I couldn't locate the source) — if the same patterns can be applied to wherever it's built, that would resolve the issue end-to-end for Flutter consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)