### PR TITLE
Add fused dense INT4 MLP op for Gemma-4 E2B decode

### DIFF
--- a/cactus/graph/graph.h
+++ b/cactus/graph/graph.h
@@ -134,6 +134,7 @@ enum class OpType {
     SCATTER_TOPK,
     TOPK, LAYERNORM, GROUPNORM,
     MOE_LAYER,
+    DENSE_MLP_INT4_FUSED,
     INDEX,
     PERSISTENT,
     QUANTIZE_ACTIVATIONS,
@@ -424,6 +425,7 @@ void compute_topk_node(GraphNode& node, const std::vector<std::unique_ptr<GraphN
 void compute_layernorm_node(GraphNode& node, const std::vector<std::unique_ptr<GraphNode>>& nodes, const std::unordered_map<size_t, size_t>& node_index_map);
 void compute_groupnorm_node(GraphNode& node, const std::vector<std::unique_ptr<GraphNode>>& nodes, const std::unordered_map<size_t, size_t>& node_index_map);
 void compute_persistent_node(GraphNode& node, const std::vector<std::unique_ptr<GraphNode>>& nodes, const std::unordered_map<size_t, size_t>& node_index_map);
+void compute_dense_mlp_int4_fused_node(GraphNode& node, const std::vector<std::unique_ptr<GraphNode>>& nodes, const std::unordered_map<size_t, size_t>& node_index_map);
 void compute_index_node(GraphNode& node, const std::vector<std::unique_ptr<GraphNode>>& nodes, const std::unordered_map<size_t, size_t>& node_index_map);
 void compute_lstm_cell_node(GraphNode& node, const std::vector<std::unique_ptr<GraphNode>>& nodes, const std::unordered_map<size_t, size_t>& node_index_map);
 void compute_gated_deltanet_decode_node(GraphNode& node, const std::vector<std::unique_ptr<GraphNode>>& nodes, const std::unordered_map<size_t, size_t>& node_index_map);
@@ -554,6 +556,8 @@ public:
     size_t groupnorm(size_t input, size_t weight, size_t bias, size_t num_groups = 32, float epsilon = 1e-5f);
     size_t batchnorm(size_t input, size_t weight, size_t bias, size_t running_mean, size_t running_var, int axis = 1, float epsilon = 1e-5f);
     size_t topk(size_t input, size_t k);
+    size_t dense_mlp_int4_fused(size_t hidden, size_t gate_weight,
+                                 size_t up_weight, size_t down_weight);
     size_t moe_layer(size_t hidden,
                      size_t routing_probs,
                      size_t topk_indices,

--- a/cactus/graph/graph.h
+++ b/cactus/graph/graph.h
@@ -134,7 +134,6 @@ enum class OpType {
     SCATTER_TOPK,
     TOPK, LAYERNORM, GROUPNORM,
     MOE_LAYER,
-    DENSE_MLP_INT4_FUSED,
     INDEX,
     PERSISTENT,
     QUANTIZE_ACTIVATIONS,
@@ -150,7 +149,8 @@ enum class OpType {
     LEAKY_RELU,
     CONV2D_K3S1P1,
     STATS_POOL,
-    WEIGHTED_STATS_POOL
+    WEIGHTED_STATS_POOL,
+    DENSE_MLP_INT4_FUSED
 };
 
 struct PrecisionTraits {

--- a/cactus/graph/graph_builder.cpp
+++ b/cactus/graph/graph_builder.cpp
@@ -355,6 +355,31 @@ size_t CactusGraph::topk(size_t input, size_t k) {
     return add_node(OpType::TOPK, {input}, output_shape, params);
 }
 
+size_t CactusGraph::dense_mlp_int4_fused(size_t hidden, size_t gate_weight,
+                                          size_t up_weight, size_t down_weight) {
+    const auto& hidden_buf = get_output_buffer(hidden);
+    if (hidden_buf.shape.size() < 2) {
+        throw std::runtime_error("dense_mlp_int4_fused requires hidden of rank >= 2");
+    }
+    const auto& down_buf = get_output_buffer(down_weight);
+    size_t hidden_dim;
+    if (down_buf.is_interleaved && down_buf.original_N > 0) {
+        hidden_dim = down_buf.original_N;
+    } else {
+        hidden_dim = down_buf.shape[down_buf.shape.size() - 2];
+    }
+
+    std::vector<size_t> output_shape = hidden_buf.shape;
+    output_shape[output_shape.size() - 1] = hidden_dim;
+
+    OpParams params;
+    params.output_precision = Precision::FP16;
+
+    return add_node(OpType::DENSE_MLP_INT4_FUSED,
+                    {hidden, gate_weight, up_weight, down_weight},
+                    output_shape, params);
+}
+
 size_t CactusGraph::moe_layer(size_t hidden,
                               size_t routing_probs,
                               size_t topk_indices,

--- a/cactus/graph/graph_execute.cpp
+++ b/cactus/graph/graph_execute.cpp
@@ -68,6 +68,7 @@ DECLARE_COMPUTE(compute_sample_node);
 DECLARE_COMPUTE(compute_topk_node);
 DECLARE_COMPUTE(compute_scatter_topk_node);
 DECLARE_COMPUTE(compute_moe_layer_node);
+DECLARE_COMPUTE(compute_dense_mlp_int4_fused_node);
 DECLARE_COMPUTE(compute_persistent_node);
 DECLARE_COMPUTE(compute_quantize_activations_node);
 extern void shrink_thread_local_buffers();
@@ -140,6 +141,7 @@ static const std::unordered_map<OpType, ComputeFn> dispatch_table = {
     {OpType::TOPK, compute_topk_node},
     {OpType::SCATTER_TOPK, compute_scatter_topk_node},
     {OpType::MOE_LAYER, compute_moe_layer_node},
+    {OpType::DENSE_MLP_INT4_FUSED, compute_dense_mlp_int4_fused_node},
     {OpType::PERSISTENT, compute_persistent_node},
     {OpType::QUANTIZE_ACTIVATIONS, compute_quantize_activations_node},
     {OpType::LSTM_CELL, compute_lstm_cell_node},
@@ -170,6 +172,7 @@ static const char* op_type_names[] = {
     "SCATTER_TOPK",
     "TOPK", "LAYERNORM", "GROUPNORM",
     "MOE_LAYER",
+    "DENSE_MLP_INT4_FUSED",
     "INDEX",
     "PERSISTENT",
     "QUANTIZE_ACTIVATIONS",

--- a/cactus/graph/graph_execute.cpp
+++ b/cactus/graph/graph_execute.cpp
@@ -172,7 +172,6 @@ static const char* op_type_names[] = {
     "SCATTER_TOPK",
     "TOPK", "LAYERNORM", "GROUPNORM",
     "MOE_LAYER",
-    "DENSE_MLP_INT4_FUSED",
     "INDEX",
     "PERSISTENT",
     "QUANTIZE_ACTIVATIONS",
@@ -188,7 +187,8 @@ static const char* op_type_names[] = {
     "LEAKY_RELU",
     "CONV2D_K3S1P1",
     "STATS_POOL",
-    "WEIGHTED_STATS_POOL"
+    "WEIGHTED_STATS_POOL",
+    "DENSE_MLP_INT4_FUSED"
 };
 
 static const char* get_op_name(OpType op) {

--- a/cactus/graph/graph_ops_nn.cpp
+++ b/cactus/graph/graph_ops_nn.cpp
@@ -519,12 +519,8 @@ namespace {
     };
     static std::vector<DenseFusedScratch> dense_fused_scratch;
 
-    // Single-threaded fp16 -> int8 quantization for the once-per-layer h vector.
-    // cactus_fp16_to_int8's parallel_for crosses ELEMENT_WISE.min_work_gate at
-    // d_ffn=12288 and dispatches ~5 threads, whose orchestration cost (mutex,
-    // futex wakeup, straggler wait on heterogeneous mobile cores) dominates the
-    // few-microsecond SIMD work. Running inline on the dispatch thread skips
-    // that overhead on both Apple silicon and Android big.LITTLE.
+    // Inline to skip cactus_fp16_to_int8's parallel_for orchestration, which
+    // dispatches ~5 threads at d_ffn=12288 and dominates the SIMD work.
     static inline void fp16_to_int8_inplace(const __fp16* src, int8_t* dst, size_t n, float scale) {
         const float inv_scale = 1.0f / scale;
         const float32x4_t inv_vec = vdupq_n_f32(inv_scale);

--- a/cactus/graph/graph_ops_nn.cpp
+++ b/cactus/graph/graph_ops_nn.cpp
@@ -518,6 +518,35 @@ namespace {
         std::vector<__fp16> up_tile;
     };
     static std::vector<DenseFusedScratch> dense_fused_scratch;
+
+    // Single-threaded fp16 -> int8 quantization for the once-per-layer h vector.
+    // cactus_fp16_to_int8's parallel_for crosses ELEMENT_WISE.min_work_gate at
+    // d_ffn=12288 and dispatches ~5 threads, whose orchestration cost (mutex,
+    // futex wakeup, straggler wait on heterogeneous mobile cores) dominates the
+    // few-microsecond SIMD work. Running inline on the dispatch thread skips
+    // that overhead on both Apple silicon and Android big.LITTLE.
+    static inline void fp16_to_int8_inplace(const __fp16* src, int8_t* dst, size_t n, float scale) {
+        const float inv_scale = 1.0f / scale;
+        const float32x4_t inv_vec = vdupq_n_f32(inv_scale);
+        const float32x4_t min_vec = vdupq_n_f32(-128.0f);
+        const float32x4_t max_vec = vdupq_n_f32(127.0f);
+        size_t i = 0;
+        for (; i + 8 <= n; i += 8) {
+            float16x8_t in = vld1q_f16(src + i);
+            float32x4_t lo = vmulq_f32(vcvt_f32_f16(vget_low_f16(in)),  inv_vec);
+            float32x4_t hi = vmulq_f32(vcvt_f32_f16(vget_high_f16(in)), inv_vec);
+            lo = vmaxq_f32(vminq_f32(lo, max_vec), min_vec);
+            hi = vmaxq_f32(vminq_f32(hi, max_vec), min_vec);
+            int16x8_t s = vcombine_s16(vqmovn_s32(vcvtnq_s32_f32(lo)),
+                                        vqmovn_s32(vcvtnq_s32_f32(hi)));
+            vst1_s8(dst + i, vqmovn_s16(s));
+        }
+        for (; i < n; ++i) {
+            float v = static_cast<float>(src[i]) * inv_scale;
+            if (v > 127.0f) v = 127.0f; else if (v < -128.0f) v = -128.0f;
+            dst[i] = static_cast<int8_t>(std::lround(v));
+        }
+    }
 }
 
 void compute_dense_mlp_int4_fused_node(
@@ -648,7 +677,7 @@ void compute_dense_mlp_int4_fused_node(
 
         const float h_maxabs = cactus_fp16_max_abs(h_full, d_ffn);
         const float h_scale = std::max(h_maxabs / 127.0f, 1e-10f);
-        cactus_fp16_to_int8(h_full, h_int8, d_ffn, h_scale);
+        fp16_to_int8_inplace(h_full, h_int8, d_ffn, h_scale);
 
         run(num_threads_p2, [&](size_t /*worker_id*/) {
             while (true) {

--- a/cactus/graph/graph_ops_nn.cpp
+++ b/cactus/graph/graph_ops_nn.cpp
@@ -681,7 +681,16 @@ void compute_dense_mlp_int4_fused_node(
         std::atomic<size_t> p1_next{0};
         std::atomic<size_t> p2_next{0};
 
-        auto phase1_task = [&](size_t worker_id) {
+        auto run = [&](size_t nt, auto&& task) {
+            if (nt <= 1) { task(0); return; }
+            pool.enqueue_n_threads(nt - 1, nt - 1, [&](size_t s, size_t e) {
+                for (size_t w = s; w < e; ++w) task(w + 1);
+            });
+            task(0);
+            pool.wait_all();
+        };
+
+        run(num_threads_p1, [&](size_t worker_id) {
             auto& sc = dense_fused_scratch[worker_id];
             __fp16* gate_tile_buf = sc.gate_tile.data();
             __fp16* up_tile_buf   = sc.up_tile.data();
@@ -695,31 +704,20 @@ void compute_dense_mlp_int4_fused_node(
 
                 cactus_gemv_int4_block_range(
                     x_int8, x_scale, gate_w, gate_s, gate_tile_buf - k_lo,
-                    hidden_dim, d_ffn, group_size, blk_start, blk_end, false);
+                    hidden_dim, d_ffn, group_size, blk_start, blk_end);
                 gelu_tanh_inplace_fp16(gate_tile_buf, k_count);
                 cactus_gemv_int4_block_range(
                     x_int8, x_scale, up_w, up_s, up_tile_buf - k_lo,
-                    hidden_dim, d_ffn, group_size, blk_start, blk_end, false);
+                    hidden_dim, d_ffn, group_size, blk_start, blk_end);
                 multiply_inplace_fp16(gate_tile_buf, up_tile_buf, h_full + k_lo, k_count);
             }
-        };
-
-        if (num_threads_p1 <= 1) {
-            phase1_task(0);
-        } else {
-            pool.enqueue_n_threads(num_threads_p1 - 1, num_threads_p1 - 1,
-                [&](size_t start, size_t end) {
-                    for (size_t w = start; w < end; ++w) phase1_task(w + 1);
-                });
-            phase1_task(0);
-            pool.wait_all();
-        }
+        });
 
         const float h_maxabs = cactus_fp16_max_abs(h_full, d_ffn);
         const float h_scale = std::max(h_maxabs / 127.0f, 1e-10f);
         fp16_to_int8_inplace(h_full, h_int8, d_ffn, h_scale);
 
-        auto phase2_task = [&](size_t /*worker_id*/) {
+        run(num_threads_p2, [&](size_t /*worker_id*/) {
             while (true) {
                 size_t tile_id = p2_next.fetch_add(1, std::memory_order_relaxed);
                 if (tile_id >= tiles_hidden) break;
@@ -727,20 +725,9 @@ void compute_dense_mlp_int4_fused_node(
                 const size_t blk_end   = std::min(blk_start + tile_n_blocks, blocks_hidden);
                 cactus_gemv_int4_block_range(
                     h_int8, h_scale, down_w, down_s, y,
-                    d_ffn, hidden_dim, group_size, blk_start, blk_end, false);
+                    d_ffn, hidden_dim, group_size, blk_start, blk_end);
             }
-        };
-
-        if (num_threads_p2 <= 1) {
-            phase2_task(0);
-        } else {
-            pool.enqueue_n_threads(num_threads_p2 - 1, num_threads_p2 - 1,
-                [&](size_t start, size_t end) {
-                    for (size_t w = start; w < end; ++w) phase2_task(w + 1);
-                });
-            phase2_task(0);
-            pool.wait_all();
-        }
+        });
     }
 }
 

--- a/cactus/graph/graph_ops_nn.cpp
+++ b/cactus/graph/graph_ops_nn.cpp
@@ -520,37 +520,69 @@ namespace {
     static std::vector<DenseFusedScratch> dense_fused_scratch;
 
     static inline void gelu_tanh_inplace_fp16(__fp16* p, size_t n) {
-        const float32x4_t v_half    = vdupq_n_f32(0.5f);
-        const float32x4_t v_one     = vdupq_n_f32(1.0f);
-        const float32x4_t v_sqrt2pi = vdupq_n_f32(0.7978845608028654f);
-        const float32x4_t v_coeff   = vdupq_n_f32(0.044715f);
+        const float sqrt_2_over_pi = 0.7978845608028654f;
+        const float coeff = 0.044715f;
+        const float32x4_t half = vdupq_n_f32(0.5f);
+        const float32x4_t one  = vdupq_n_f32(1.0f);
+        const float32x4_t sqrt_2_pi_vec = vdupq_n_f32(sqrt_2_over_pi);
+        const float32x4_t coeff_vec     = vdupq_n_f32(coeff);
         size_t i = 0;
         for (; i + 8 <= n; i += 8) {
-            float16x8_t xh = vld1q_f16(p + i);
-            float32x4_t x_lo = vcvt_f32_f16(vget_low_f16(xh));
-            float32x4_t x_hi = vcvt_f32_f16(vget_high_f16(xh));
-            auto gelu = [&](float32x4_t x) {
-                float32x4_t x2 = vmulq_f32(x, x);
-                float32x4_t x3 = vmulq_f32(x2, x);
-                float32x4_t z  = vmulq_f32(v_sqrt2pi, vaddq_f32(x, vmulq_f32(v_coeff, x3)));
-                float32x4_t zc = vmaxq_f32(vdupq_n_f32(-4.5f), vminq_f32(vdupq_n_f32(4.5f), z));
-                float32x4_t z2 = vmulq_f32(zc, zc);
-                float32x4_t num = vmulq_f32(zc, vaddq_f32(vdupq_n_f32(27.f), z2));
-                float32x4_t den = vaddq_f32(vdupq_n_f32(27.f), vmulq_f32(vdupq_n_f32(9.f), z2));
-                float32x4_t tanh_z = vdivq_f32(num, den);
-                return vmulq_f32(vmulq_f32(v_half, x), vaddq_f32(v_one, tanh_z));
-            };
-            float16x8_t out = vcombine_f16(vcvt_f16_f32(gelu(x_lo)), vcvt_f16_f32(gelu(x_hi)));
-            vst1q_f16(p + i, out);
+            float16x8_t x_f16 = vld1q_f16(p + i);
+            float32x4_t x_lo = vcvt_f32_f16(vget_low_f16(x_f16));
+            float32x4_t x_hi = vcvt_f32_f16(vget_high_f16(x_f16));
+            float32x4_t x3_lo = vmulq_f32(vmulq_f32(x_lo, x_lo), x_lo);
+            float32x4_t x3_hi = vmulq_f32(vmulq_f32(x_hi, x_hi), x_hi);
+            float32x4_t inner_lo = vmulq_f32(sqrt_2_pi_vec, vfmaq_f32(x_lo, coeff_vec, x3_lo));
+            float32x4_t inner_hi = vmulq_f32(sqrt_2_pi_vec, vfmaq_f32(x_hi, coeff_vec, x3_hi));
+            float32x4_t tanh_lo = fast_tanh_f32x4(inner_lo);
+            float32x4_t tanh_hi = fast_tanh_f32x4(inner_hi);
+            float32x4_t g_lo = vmulq_f32(vmulq_f32(half, x_lo), vaddq_f32(one, tanh_lo));
+            float32x4_t g_hi = vmulq_f32(vmulq_f32(half, x_hi), vaddq_f32(one, tanh_hi));
+            vst1q_f16(p + i, vcombine_f16(vcvt_f16_f32(g_lo), vcvt_f16_f32(g_hi)));
         }
         for (; i < n; ++i) {
             float x = static_cast<float>(p[i]);
-            float x3 = x * x * x;
-            float z  = 0.7978845608028654f * (x + 0.044715f * x3);
-            if (z > 4.5f) z = 4.5f; else if (z < -4.5f) z = -4.5f;
-            float z2 = z * z;
-            float tanh_z = (z * (27.f + z2)) / (27.f + 9.f * z2);
-            p[i] = static_cast<__fp16>(0.5f * x * (1.f + tanh_z));
+            float inner = sqrt_2_over_pi * (x + coeff * x * x * x);
+            p[i] = static_cast<__fp16>(0.5f * x * (1.0f + tanhf(inner)));
+        }
+    }
+
+    // Inline mirror of cactus_multiply_f16's small-N SIMD body. k_count is
+    // tile-sized (≤ 128 for Gemma-4) so streaming stores aren't relevant.
+    static inline void multiply_inplace_fp16(const __fp16* a, const __fp16* b, __fp16* out, size_t n) {
+        size_t i = 0;
+        for (; i + 8 <= n; i += 8) {
+            float16x8_t va = vld1q_f16(a + i);
+            float16x8_t vb = vld1q_f16(b + i);
+            vst1q_f16(out + i, vmulq_f16(va, vb));
+        }
+        for (; i < n; ++i) out[i] = a[i] * b[i];
+    }
+
+    // Single-threaded mirror of cactus_fp16_to_int8's SIMD body (kernel_quants.cpp).
+    // Called once per layer on the dispatch thread; staying single-threaded avoids
+    // a parallel_for barrier between phase 1 and phase 2.
+    static inline void fp16_to_int8_inplace(const __fp16* src, int8_t* dst, size_t n, float scale) {
+        const float inv_scale = 1.0f / scale;
+        const float32x4_t inv_vec = vdupq_n_f32(inv_scale);
+        const float32x4_t min_vec = vdupq_n_f32(-128.0f);
+        const float32x4_t max_vec = vdupq_n_f32(127.0f);
+        size_t i = 0;
+        for (; i + 8 <= n; i += 8) {
+            float16x8_t in = vld1q_f16(src + i);
+            float32x4_t lo = vmulq_f32(vcvt_f32_f16(vget_low_f16(in)),  inv_vec);
+            float32x4_t hi = vmulq_f32(vcvt_f32_f16(vget_high_f16(in)), inv_vec);
+            lo = vmaxq_f32(vminq_f32(lo, max_vec), min_vec);
+            hi = vmaxq_f32(vminq_f32(hi, max_vec), min_vec);
+            int16x8_t s = vcombine_s16(vqmovn_s32(vcvtnq_s32_f32(lo)),
+                                        vqmovn_s32(vcvtnq_s32_f32(hi)));
+            vst1_s8(dst + i, vqmovn_s16(s));
+        }
+        for (; i < n; ++i) {
+            float v = static_cast<float>(src[i]) * inv_scale;
+            if (v > 127.0f) v = 127.0f; else if (v < -128.0f) v = -128.0f;
+            dst[i] = static_cast<int8_t>(std::lround(v));
         }
     }
 }
@@ -620,9 +652,8 @@ void compute_dense_mlp_int4_fused_node(
 
     auto& pool = CactusThreading::get_thread_pool();
     const size_t num_workers = pool.num_workers();
-    if (dense_fused_scratch.size() < num_workers + 1) dense_fused_scratch.resize(num_workers + 1);
-    for (size_t w = 0; w < num_workers + 1; ++w) {
-        auto& sc = dense_fused_scratch[w];
+    if (dense_fused_scratch.size() < num_workers) dense_fused_scratch.resize(num_workers);
+    for (auto& sc : dense_fused_scratch) {
         if (sc.gate_tile.size() < tile_rows) sc.gate_tile.resize(tile_rows);
         if (sc.up_tile.size()   < tile_rows) sc.up_tile.resize(tile_rows);
     }
@@ -635,8 +666,10 @@ void compute_dense_mlp_int4_fused_node(
         cactus_fp16_to_int8(x, dense_x_int8.data() + t * hidden_dim, hidden_dim, xs);
     }
 
-    const size_t num_threads = std::min(num_workers,
-                                         std::max(blocks_d_ffn, blocks_hidden));
+    const size_t tiles_d_ffn  = (blocks_d_ffn  + tile_n_blocks - 1) / tile_n_blocks;
+    const size_t tiles_hidden = (blocks_hidden + tile_n_blocks - 1) / tile_n_blocks;
+    const size_t num_threads_p1 = std::min(num_workers, tiles_d_ffn);
+    const size_t num_threads_p2 = std::min(num_workers, tiles_hidden);
 
     for (size_t t = 0; t < M; ++t) {
         const int8_t* x_int8 = dense_x_int8.data() + t * hidden_dim;
@@ -644,9 +677,6 @@ void compute_dense_mlp_int4_fused_node(
         __fp16* y = output + t * hidden_dim;
         __fp16* h_full = dense_h_fp16.data();
         int8_t* h_int8 = dense_h_int8.data();
-
-        const size_t tiles_d_ffn  = (blocks_d_ffn  + tile_n_blocks - 1) / tile_n_blocks;
-        const size_t tiles_hidden = (blocks_hidden + tile_n_blocks - 1) / tile_n_blocks;
 
         std::atomic<size_t> p1_next{0};
         std::atomic<size_t> p2_next{0};
@@ -670,24 +700,14 @@ void compute_dense_mlp_int4_fused_node(
                 cactus_gemv_int4_block_range(
                     x_int8, x_scale, up_w, up_s, up_tile_buf - k_lo,
                     hidden_dim, d_ffn, group_size, blk_start, blk_end, false);
-
-                __fp16* h_dst = h_full + k_lo;
-                size_t k = 0;
-                for (; k + 8 <= k_count; k += 8) {
-                    float16x8_t a = vld1q_f16(gate_tile_buf + k);
-                    float16x8_t b = vld1q_f16(up_tile_buf + k);
-                    vst1q_f16(h_dst + k, vmulq_f16(a, b));
-                }
-                for (; k < k_count; ++k) {
-                    h_dst[k] = static_cast<__fp16>(float(gate_tile_buf[k]) * float(up_tile_buf[k]));
-                }
+                multiply_inplace_fp16(gate_tile_buf, up_tile_buf, h_full + k_lo, k_count);
             }
         };
 
-        if (num_threads <= 1) {
+        if (num_threads_p1 <= 1) {
             phase1_task(0);
         } else {
-            pool.enqueue_n_threads(num_threads - 1, num_threads - 1,
+            pool.enqueue_n_threads(num_threads_p1 - 1, num_threads_p1 - 1,
                 [&](size_t start, size_t end) {
                     for (size_t w = start; w < end; ++w) phase1_task(w + 1);
                 });
@@ -695,31 +715,10 @@ void compute_dense_mlp_int4_fused_node(
             pool.wait_all();
         }
 
-        float h_maxabs = cactus_fp16_max_abs(h_full, d_ffn);
+        const float h_maxabs = cactus_fp16_max_abs(h_full, d_ffn);
         const float h_scale = std::max(h_maxabs / 127.0f, 1e-10f);
-        const float h_inv = 1.0f / h_scale;
-        {
-            const float32x4_t v_inv = vdupq_n_f32(h_inv);
-            size_t k = 0;
-            for (; k + 16 <= d_ffn; k += 16) {
-                float16x8_t f0 = vld1q_f16(h_full + k);
-                float16x8_t f1 = vld1q_f16(h_full + k + 8);
-                float32x4_t a0 = vmulq_f32(vcvt_f32_f16(vget_low_f16(f0)),  v_inv);
-                float32x4_t a1 = vmulq_f32(vcvt_f32_f16(vget_high_f16(f0)), v_inv);
-                float32x4_t a2 = vmulq_f32(vcvt_f32_f16(vget_low_f16(f1)),  v_inv);
-                float32x4_t a3 = vmulq_f32(vcvt_f32_f16(vget_high_f16(f1)), v_inv);
-                int16x8_t s01 = vcombine_s16(vqmovn_s32(vcvtnq_s32_f32(a0)), vqmovn_s32(vcvtnq_s32_f32(a1)));
-                int16x8_t s23 = vcombine_s16(vqmovn_s32(vcvtnq_s32_f32(a2)), vqmovn_s32(vcvtnq_s32_f32(a3)));
-                vst1q_s8(h_int8 + k, vcombine_s8(vqmovn_s16(s01), vqmovn_s16(s23)));
-            }
-            for (; k < d_ffn; ++k) {
-                int q = (int)std::lround(float(h_full[k]) * h_inv);
-                if (q > 127) q = 127; else if (q < -128) q = -128;
-                h_int8[k] = static_cast<int8_t>(q);
-            }
-        }
+        fp16_to_int8_inplace(h_full, h_int8, d_ffn, h_scale);
 
-        const size_t num_threads_p2 = std::min(num_workers, std::max<size_t>(1, blocks_hidden));
         auto phase2_task = [&](size_t /*worker_id*/) {
             while (true) {
                 size_t tile_id = p2_next.fetch_add(1, std::memory_order_relaxed);

--- a/cactus/graph/graph_ops_nn.cpp
+++ b/cactus/graph/graph_ops_nn.cpp
@@ -9,6 +9,7 @@
 #include <assert.h>
 #include <algorithm>
 #include <limits>
+#include <atomic>
 
 namespace {
     thread_local std::vector<__fp16> transpose_buffer_fp16;
@@ -507,6 +508,278 @@ void compute_moe_layer_node(GraphNode& node, const std::vector<std::unique_ptr<G
             auto* out_row = output + tok * hidden_dim;
             const auto* expert_row = expert_out + i * hidden_dim;
             cactus_add_scaled_f16(out_row, expert_row, out_row, hidden_dim, route_weight);
+        }
+    }
+}
+
+namespace {
+    struct DenseFusedScratch {
+        std::vector<float>  y_acc;
+        std::vector<__fp16> gate_tile;
+        std::vector<__fp16> up_tile;
+        std::vector<int8_t> h_int8;
+    };
+    static std::vector<DenseFusedScratch> dense_fused_scratch;
+
+    static inline void gelu_tanh_inplace_fp16(__fp16* p, size_t n) {
+        const float32x4_t v_half    = vdupq_n_f32(0.5f);
+        const float32x4_t v_one     = vdupq_n_f32(1.0f);
+        const float32x4_t v_sqrt2pi = vdupq_n_f32(0.7978845608028654f);
+        const float32x4_t v_coeff   = vdupq_n_f32(0.044715f);
+        size_t i = 0;
+        for (; i + 8 <= n; i += 8) {
+            float16x8_t xh = vld1q_f16(p + i);
+            float32x4_t x_lo = vcvt_f32_f16(vget_low_f16(xh));
+            float32x4_t x_hi = vcvt_f32_f16(vget_high_f16(xh));
+            auto gelu = [&](float32x4_t x) {
+                float32x4_t x2 = vmulq_f32(x, x);
+                float32x4_t x3 = vmulq_f32(x2, x);
+                float32x4_t z  = vmulq_f32(v_sqrt2pi, vaddq_f32(x, vmulq_f32(v_coeff, x3)));
+                float32x4_t zc = vmaxq_f32(vdupq_n_f32(-4.5f), vminq_f32(vdupq_n_f32(4.5f), z));
+                float32x4_t z2 = vmulq_f32(zc, zc);
+                float32x4_t num = vmulq_f32(zc, vaddq_f32(vdupq_n_f32(27.f), z2));
+                float32x4_t den = vaddq_f32(vdupq_n_f32(27.f), vmulq_f32(vdupq_n_f32(9.f), z2));
+                float32x4_t tanh_z = vdivq_f32(num, den);
+                return vmulq_f32(vmulq_f32(v_half, x), vaddq_f32(v_one, tanh_z));
+            };
+            float16x8_t out = vcombine_f16(vcvt_f16_f32(gelu(x_lo)), vcvt_f16_f32(gelu(x_hi)));
+            vst1q_f16(p + i, out);
+        }
+        for (; i < n; ++i) {
+            float x = static_cast<float>(p[i]);
+            float x3 = x * x * x;
+            float z  = 0.7978845608028654f * (x + 0.044715f * x3);
+            if (z > 4.5f) z = 4.5f; else if (z < -4.5f) z = -4.5f;
+            float z2 = z * z;
+            float tanh_z = (z * (27.f + z2)) / (27.f + 9.f * z2);
+            p[i] = static_cast<__fp16>(0.5f * x * (1.f + tanh_z));
+        }
+    }
+}
+
+void compute_dense_mlp_int4_fused_node(
+        GraphNode& node,
+        const std::vector<std::unique_ptr<GraphNode>>& nodes,
+        const std::unordered_map<size_t, size_t>& node_index_map) {
+    const auto& hidden_buf = get_input(node, 0, nodes, node_index_map);
+    const auto& gate_buf   = get_input(node, 1, nodes, node_index_map);
+    const auto& up_buf     = get_input(node, 2, nodes, node_index_map);
+    const auto& down_buf   = get_input(node, 3, nodes, node_index_map);
+
+    if (hidden_buf.precision != Precision::FP16) {
+        throw std::runtime_error("dense_mlp_int4_fused: hidden must be FP16");
+    }
+    if (gate_buf.precision != Precision::INT4 || gate_buf.group_size == 0 ||
+        up_buf.precision   != Precision::INT4 || up_buf.group_size   == 0 ||
+        down_buf.precision != Precision::INT4 || down_buf.group_size == 0) {
+        throw std::runtime_error("dense_mlp_int4_fused: weights must be INT4 group-quantized");
+    }
+    const size_t group_size = gate_buf.group_size;
+    if (up_buf.group_size != group_size || down_buf.group_size != group_size) {
+        throw std::runtime_error("dense_mlp_int4_fused: gate/up/down group_size must match");
+    }
+
+    const auto& shape = hidden_buf.shape;
+    const size_t hidden_dim_in = shape.back();
+    size_t M = 1;
+    for (size_t i = 0; i + 1 < shape.size(); ++i) M *= shape[i];
+
+    const size_t d_ffn      = gate_buf.is_interleaved ? gate_buf.original_N : gate_buf.shape[0];
+    const size_t hidden_dim = down_buf.is_interleaved ? down_buf.original_N : down_buf.shape[0];
+    if (hidden_dim_in != hidden_dim) {
+        throw std::runtime_error("dense_mlp_int4_fused: hidden dim mismatch with down weight");
+    }
+    if (d_ffn % 4 != 0) {
+        throw std::runtime_error("dense_mlp_int4_fused: d_ffn must be a multiple of 4");
+    }
+    if (d_ffn % group_size != 0) {
+        throw std::runtime_error("dense_mlp_int4_fused: d_ffn must be a multiple of group_size");
+    }
+    const size_t total_n_blocks = d_ffn / 4;
+
+    constexpr size_t tile_n_blocks = 32;
+    constexpr size_t tile_rows = tile_n_blocks * 4;
+    if (tile_rows % group_size != 0) {
+        throw std::runtime_error("dense_mlp_int4_fused: tile_rows must be a multiple of group_size");
+    }
+
+    const __fp16* hidden_fp16 = hidden_buf.data_as<__fp16>();
+    __fp16* output = node.output_buffer.data_as<__fp16>();
+
+    const int8_t* gate_w = gate_buf.data_as<int8_t>();
+    const __fp16* gate_s = gate_buf.scales_as_fp16();
+    const int8_t* up_w   = up_buf.data_as<int8_t>();
+    const __fp16* up_s   = up_buf.scales_as_fp16();
+    const int8_t* down_w = down_buf.data_as<int8_t>();
+    const __fp16* down_s = down_buf.scales_as_fp16();
+
+    thread_local std::vector<int8_t> dense_x_int8;
+    thread_local std::vector<float>  dense_x_scales;
+    if (dense_x_int8.size()    < M * hidden_dim) dense_x_int8.resize(M * hidden_dim);
+    if (dense_x_scales.size()  < M)              dense_x_scales.resize(M);
+
+    auto& pool = CactusThreading::get_thread_pool();
+    const size_t num_workers = pool.num_workers();
+    if (dense_fused_scratch.size() < num_workers + 1) dense_fused_scratch.resize(num_workers + 1);
+    for (size_t w = 0; w < num_workers + 1; ++w) {
+        auto& sc = dense_fused_scratch[w];
+        if (sc.y_acc.size()     < hidden_dim) sc.y_acc.resize(hidden_dim);
+        if (sc.gate_tile.size() < tile_rows)  sc.gate_tile.resize(tile_rows);
+        if (sc.up_tile.size()   < tile_rows)  sc.up_tile.resize(tile_rows);
+        if (sc.h_int8.size()    < tile_rows)  sc.h_int8.resize(tile_rows);
+    }
+
+    for (size_t t = 0; t < M; ++t) {
+        const __fp16* x = hidden_fp16 + t * hidden_dim;
+        float maxabs = cactus_fp16_max_abs(x, hidden_dim);
+        float xs = std::max(maxabs / 127.0f, 1e-10f);
+        dense_x_scales[t] = xs;
+        cactus_fp16_to_int8(x, dense_x_int8.data() + t * hidden_dim, hidden_dim, xs);
+    }
+
+    const size_t num_threads = std::min(num_workers, total_n_blocks);
+
+    for (size_t t = 0; t < M; ++t) {
+        const int8_t* x_int8 = dense_x_int8.data() + t * hidden_dim;
+        const float x_scale = dense_x_scales[t];
+        __fp16* y = output + t * hidden_dim;
+
+        for (size_t w = 0; w < num_threads; ++w) {
+            std::fill(dense_fused_scratch[w].y_acc.begin(),
+                      dense_fused_scratch[w].y_acc.begin() + hidden_dim, 0.0f);
+        }
+
+        std::atomic<size_t> next_tile{0};
+        const size_t tile_count = (total_n_blocks + tile_n_blocks - 1) / tile_n_blocks;
+
+        auto tile_task = [&](size_t worker_id) {
+            auto& sc = dense_fused_scratch[worker_id];
+            __fp16* gate_tile_buf = sc.gate_tile.data();
+            __fp16* up_tile_buf   = sc.up_tile.data();
+            int8_t* h_int8_buf    = sc.h_int8.data();
+            float*  y_acc         = sc.y_acc.data();
+
+            while (true) {
+                size_t tile_id = next_tile.fetch_add(1, std::memory_order_relaxed);
+                if (tile_id >= tile_count) break;
+
+                const size_t blk_start = tile_id * tile_n_blocks;
+                size_t blk_end = blk_start + tile_n_blocks;
+                if (blk_end > total_n_blocks) blk_end = total_n_blocks;
+
+                const size_t k_lo = blk_start * 4;
+                const size_t k_count = (blk_end - blk_start) * 4;
+
+                __fp16* gate_C_biased = gate_tile_buf - k_lo;
+                __fp16* up_C_biased   = up_tile_buf   - k_lo;
+
+                cactus_gemv_int4_block_range(
+                    x_int8, x_scale,
+                    gate_w, gate_s,
+                    gate_C_biased,
+                    hidden_dim, d_ffn, group_size,
+                    blk_start, blk_end,
+                    false);
+
+                gelu_tanh_inplace_fp16(gate_tile_buf, k_count);
+
+                cactus_gemv_int4_block_range(
+                    x_int8, x_scale,
+                    up_w, up_s,
+                    up_C_biased,
+                    hidden_dim, d_ffn, group_size,
+                    blk_start, blk_end,
+                    false);
+
+                float h_max;
+                {
+                    float16x8_t v_max = vdupq_n_f16(static_cast<__fp16>(1e-6f));
+                    size_t k = 0;
+                    for (; k + 8 <= k_count; k += 8) {
+                        float16x8_t a = vld1q_f16(gate_tile_buf + k);
+                        float16x8_t b = vld1q_f16(up_tile_buf   + k);
+                        float16x8_t v = vmulq_f16(a, b);
+                        vst1q_f16(up_tile_buf + k, v);
+                        v_max = vmaxq_f16(v_max, vabsq_f16(v));
+                    }
+                    float32x4_t m_lo = vcvt_f32_f16(vget_low_f16(v_max));
+                    float32x4_t m_hi = vcvt_f32_f16(vget_high_f16(v_max));
+                    float32x4_t mm = vmaxq_f32(m_lo, m_hi);
+                    h_max = vmaxvq_f32(mm);
+                    for (; k < k_count; ++k) {
+                        float gv = float(gate_tile_buf[k]);
+                        float uv = float(up_tile_buf[k]);
+                        float v = gv * uv;
+                        up_tile_buf[k] = static_cast<__fp16>(v);
+                        float a = std::fabs(v);
+                        if (a > h_max) h_max = a;
+                    }
+                    if (h_max < 1e-6f) h_max = 1e-6f;
+                }
+                const float h_scale = h_max / 127.0f;
+                const float inv = 1.0f / h_scale;
+
+                {
+                    const float32x4_t v_inv = vdupq_n_f32(inv);
+                    size_t k = 0;
+                    for (; k + 16 <= k_count; k += 16) {
+                        float16x8_t f0 = vld1q_f16(up_tile_buf + k);
+                        float16x8_t f1 = vld1q_f16(up_tile_buf + k + 8);
+                        float32x4_t a0 = vmulq_f32(vcvt_f32_f16(vget_low_f16(f0)), v_inv);
+                        float32x4_t a1 = vmulq_f32(vcvt_f32_f16(vget_high_f16(f0)), v_inv);
+                        float32x4_t a2 = vmulq_f32(vcvt_f32_f16(vget_low_f16(f1)), v_inv);
+                        float32x4_t a3 = vmulq_f32(vcvt_f32_f16(vget_high_f16(f1)), v_inv);
+                        int32x4_t q0 = vcvtnq_s32_f32(a0);
+                        int32x4_t q1 = vcvtnq_s32_f32(a1);
+                        int32x4_t q2 = vcvtnq_s32_f32(a2);
+                        int32x4_t q3 = vcvtnq_s32_f32(a3);
+                        int16x8_t s01 = vcombine_s16(vqmovn_s32(q0), vqmovn_s32(q1));
+                        int16x8_t s23 = vcombine_s16(vqmovn_s32(q2), vqmovn_s32(q3));
+                        int8x16_t out = vcombine_s8(vqmovn_s16(s01), vqmovn_s16(s23));
+                        vst1q_s8(h_int8_buf + k, out);
+                    }
+                    for (; k < k_count; ++k) {
+                        float v = float(up_tile_buf[k]) * inv;
+                        int q = (int)std::lround(v);
+                        if (q > 127) q = 127; else if (q < -128) q = -128;
+                        h_int8_buf[k] = static_cast<int8_t>(q);
+                    }
+                }
+
+                cactus_gemv_int4_st_kslice_fp32acc(
+                    h_int8_buf, h_scale,
+                    down_w, down_s,
+                    y_acc,
+                    d_ffn, hidden_dim, group_size,
+                    k_lo, k_count);
+            }
+        };
+
+        if (num_threads <= 1) {
+            tile_task(0);
+        } else {
+            pool.enqueue_n_threads(num_threads - 1, num_threads - 1,
+                [&](size_t start, size_t end) {
+                    for (size_t w = start; w < end; ++w) tile_task(w + 1);
+                });
+            tile_task(0);
+            pool.wait_all();
+        }
+
+        {
+            size_t k = 0;
+            for (; k + 4 <= hidden_dim; k += 4) {
+                float32x4_t s = vld1q_f32(dense_fused_scratch[0].y_acc.data() + k);
+                for (size_t w = 1; w < num_threads; ++w) {
+                    s = vaddq_f32(s, vld1q_f32(dense_fused_scratch[w].y_acc.data() + k));
+                }
+                vst1_f16(y + k, vcvt_f16_f32(s));
+            }
+            for (; k < hidden_dim; ++k) {
+                float s = dense_fused_scratch[0].y_acc[k];
+                for (size_t w = 1; w < num_threads; ++w) s += dense_fused_scratch[w].y_acc[k];
+                y[k] = static_cast<__fp16>(s);
+            }
         }
     }
 }

--- a/cactus/graph/graph_ops_nn.cpp
+++ b/cactus/graph/graph_ops_nn.cpp
@@ -514,10 +514,8 @@ void compute_moe_layer_node(GraphNode& node, const std::vector<std::unique_ptr<G
 
 namespace {
     struct DenseFusedScratch {
-        std::vector<float>  y_acc;
         std::vector<__fp16> gate_tile;
         std::vector<__fp16> up_tile;
-        std::vector<int8_t> h_int8;
     };
     static std::vector<DenseFusedScratch> dense_fused_scratch;
 
@@ -589,13 +587,11 @@ void compute_dense_mlp_int4_fused_node(
     if (hidden_dim_in != hidden_dim) {
         throw std::runtime_error("dense_mlp_int4_fused: hidden dim mismatch with down weight");
     }
-    if (d_ffn % 4 != 0) {
-        throw std::runtime_error("dense_mlp_int4_fused: d_ffn must be a multiple of 4");
+    if (d_ffn % 4 != 0 || d_ffn % group_size != 0 || hidden_dim % 4 != 0) {
+        throw std::runtime_error("dense_mlp_int4_fused: d_ffn must be a multiple of 4 and of group_size, hidden_dim a multiple of 4");
     }
-    if (d_ffn % group_size != 0) {
-        throw std::runtime_error("dense_mlp_int4_fused: d_ffn must be a multiple of group_size");
-    }
-    const size_t total_n_blocks = d_ffn / 4;
+    const size_t blocks_d_ffn  = d_ffn / 4;
+    const size_t blocks_hidden = hidden_dim / 4;
 
     constexpr size_t tile_n_blocks = 32;
     constexpr size_t tile_rows = tile_n_blocks * 4;
@@ -615,18 +611,20 @@ void compute_dense_mlp_int4_fused_node(
 
     thread_local std::vector<int8_t> dense_x_int8;
     thread_local std::vector<float>  dense_x_scales;
-    if (dense_x_int8.size()    < M * hidden_dim) dense_x_int8.resize(M * hidden_dim);
-    if (dense_x_scales.size()  < M)              dense_x_scales.resize(M);
+    thread_local std::vector<__fp16> dense_h_fp16;
+    thread_local std::vector<int8_t> dense_h_int8;
+    if (dense_x_int8.size()   < M * hidden_dim) dense_x_int8.resize(M * hidden_dim);
+    if (dense_x_scales.size() < M)              dense_x_scales.resize(M);
+    if (dense_h_fp16.size()   < d_ffn)          dense_h_fp16.resize(d_ffn);
+    if (dense_h_int8.size()   < d_ffn)          dense_h_int8.resize(d_ffn);
 
     auto& pool = CactusThreading::get_thread_pool();
     const size_t num_workers = pool.num_workers();
     if (dense_fused_scratch.size() < num_workers + 1) dense_fused_scratch.resize(num_workers + 1);
     for (size_t w = 0; w < num_workers + 1; ++w) {
         auto& sc = dense_fused_scratch[w];
-        if (sc.y_acc.size()     < hidden_dim) sc.y_acc.resize(hidden_dim);
-        if (sc.gate_tile.size() < tile_rows)  sc.gate_tile.resize(tile_rows);
-        if (sc.up_tile.size()   < tile_rows)  sc.up_tile.resize(tile_rows);
-        if (sc.h_int8.size()    < tile_rows)  sc.h_int8.resize(tile_rows);
+        if (sc.gate_tile.size() < tile_rows) sc.gate_tile.resize(tile_rows);
+        if (sc.up_tile.size()   < tile_rows) sc.up_tile.resize(tile_rows);
     }
 
     for (size_t t = 0; t < M; ++t) {
@@ -637,149 +635,112 @@ void compute_dense_mlp_int4_fused_node(
         cactus_fp16_to_int8(x, dense_x_int8.data() + t * hidden_dim, hidden_dim, xs);
     }
 
-    const size_t num_threads = std::min(num_workers, total_n_blocks);
+    const size_t num_threads = std::min(num_workers,
+                                         std::max(blocks_d_ffn, blocks_hidden));
 
     for (size_t t = 0; t < M; ++t) {
         const int8_t* x_int8 = dense_x_int8.data() + t * hidden_dim;
         const float x_scale = dense_x_scales[t];
         __fp16* y = output + t * hidden_dim;
+        __fp16* h_full = dense_h_fp16.data();
+        int8_t* h_int8 = dense_h_int8.data();
 
-        for (size_t w = 0; w < num_threads; ++w) {
-            std::fill(dense_fused_scratch[w].y_acc.begin(),
-                      dense_fused_scratch[w].y_acc.begin() + hidden_dim, 0.0f);
-        }
+        const size_t tiles_d_ffn  = (blocks_d_ffn  + tile_n_blocks - 1) / tile_n_blocks;
+        const size_t tiles_hidden = (blocks_hidden + tile_n_blocks - 1) / tile_n_blocks;
 
-        std::atomic<size_t> next_tile{0};
-        const size_t tile_count = (total_n_blocks + tile_n_blocks - 1) / tile_n_blocks;
+        std::atomic<size_t> p1_next{0};
+        std::atomic<size_t> p2_next{0};
 
-        auto tile_task = [&](size_t worker_id) {
+        auto phase1_task = [&](size_t worker_id) {
             auto& sc = dense_fused_scratch[worker_id];
             __fp16* gate_tile_buf = sc.gate_tile.data();
             __fp16* up_tile_buf   = sc.up_tile.data();
-            int8_t* h_int8_buf    = sc.h_int8.data();
-            float*  y_acc         = sc.y_acc.data();
-
             while (true) {
-                size_t tile_id = next_tile.fetch_add(1, std::memory_order_relaxed);
-                if (tile_id >= tile_count) break;
-
+                size_t tile_id = p1_next.fetch_add(1, std::memory_order_relaxed);
+                if (tile_id >= tiles_d_ffn) break;
                 const size_t blk_start = tile_id * tile_n_blocks;
-                size_t blk_end = blk_start + tile_n_blocks;
-                if (blk_end > total_n_blocks) blk_end = total_n_blocks;
-
-                const size_t k_lo = blk_start * 4;
-                const size_t k_count = (blk_end - blk_start) * 4;
-
-                __fp16* gate_C_biased = gate_tile_buf - k_lo;
-                __fp16* up_C_biased   = up_tile_buf   - k_lo;
+                const size_t blk_end   = std::min(blk_start + tile_n_blocks, blocks_d_ffn);
+                const size_t k_lo      = blk_start * 4;
+                const size_t k_count   = (blk_end - blk_start) * 4;
 
                 cactus_gemv_int4_block_range(
-                    x_int8, x_scale,
-                    gate_w, gate_s,
-                    gate_C_biased,
-                    hidden_dim, d_ffn, group_size,
-                    blk_start, blk_end,
-                    false);
-
+                    x_int8, x_scale, gate_w, gate_s, gate_tile_buf - k_lo,
+                    hidden_dim, d_ffn, group_size, blk_start, blk_end, false);
                 gelu_tanh_inplace_fp16(gate_tile_buf, k_count);
-
                 cactus_gemv_int4_block_range(
-                    x_int8, x_scale,
-                    up_w, up_s,
-                    up_C_biased,
-                    hidden_dim, d_ffn, group_size,
-                    blk_start, blk_end,
-                    false);
+                    x_int8, x_scale, up_w, up_s, up_tile_buf - k_lo,
+                    hidden_dim, d_ffn, group_size, blk_start, blk_end, false);
 
-                float h_max;
-                {
-                    float16x8_t v_max = vdupq_n_f16(static_cast<__fp16>(1e-6f));
-                    size_t k = 0;
-                    for (; k + 8 <= k_count; k += 8) {
-                        float16x8_t a = vld1q_f16(gate_tile_buf + k);
-                        float16x8_t b = vld1q_f16(up_tile_buf   + k);
-                        float16x8_t v = vmulq_f16(a, b);
-                        vst1q_f16(up_tile_buf + k, v);
-                        v_max = vmaxq_f16(v_max, vabsq_f16(v));
-                    }
-                    float32x4_t m_lo = vcvt_f32_f16(vget_low_f16(v_max));
-                    float32x4_t m_hi = vcvt_f32_f16(vget_high_f16(v_max));
-                    float32x4_t mm = vmaxq_f32(m_lo, m_hi);
-                    h_max = vmaxvq_f32(mm);
-                    for (; k < k_count; ++k) {
-                        float gv = float(gate_tile_buf[k]);
-                        float uv = float(up_tile_buf[k]);
-                        float v = gv * uv;
-                        up_tile_buf[k] = static_cast<__fp16>(v);
-                        float a = std::fabs(v);
-                        if (a > h_max) h_max = a;
-                    }
-                    if (h_max < 1e-6f) h_max = 1e-6f;
+                __fp16* h_dst = h_full + k_lo;
+                size_t k = 0;
+                for (; k + 8 <= k_count; k += 8) {
+                    float16x8_t a = vld1q_f16(gate_tile_buf + k);
+                    float16x8_t b = vld1q_f16(up_tile_buf + k);
+                    vst1q_f16(h_dst + k, vmulq_f16(a, b));
                 }
-                const float h_scale = h_max / 127.0f;
-                const float inv = 1.0f / h_scale;
-
-                {
-                    const float32x4_t v_inv = vdupq_n_f32(inv);
-                    size_t k = 0;
-                    for (; k + 16 <= k_count; k += 16) {
-                        float16x8_t f0 = vld1q_f16(up_tile_buf + k);
-                        float16x8_t f1 = vld1q_f16(up_tile_buf + k + 8);
-                        float32x4_t a0 = vmulq_f32(vcvt_f32_f16(vget_low_f16(f0)), v_inv);
-                        float32x4_t a1 = vmulq_f32(vcvt_f32_f16(vget_high_f16(f0)), v_inv);
-                        float32x4_t a2 = vmulq_f32(vcvt_f32_f16(vget_low_f16(f1)), v_inv);
-                        float32x4_t a3 = vmulq_f32(vcvt_f32_f16(vget_high_f16(f1)), v_inv);
-                        int32x4_t q0 = vcvtnq_s32_f32(a0);
-                        int32x4_t q1 = vcvtnq_s32_f32(a1);
-                        int32x4_t q2 = vcvtnq_s32_f32(a2);
-                        int32x4_t q3 = vcvtnq_s32_f32(a3);
-                        int16x8_t s01 = vcombine_s16(vqmovn_s32(q0), vqmovn_s32(q1));
-                        int16x8_t s23 = vcombine_s16(vqmovn_s32(q2), vqmovn_s32(q3));
-                        int8x16_t out = vcombine_s8(vqmovn_s16(s01), vqmovn_s16(s23));
-                        vst1q_s8(h_int8_buf + k, out);
-                    }
-                    for (; k < k_count; ++k) {
-                        float v = float(up_tile_buf[k]) * inv;
-                        int q = (int)std::lround(v);
-                        if (q > 127) q = 127; else if (q < -128) q = -128;
-                        h_int8_buf[k] = static_cast<int8_t>(q);
-                    }
+                for (; k < k_count; ++k) {
+                    h_dst[k] = static_cast<__fp16>(float(gate_tile_buf[k]) * float(up_tile_buf[k]));
                 }
-
-                cactus_gemv_int4_st_kslice_fp32acc(
-                    h_int8_buf, h_scale,
-                    down_w, down_s,
-                    y_acc,
-                    d_ffn, hidden_dim, group_size,
-                    k_lo, k_count);
             }
         };
 
         if (num_threads <= 1) {
-            tile_task(0);
+            phase1_task(0);
         } else {
             pool.enqueue_n_threads(num_threads - 1, num_threads - 1,
                 [&](size_t start, size_t end) {
-                    for (size_t w = start; w < end; ++w) tile_task(w + 1);
+                    for (size_t w = start; w < end; ++w) phase1_task(w + 1);
                 });
-            tile_task(0);
+            phase1_task(0);
             pool.wait_all();
         }
 
+        float h_maxabs = cactus_fp16_max_abs(h_full, d_ffn);
+        const float h_scale = std::max(h_maxabs / 127.0f, 1e-10f);
+        const float h_inv = 1.0f / h_scale;
         {
+            const float32x4_t v_inv = vdupq_n_f32(h_inv);
             size_t k = 0;
-            for (; k + 4 <= hidden_dim; k += 4) {
-                float32x4_t s = vld1q_f32(dense_fused_scratch[0].y_acc.data() + k);
-                for (size_t w = 1; w < num_threads; ++w) {
-                    s = vaddq_f32(s, vld1q_f32(dense_fused_scratch[w].y_acc.data() + k));
-                }
-                vst1_f16(y + k, vcvt_f16_f32(s));
+            for (; k + 16 <= d_ffn; k += 16) {
+                float16x8_t f0 = vld1q_f16(h_full + k);
+                float16x8_t f1 = vld1q_f16(h_full + k + 8);
+                float32x4_t a0 = vmulq_f32(vcvt_f32_f16(vget_low_f16(f0)),  v_inv);
+                float32x4_t a1 = vmulq_f32(vcvt_f32_f16(vget_high_f16(f0)), v_inv);
+                float32x4_t a2 = vmulq_f32(vcvt_f32_f16(vget_low_f16(f1)),  v_inv);
+                float32x4_t a3 = vmulq_f32(vcvt_f32_f16(vget_high_f16(f1)), v_inv);
+                int16x8_t s01 = vcombine_s16(vqmovn_s32(vcvtnq_s32_f32(a0)), vqmovn_s32(vcvtnq_s32_f32(a1)));
+                int16x8_t s23 = vcombine_s16(vqmovn_s32(vcvtnq_s32_f32(a2)), vqmovn_s32(vcvtnq_s32_f32(a3)));
+                vst1q_s8(h_int8 + k, vcombine_s8(vqmovn_s16(s01), vqmovn_s16(s23)));
             }
-            for (; k < hidden_dim; ++k) {
-                float s = dense_fused_scratch[0].y_acc[k];
-                for (size_t w = 1; w < num_threads; ++w) s += dense_fused_scratch[w].y_acc[k];
-                y[k] = static_cast<__fp16>(s);
+            for (; k < d_ffn; ++k) {
+                int q = (int)std::lround(float(h_full[k]) * h_inv);
+                if (q > 127) q = 127; else if (q < -128) q = -128;
+                h_int8[k] = static_cast<int8_t>(q);
             }
+        }
+
+        const size_t num_threads_p2 = std::min(num_workers, std::max<size_t>(1, blocks_hidden));
+        auto phase2_task = [&](size_t /*worker_id*/) {
+            while (true) {
+                size_t tile_id = p2_next.fetch_add(1, std::memory_order_relaxed);
+                if (tile_id >= tiles_hidden) break;
+                const size_t blk_start = tile_id * tile_n_blocks;
+                const size_t blk_end   = std::min(blk_start + tile_n_blocks, blocks_hidden);
+                cactus_gemv_int4_block_range(
+                    h_int8, h_scale, down_w, down_s, y,
+                    d_ffn, hidden_dim, group_size, blk_start, blk_end, false);
+            }
+        };
+
+        if (num_threads_p2 <= 1) {
+            phase2_task(0);
+        } else {
+            pool.enqueue_n_threads(num_threads_p2 - 1, num_threads_p2 - 1,
+                [&](size_t start, size_t end) {
+                    for (size_t w = start; w < end; ++w) phase2_task(w + 1);
+                });
+            phase2_task(0);
+            pool.wait_all();
         }
     }
 }

--- a/cactus/graph/graph_ops_nn.cpp
+++ b/cactus/graph/graph_ops_nn.cpp
@@ -517,7 +517,6 @@ namespace {
         std::vector<__fp16> gate_tile;
         std::vector<__fp16> up_tile;
     };
-    static std::vector<DenseFusedScratch> dense_fused_scratch;
 
     // Inline to skip cactus_fp16_to_int8's parallel_for orchestration, which
     // dispatches ~5 threads at d_ffn=12288 and dominates the SIMD work.
@@ -610,10 +609,10 @@ void compute_dense_mlp_int4_fused_node(
 
     auto& pool = CactusThreading::get_thread_pool();
     const size_t num_workers = pool.num_workers();
-    if (dense_fused_scratch.size() < num_workers) dense_fused_scratch.resize(num_workers);
+    std::vector<DenseFusedScratch> dense_fused_scratch(num_workers);
     for (auto& sc : dense_fused_scratch) {
-        if (sc.gate_tile.size() < tile_rows) sc.gate_tile.resize(tile_rows);
-        if (sc.up_tile.size()   < tile_rows) sc.up_tile.resize(tile_rows);
+        sc.gate_tile.resize(tile_rows);
+        sc.up_tile.resize(tile_rows);
     }
 
     for (size_t t = 0; t < M; ++t) {

--- a/cactus/graph/graph_ops_nn.cpp
+++ b/cactus/graph/graph_ops_nn.cpp
@@ -518,73 +518,6 @@ namespace {
         std::vector<__fp16> up_tile;
     };
     static std::vector<DenseFusedScratch> dense_fused_scratch;
-
-    static inline void gelu_tanh_inplace_fp16(__fp16* p, size_t n) {
-        const float sqrt_2_over_pi = 0.7978845608028654f;
-        const float coeff = 0.044715f;
-        const float32x4_t half = vdupq_n_f32(0.5f);
-        const float32x4_t one  = vdupq_n_f32(1.0f);
-        const float32x4_t sqrt_2_pi_vec = vdupq_n_f32(sqrt_2_over_pi);
-        const float32x4_t coeff_vec     = vdupq_n_f32(coeff);
-        size_t i = 0;
-        for (; i + 8 <= n; i += 8) {
-            float16x8_t x_f16 = vld1q_f16(p + i);
-            float32x4_t x_lo = vcvt_f32_f16(vget_low_f16(x_f16));
-            float32x4_t x_hi = vcvt_f32_f16(vget_high_f16(x_f16));
-            float32x4_t x3_lo = vmulq_f32(vmulq_f32(x_lo, x_lo), x_lo);
-            float32x4_t x3_hi = vmulq_f32(vmulq_f32(x_hi, x_hi), x_hi);
-            float32x4_t inner_lo = vmulq_f32(sqrt_2_pi_vec, vfmaq_f32(x_lo, coeff_vec, x3_lo));
-            float32x4_t inner_hi = vmulq_f32(sqrt_2_pi_vec, vfmaq_f32(x_hi, coeff_vec, x3_hi));
-            float32x4_t tanh_lo = fast_tanh_f32x4(inner_lo);
-            float32x4_t tanh_hi = fast_tanh_f32x4(inner_hi);
-            float32x4_t g_lo = vmulq_f32(vmulq_f32(half, x_lo), vaddq_f32(one, tanh_lo));
-            float32x4_t g_hi = vmulq_f32(vmulq_f32(half, x_hi), vaddq_f32(one, tanh_hi));
-            vst1q_f16(p + i, vcombine_f16(vcvt_f16_f32(g_lo), vcvt_f16_f32(g_hi)));
-        }
-        for (; i < n; ++i) {
-            float x = static_cast<float>(p[i]);
-            float inner = sqrt_2_over_pi * (x + coeff * x * x * x);
-            p[i] = static_cast<__fp16>(0.5f * x * (1.0f + tanhf(inner)));
-        }
-    }
-
-    // Inline mirror of cactus_multiply_f16's small-N SIMD body. k_count is
-    // tile-sized (≤ 128 for Gemma-4) so streaming stores aren't relevant.
-    static inline void multiply_inplace_fp16(const __fp16* a, const __fp16* b, __fp16* out, size_t n) {
-        size_t i = 0;
-        for (; i + 8 <= n; i += 8) {
-            float16x8_t va = vld1q_f16(a + i);
-            float16x8_t vb = vld1q_f16(b + i);
-            vst1q_f16(out + i, vmulq_f16(va, vb));
-        }
-        for (; i < n; ++i) out[i] = a[i] * b[i];
-    }
-
-    // Single-threaded mirror of cactus_fp16_to_int8's SIMD body (kernel_quants.cpp).
-    // Called once per layer on the dispatch thread; staying single-threaded avoids
-    // a parallel_for barrier between phase 1 and phase 2.
-    static inline void fp16_to_int8_inplace(const __fp16* src, int8_t* dst, size_t n, float scale) {
-        const float inv_scale = 1.0f / scale;
-        const float32x4_t inv_vec = vdupq_n_f32(inv_scale);
-        const float32x4_t min_vec = vdupq_n_f32(-128.0f);
-        const float32x4_t max_vec = vdupq_n_f32(127.0f);
-        size_t i = 0;
-        for (; i + 8 <= n; i += 8) {
-            float16x8_t in = vld1q_f16(src + i);
-            float32x4_t lo = vmulq_f32(vcvt_f32_f16(vget_low_f16(in)),  inv_vec);
-            float32x4_t hi = vmulq_f32(vcvt_f32_f16(vget_high_f16(in)), inv_vec);
-            lo = vmaxq_f32(vminq_f32(lo, max_vec), min_vec);
-            hi = vmaxq_f32(vminq_f32(hi, max_vec), min_vec);
-            int16x8_t s = vcombine_s16(vqmovn_s32(vcvtnq_s32_f32(lo)),
-                                        vqmovn_s32(vcvtnq_s32_f32(hi)));
-            vst1_s8(dst + i, vqmovn_s16(s));
-        }
-        for (; i < n; ++i) {
-            float v = static_cast<float>(src[i]) * inv_scale;
-            if (v > 127.0f) v = 127.0f; else if (v < -128.0f) v = -128.0f;
-            dst[i] = static_cast<int8_t>(std::lround(v));
-        }
-    }
 }
 
 void compute_dense_mlp_int4_fused_node(
@@ -705,17 +638,17 @@ void compute_dense_mlp_int4_fused_node(
                 cactus_gemv_int4_block_range(
                     x_int8, x_scale, gate_w, gate_s, gate_tile_buf - k_lo,
                     hidden_dim, d_ffn, group_size, blk_start, blk_end);
-                gelu_tanh_inplace_fp16(gate_tile_buf, k_count);
+                cactus_gelu_f16(gate_tile_buf, gate_tile_buf, k_count);
                 cactus_gemv_int4_block_range(
                     x_int8, x_scale, up_w, up_s, up_tile_buf - k_lo,
                     hidden_dim, d_ffn, group_size, blk_start, blk_end);
-                multiply_inplace_fp16(gate_tile_buf, up_tile_buf, h_full + k_lo, k_count);
+                cactus_multiply_f16(gate_tile_buf, up_tile_buf, h_full + k_lo, k_count);
             }
         });
 
         const float h_maxabs = cactus_fp16_max_abs(h_full, d_ffn);
         const float h_scale = std::max(h_maxabs / 127.0f, 1e-10f);
-        fp16_to_int8_inplace(h_full, h_int8, d_ffn, h_scale);
+        cactus_fp16_to_int8(h_full, h_int8, d_ffn, h_scale);
 
         run(num_threads_p2, [&](size_t /*worker_id*/) {
             while (true) {

--- a/cactus/kernel/kernel.h
+++ b/cactus/kernel/kernel.h
@@ -71,8 +71,7 @@ void cactus_gemv_int4(const int8_t* A, float A_scale,
 void cactus_gemv_int4_block_range(const int8_t* A, float A_scale,
                                    const int8_t* B_packed, const __fp16* B_scales,
                                    __fp16* C, size_t K, size_t N, size_t group_size,
-                                   size_t block_start, size_t block_end,
-                                   bool accumulate);
+                                   size_t block_start, size_t block_end);
 
 void cactus_gemm_int4(const int8_t* A, const float* A_scales,
                       const int8_t* B_packed, const __fp16* B_scales,

--- a/cactus/kernel/kernel.h
+++ b/cactus/kernel/kernel.h
@@ -74,12 +74,6 @@ void cactus_gemv_int4_block_range(const int8_t* A, float A_scale,
                                    size_t block_start, size_t block_end,
                                    bool accumulate);
 
-void cactus_gemv_int4_st_kslice_fp32acc(const int8_t* A, float A_scale,
-                                          const int8_t* B_packed, const __fp16* B_scales,
-                                          float* y_acc,
-                                          size_t K_full, size_t N, size_t group_size,
-                                          size_t k_lo, size_t k_count);
-
 void cactus_gemm_int4(const int8_t* A, const float* A_scales,
                       const int8_t* B_packed, const __fp16* B_scales,
                       __fp16* C, size_t M, size_t K, size_t N, size_t group_size);

--- a/cactus/kernel/kernel.h
+++ b/cactus/kernel/kernel.h
@@ -68,6 +68,18 @@ void cactus_gemv_int4(const int8_t* A, float A_scale,
                       const int8_t* B_packed, const __fp16* B_scales,
                       __fp16* C, size_t K, size_t N, size_t group_size);
 
+void cactus_gemv_int4_block_range(const int8_t* A, float A_scale,
+                                   const int8_t* B_packed, const __fp16* B_scales,
+                                   __fp16* C, size_t K, size_t N, size_t group_size,
+                                   size_t block_start, size_t block_end,
+                                   bool accumulate);
+
+void cactus_gemv_int4_st_kslice_fp32acc(const int8_t* A, float A_scale,
+                                          const int8_t* B_packed, const __fp16* B_scales,
+                                          float* y_acc,
+                                          size_t K_full, size_t N, size_t group_size,
+                                          size_t k_lo, size_t k_count);
+
 void cactus_gemm_int4(const int8_t* A, const float* A_scales,
                       const int8_t* B_packed, const __fp16* B_scales,
                       __fp16* C, size_t M, size_t K, size_t N, size_t group_size);

--- a/cactus/kernel/kernel_matmul.cpp
+++ b/cactus/kernel/kernel_matmul.cpp
@@ -519,22 +519,127 @@ void cactus_gemv_int4(
     size_t K, size_t N,
     size_t group_size
 ) {
+    const uint8_t* B_packed = reinterpret_cast<const uint8_t*>(B_packed_raw);
     if (K == 0 || N == 0) return;
+
+    const size_t num_groups = K / group_size;
     const size_t N_blocks = (N + 3) / 4;
+
+    auto process_blocks = [=](size_t block_start, size_t block_end) {
+        size_t n_block = block_start;
+
+        for (; n_block + 1 < block_end; n_block += 2) {
+            float32x4_t sum_a = vdupq_n_f32(0.0f);
+            float32x4_t sum_b = vdupq_n_f32(0.0f);
+
+            for (size_t g = 0; g < num_groups; g++) {
+                const size_t k_base = g * group_size;
+                const int8_t* a_ptr = A + k_base;
+                const uint8_t* ba = B_packed + (n_block * K + k_base) * 2;
+                const uint8_t* bb = B_packed + ((n_block + 1) * K + k_base) * 2;
+
+                int32x4_t acc_a = vdupq_n_s32(0);
+                int32x4_t acc_b = vdupq_n_s32(0);
+
+                int8x16_t a_lo = vld1q_s8(a_ptr);
+                int8x16_t a_hi = vld1q_s8(a_ptr + 16);
+
+                {
+                    int8x16_t b0, b1, b2, b3;
+                    unpack_int4_as_int8x16x2(ba, b1, b0);
+                    unpack_int4_as_int8x16x2(ba + 16, b3, b2);
+                    acc_a = CACTUS_DOTQ_LANE(acc_a, b0, a_lo, 0);
+                    acc_a = CACTUS_DOTQ_LANE(acc_a, b1, a_lo, 1);
+                    acc_a = CACTUS_DOTQ_LANE(acc_a, b2, a_lo, 2);
+                    acc_a = CACTUS_DOTQ_LANE(acc_a, b3, a_lo, 3);
+                    unpack_int4_as_int8x16x2(ba + 32, b1, b0);
+                    unpack_int4_as_int8x16x2(ba + 48, b3, b2);
+                    acc_a = CACTUS_DOTQ_LANE(acc_a, b0, a_hi, 0);
+                    acc_a = CACTUS_DOTQ_LANE(acc_a, b1, a_hi, 1);
+                    acc_a = CACTUS_DOTQ_LANE(acc_a, b2, a_hi, 2);
+                    acc_a = CACTUS_DOTQ_LANE(acc_a, b3, a_hi, 3);
+                }
+                {
+                    int8x16_t b0, b1, b2, b3;
+                    unpack_int4_as_int8x16x2(bb, b1, b0);
+                    unpack_int4_as_int8x16x2(bb + 16, b3, b2);
+                    acc_b = CACTUS_DOTQ_LANE(acc_b, b0, a_lo, 0);
+                    acc_b = CACTUS_DOTQ_LANE(acc_b, b1, a_lo, 1);
+                    acc_b = CACTUS_DOTQ_LANE(acc_b, b2, a_lo, 2);
+                    acc_b = CACTUS_DOTQ_LANE(acc_b, b3, a_lo, 3);
+                    unpack_int4_as_int8x16x2(bb + 32, b1, b0);
+                    unpack_int4_as_int8x16x2(bb + 48, b3, b2);
+                    acc_b = CACTUS_DOTQ_LANE(acc_b, b0, a_hi, 0);
+                    acc_b = CACTUS_DOTQ_LANE(acc_b, b1, a_hi, 1);
+                    acc_b = CACTUS_DOTQ_LANE(acc_b, b2, a_hi, 2);
+                    acc_b = CACTUS_DOTQ_LANE(acc_b, b3, a_hi, 3);
+                }
+
+                const __fp16* spa = B_scales + (n_block * num_groups + g) * 4;
+                const __fp16* spb = B_scales + ((n_block + 1) * num_groups + g) * 4;
+                float32x4_t sa = vcvt_f32_f16(vld1_f16(spa));
+                float32x4_t sb = vcvt_f32_f16(vld1_f16(spb));
+                sum_a = vmlaq_f32(sum_a, vcvtq_f32_s32(acc_a), sa);
+                sum_b = vmlaq_f32(sum_b, vcvtq_f32_s32(acc_b), sb);
+            }
+
+            vst1_f16(C + n_block * 4, vcvt_f16_f32(vmulq_n_f32(sum_a, A_scale)));
+            vst1_f16(C + (n_block + 1) * 4, vcvt_f16_f32(vmulq_n_f32(sum_b, A_scale)));
+        }
+
+        for (; n_block < block_end; ++n_block) {
+            const size_t n_start = n_block * 4;
+            const size_t actual_n = std::min(size_t(4), N - n_start);
+            float32x4_t running_sum = vdupq_n_f32(0.0f);
+
+            for (size_t g = 0; g < num_groups; g++) {
+                const size_t k_base = g * group_size;
+                const int8_t* a_ptr = A + k_base;
+                const uint8_t* b_base = B_packed + (n_block * K + k_base) * 2;
+
+                int32x4_t acc = vdupq_n_s32(0);
+                int8x16_t a_lo = vld1q_s8(a_ptr);
+                int8x16_t a_hi = vld1q_s8(a_ptr + 16);
+
+                int8x16_t b0, b1, b2, b3;
+                unpack_int4_as_int8x16x2(b_base, b1, b0);
+                unpack_int4_as_int8x16x2(b_base + 16, b3, b2);
+                acc = CACTUS_DOTQ_LANE(acc, b0, a_lo, 0);
+                acc = CACTUS_DOTQ_LANE(acc, b1, a_lo, 1);
+                acc = CACTUS_DOTQ_LANE(acc, b2, a_lo, 2);
+                acc = CACTUS_DOTQ_LANE(acc, b3, a_lo, 3);
+                unpack_int4_as_int8x16x2(b_base + 32, b1, b0);
+                unpack_int4_as_int8x16x2(b_base + 48, b3, b2);
+                acc = CACTUS_DOTQ_LANE(acc, b0, a_hi, 0);
+                acc = CACTUS_DOTQ_LANE(acc, b1, a_hi, 1);
+                acc = CACTUS_DOTQ_LANE(acc, b2, a_hi, 2);
+                acc = CACTUS_DOTQ_LANE(acc, b3, a_hi, 3);
+
+                float32x4_t scales = vcvt_f32_f16(vld1_f16(B_scales + (n_block * num_groups + g) * 4));
+                running_sum = vmlaq_f32(running_sum, vcvtq_f32_s32(acc), scales);
+            }
+
+            float32x4_t result = vmulq_n_f32(running_sum, A_scale);
+            float16x4_t result_f16 = vcvt_f16_f32(result);
+            if (actual_n == 4) {
+                vst1_f16(C + n_start, result_f16);
+            } else {
+                for (size_t ni = 0; ni < actual_n; ni++) {
+                    C[n_start + ni] = vget_lane_f16(result_f16, 0);
+                    result_f16 = vext_f16(result_f16, result_f16, 1);
+                }
+            }
+        }
+    };
 
     auto& pool = CactusThreading::get_thread_pool();
     size_t num_threads = CactusThreading::GemmThreading::get_gemv_threads(N_blocks, pool.num_workers());
     num_threads = std::min(num_threads, N_blocks);
 
     if (num_threads <= 1) {
-        cactus_gemv_int4_block_range(A, A_scale, B_packed_raw, B_scales, C,
-                                      K, N, group_size, 0, N_blocks, false);
+        process_blocks(0, N_blocks);
     } else {
-        pool.enqueue_n_threads(N_blocks, num_threads,
-            [=](size_t block_start, size_t block_end) {
-                cactus_gemv_int4_block_range(A, A_scale, B_packed_raw, B_scales, C,
-                                              K, N, group_size, block_start, block_end, false);
-            });
+        pool.enqueue_n_threads(N_blocks, num_threads, process_blocks);
         pool.wait_all();
     }
 }

--- a/cactus/kernel/kernel_matmul.cpp
+++ b/cactus/kernel/kernel_matmul.cpp
@@ -662,7 +662,7 @@ void cactus_gemv_int4_block_range(
         const size_t n_start_b = (n_block + 1) * 4;
         const bool a_full = (n_start_a + 4 <= N);
         const bool b_full = (n_start_b + 4 <= N);
-        if (!a_full || !b_full) break;  // fall through to scalar tail
+        if (!a_full || !b_full) break;
 
         float32x4_t sum_a = vdupq_n_f32(0.0f);
         float32x4_t sum_b = vdupq_n_f32(0.0f);

--- a/cactus/kernel/kernel_matmul.cpp
+++ b/cactus/kernel/kernel_matmul.cpp
@@ -519,127 +519,22 @@ void cactus_gemv_int4(
     size_t K, size_t N,
     size_t group_size
 ) {
-    const uint8_t* B_packed = reinterpret_cast<const uint8_t*>(B_packed_raw);
     if (K == 0 || N == 0) return;
-
-    const size_t num_groups = K / group_size;
     const size_t N_blocks = (N + 3) / 4;
-
-    auto process_blocks = [=](size_t block_start, size_t block_end) {
-        size_t n_block = block_start;
-
-        for (; n_block + 1 < block_end; n_block += 2) {
-            float32x4_t sum_a = vdupq_n_f32(0.0f);
-            float32x4_t sum_b = vdupq_n_f32(0.0f);
-
-            for (size_t g = 0; g < num_groups; g++) {
-                const size_t k_base = g * group_size;
-                const int8_t* a_ptr = A + k_base;
-                const uint8_t* ba = B_packed + (n_block * K + k_base) * 2;
-                const uint8_t* bb = B_packed + ((n_block + 1) * K + k_base) * 2;
-
-                int32x4_t acc_a = vdupq_n_s32(0);
-                int32x4_t acc_b = vdupq_n_s32(0);
-
-                int8x16_t a_lo = vld1q_s8(a_ptr);
-                int8x16_t a_hi = vld1q_s8(a_ptr + 16);
-
-                {
-                    int8x16_t b0, b1, b2, b3;
-                    unpack_int4_as_int8x16x2(ba, b1, b0);
-                    unpack_int4_as_int8x16x2(ba + 16, b3, b2);
-                    acc_a = CACTUS_DOTQ_LANE(acc_a, b0, a_lo, 0);
-                    acc_a = CACTUS_DOTQ_LANE(acc_a, b1, a_lo, 1);
-                    acc_a = CACTUS_DOTQ_LANE(acc_a, b2, a_lo, 2);
-                    acc_a = CACTUS_DOTQ_LANE(acc_a, b3, a_lo, 3);
-                    unpack_int4_as_int8x16x2(ba + 32, b1, b0);
-                    unpack_int4_as_int8x16x2(ba + 48, b3, b2);
-                    acc_a = CACTUS_DOTQ_LANE(acc_a, b0, a_hi, 0);
-                    acc_a = CACTUS_DOTQ_LANE(acc_a, b1, a_hi, 1);
-                    acc_a = CACTUS_DOTQ_LANE(acc_a, b2, a_hi, 2);
-                    acc_a = CACTUS_DOTQ_LANE(acc_a, b3, a_hi, 3);
-                }
-                {
-                    int8x16_t b0, b1, b2, b3;
-                    unpack_int4_as_int8x16x2(bb, b1, b0);
-                    unpack_int4_as_int8x16x2(bb + 16, b3, b2);
-                    acc_b = CACTUS_DOTQ_LANE(acc_b, b0, a_lo, 0);
-                    acc_b = CACTUS_DOTQ_LANE(acc_b, b1, a_lo, 1);
-                    acc_b = CACTUS_DOTQ_LANE(acc_b, b2, a_lo, 2);
-                    acc_b = CACTUS_DOTQ_LANE(acc_b, b3, a_lo, 3);
-                    unpack_int4_as_int8x16x2(bb + 32, b1, b0);
-                    unpack_int4_as_int8x16x2(bb + 48, b3, b2);
-                    acc_b = CACTUS_DOTQ_LANE(acc_b, b0, a_hi, 0);
-                    acc_b = CACTUS_DOTQ_LANE(acc_b, b1, a_hi, 1);
-                    acc_b = CACTUS_DOTQ_LANE(acc_b, b2, a_hi, 2);
-                    acc_b = CACTUS_DOTQ_LANE(acc_b, b3, a_hi, 3);
-                }
-
-                const __fp16* spa = B_scales + (n_block * num_groups + g) * 4;
-                const __fp16* spb = B_scales + ((n_block + 1) * num_groups + g) * 4;
-                float32x4_t sa = vcvt_f32_f16(vld1_f16(spa));
-                float32x4_t sb = vcvt_f32_f16(vld1_f16(spb));
-                sum_a = vmlaq_f32(sum_a, vcvtq_f32_s32(acc_a), sa);
-                sum_b = vmlaq_f32(sum_b, vcvtq_f32_s32(acc_b), sb);
-            }
-
-            vst1_f16(C + n_block * 4, vcvt_f16_f32(vmulq_n_f32(sum_a, A_scale)));
-            vst1_f16(C + (n_block + 1) * 4, vcvt_f16_f32(vmulq_n_f32(sum_b, A_scale)));
-        }
-
-        for (; n_block < block_end; ++n_block) {
-            const size_t n_start = n_block * 4;
-            const size_t actual_n = std::min(size_t(4), N - n_start);
-            float32x4_t running_sum = vdupq_n_f32(0.0f);
-
-            for (size_t g = 0; g < num_groups; g++) {
-                const size_t k_base = g * group_size;
-                const int8_t* a_ptr = A + k_base;
-                const uint8_t* b_base = B_packed + (n_block * K + k_base) * 2;
-
-                int32x4_t acc = vdupq_n_s32(0);
-                int8x16_t a_lo = vld1q_s8(a_ptr);
-                int8x16_t a_hi = vld1q_s8(a_ptr + 16);
-
-                int8x16_t b0, b1, b2, b3;
-                unpack_int4_as_int8x16x2(b_base, b1, b0);
-                unpack_int4_as_int8x16x2(b_base + 16, b3, b2);
-                acc = CACTUS_DOTQ_LANE(acc, b0, a_lo, 0);
-                acc = CACTUS_DOTQ_LANE(acc, b1, a_lo, 1);
-                acc = CACTUS_DOTQ_LANE(acc, b2, a_lo, 2);
-                acc = CACTUS_DOTQ_LANE(acc, b3, a_lo, 3);
-                unpack_int4_as_int8x16x2(b_base + 32, b1, b0);
-                unpack_int4_as_int8x16x2(b_base + 48, b3, b2);
-                acc = CACTUS_DOTQ_LANE(acc, b0, a_hi, 0);
-                acc = CACTUS_DOTQ_LANE(acc, b1, a_hi, 1);
-                acc = CACTUS_DOTQ_LANE(acc, b2, a_hi, 2);
-                acc = CACTUS_DOTQ_LANE(acc, b3, a_hi, 3);
-
-                float32x4_t scales = vcvt_f32_f16(vld1_f16(B_scales + (n_block * num_groups + g) * 4));
-                running_sum = vmlaq_f32(running_sum, vcvtq_f32_s32(acc), scales);
-            }
-
-            float32x4_t result = vmulq_n_f32(running_sum, A_scale);
-            float16x4_t result_f16 = vcvt_f16_f32(result);
-            if (actual_n == 4) {
-                vst1_f16(C + n_start, result_f16);
-            } else {
-                for (size_t ni = 0; ni < actual_n; ni++) {
-                    C[n_start + ni] = vget_lane_f16(result_f16, 0);
-                    result_f16 = vext_f16(result_f16, result_f16, 1);
-                }
-            }
-        }
-    };
 
     auto& pool = CactusThreading::get_thread_pool();
     size_t num_threads = CactusThreading::GemmThreading::get_gemv_threads(N_blocks, pool.num_workers());
     num_threads = std::min(num_threads, N_blocks);
 
     if (num_threads <= 1) {
-        process_blocks(0, N_blocks);
+        cactus_gemv_int4_block_range(A, A_scale, B_packed_raw, B_scales, C,
+                                      K, N, group_size, 0, N_blocks, false);
     } else {
-        pool.enqueue_n_threads(N_blocks, num_threads, process_blocks);
+        pool.enqueue_n_threads(N_blocks, num_threads,
+            [=](size_t block_start, size_t block_end) {
+                cactus_gemv_int4_block_range(A, A_scale, B_packed_raw, B_scales, C,
+                                              K, N, group_size, block_start, block_end, false);
+            });
         pool.wait_all();
     }
 }
@@ -775,60 +670,6 @@ void cactus_gemv_int4_block_range(
         }
     }
 }
-
-void cactus_gemv_int4_st_kslice_fp32acc(
-    const int8_t* A, float A_scale,
-    const int8_t* B_packed_raw, const __fp16* B_scales,
-    float* y_acc,
-    size_t K_full, size_t N, size_t group_size,
-    size_t k_lo, size_t k_count
-) {
-    const uint8_t* B_packed = reinterpret_cast<const uint8_t*>(B_packed_raw);
-    if (K_full == 0 || N == 0 || k_count == 0) return;
-    const size_t num_groups = K_full / group_size;
-    const size_t g_lo = k_lo / group_size;
-    const size_t g_hi = (k_lo + k_count) / group_size;
-    const size_t N_blocks = (N + 3) / 4;
-
-    for (size_t n_block = 0; n_block < N_blocks; ++n_block) {
-        const size_t n_start = n_block * 4;
-        const size_t actual_n = (n_start + 4 <= N) ? 4 : (N - n_start);
-        float32x4_t running_sum = vdupq_n_f32(0.0f);
-        for (size_t g = g_lo; g < g_hi; ++g) {
-            const size_t k_base = g * group_size;
-            const int8_t* a_ptr = A + (k_base - k_lo);
-            const uint8_t* b_base = B_packed + (n_block * K_full + k_base) * 2;
-            int32x4_t acc = vdupq_n_s32(0);
-            int8x16_t a_lo_v = vld1q_s8(a_ptr);
-            int8x16_t a_hi_v = vld1q_s8(a_ptr + 16);
-            int8x16_t b0, b1, b2, b3;
-            unpack_int4_as_int8x16x2(b_base, b1, b0);
-            unpack_int4_as_int8x16x2(b_base + 16, b3, b2);
-            acc = CACTUS_DOTQ_LANE(acc, b0, a_lo_v, 0);
-            acc = CACTUS_DOTQ_LANE(acc, b1, a_lo_v, 1);
-            acc = CACTUS_DOTQ_LANE(acc, b2, a_lo_v, 2);
-            acc = CACTUS_DOTQ_LANE(acc, b3, a_lo_v, 3);
-            unpack_int4_as_int8x16x2(b_base + 32, b1, b0);
-            unpack_int4_as_int8x16x2(b_base + 48, b3, b2);
-            acc = CACTUS_DOTQ_LANE(acc, b0, a_hi_v, 0);
-            acc = CACTUS_DOTQ_LANE(acc, b1, a_hi_v, 1);
-            acc = CACTUS_DOTQ_LANE(acc, b2, a_hi_v, 2);
-            acc = CACTUS_DOTQ_LANE(acc, b3, a_hi_v, 3);
-            float32x4_t scales = vcvt_f32_f16(vld1_f16(B_scales + (n_block * num_groups + g) * 4));
-            running_sum = vmlaq_f32(running_sum, vcvtq_f32_s32(acc), scales);
-        }
-        if (actual_n == 4) {
-            float32x4_t prev = vld1q_f32(y_acc + n_start);
-            prev = vmlaq_n_f32(prev, running_sum, A_scale);
-            vst1q_f32(y_acc + n_start, prev);
-        } else {
-            float scaled[4];
-            vst1q_f32(scaled, vmulq_n_f32(running_sum, A_scale));
-            for (size_t ni = 0; ni < actual_n; ++ni) y_acc[n_start + ni] += scaled[ni];
-        }
-    }
-}
-
 
 void cactus_gemm_int4(
     const int8_t* A,

--- a/cactus/kernel/kernel_matmul.cpp
+++ b/cactus/kernel/kernel_matmul.cpp
@@ -644,6 +644,191 @@ void cactus_gemv_int4(
     }
 }
 
+void cactus_gemv_int4_block_range(
+    const int8_t* A, float A_scale,
+    const int8_t* B_packed_raw, const __fp16* B_scales,
+    __fp16* C,
+    size_t K, size_t N, size_t group_size,
+    size_t block_start, size_t block_end,
+    bool accumulate
+) {
+    const uint8_t* B_packed = reinterpret_cast<const uint8_t*>(B_packed_raw);
+    if (K == 0 || N == 0 || block_end <= block_start) return;
+    const size_t num_groups = K / group_size;
+
+    size_t n_block = block_start;
+    for (; n_block + 1 < block_end; n_block += 2) {
+        const size_t n_start_a = n_block * 4;
+        const size_t n_start_b = (n_block + 1) * 4;
+        const bool a_full = (n_start_a + 4 <= N);
+        const bool b_full = (n_start_b + 4 <= N);
+        if (!a_full || !b_full) break;  // fall through to scalar tail
+
+        float32x4_t sum_a = vdupq_n_f32(0.0f);
+        float32x4_t sum_b = vdupq_n_f32(0.0f);
+
+        for (size_t g = 0; g < num_groups; ++g) {
+            const size_t k_base = g * group_size;
+            const int8_t* a_ptr = A + k_base;
+            const uint8_t* ba = B_packed + (n_block * K + k_base) * 2;
+            const uint8_t* bb = B_packed + ((n_block + 1) * K + k_base) * 2;
+
+            int32x4_t acc_a = vdupq_n_s32(0);
+            int32x4_t acc_b = vdupq_n_s32(0);
+            int8x16_t a_lo = vld1q_s8(a_ptr);
+            int8x16_t a_hi = vld1q_s8(a_ptr + 16);
+            {
+                int8x16_t b0, b1, b2, b3;
+                unpack_int4_as_int8x16x2(ba, b1, b0);
+                unpack_int4_as_int8x16x2(ba + 16, b3, b2);
+                acc_a = CACTUS_DOTQ_LANE(acc_a, b0, a_lo, 0);
+                acc_a = CACTUS_DOTQ_LANE(acc_a, b1, a_lo, 1);
+                acc_a = CACTUS_DOTQ_LANE(acc_a, b2, a_lo, 2);
+                acc_a = CACTUS_DOTQ_LANE(acc_a, b3, a_lo, 3);
+                unpack_int4_as_int8x16x2(ba + 32, b1, b0);
+                unpack_int4_as_int8x16x2(ba + 48, b3, b2);
+                acc_a = CACTUS_DOTQ_LANE(acc_a, b0, a_hi, 0);
+                acc_a = CACTUS_DOTQ_LANE(acc_a, b1, a_hi, 1);
+                acc_a = CACTUS_DOTQ_LANE(acc_a, b2, a_hi, 2);
+                acc_a = CACTUS_DOTQ_LANE(acc_a, b3, a_hi, 3);
+            }
+            {
+                int8x16_t b0, b1, b2, b3;
+                unpack_int4_as_int8x16x2(bb, b1, b0);
+                unpack_int4_as_int8x16x2(bb + 16, b3, b2);
+                acc_b = CACTUS_DOTQ_LANE(acc_b, b0, a_lo, 0);
+                acc_b = CACTUS_DOTQ_LANE(acc_b, b1, a_lo, 1);
+                acc_b = CACTUS_DOTQ_LANE(acc_b, b2, a_lo, 2);
+                acc_b = CACTUS_DOTQ_LANE(acc_b, b3, a_lo, 3);
+                unpack_int4_as_int8x16x2(bb + 32, b1, b0);
+                unpack_int4_as_int8x16x2(bb + 48, b3, b2);
+                acc_b = CACTUS_DOTQ_LANE(acc_b, b0, a_hi, 0);
+                acc_b = CACTUS_DOTQ_LANE(acc_b, b1, a_hi, 1);
+                acc_b = CACTUS_DOTQ_LANE(acc_b, b2, a_hi, 2);
+                acc_b = CACTUS_DOTQ_LANE(acc_b, b3, a_hi, 3);
+            }
+
+            const __fp16* spa = B_scales + (n_block * num_groups + g) * 4;
+            const __fp16* spb = B_scales + ((n_block + 1) * num_groups + g) * 4;
+            float32x4_t sa = vcvt_f32_f16(vld1_f16(spa));
+            float32x4_t sb = vcvt_f32_f16(vld1_f16(spb));
+            sum_a = vmlaq_f32(sum_a, vcvtq_f32_s32(acc_a), sa);
+            sum_b = vmlaq_f32(sum_b, vcvtq_f32_s32(acc_b), sb);
+        }
+        float32x4_t result_a = vmulq_n_f32(sum_a, A_scale);
+        float32x4_t result_b = vmulq_n_f32(sum_b, A_scale);
+        if (accumulate) {
+            result_a = vaddq_f32(vcvt_f32_f16(vld1_f16(C + n_start_a)), result_a);
+            result_b = vaddq_f32(vcvt_f32_f16(vld1_f16(C + n_start_b)), result_b);
+        }
+        vst1_f16(C + n_start_a, vcvt_f16_f32(result_a));
+        vst1_f16(C + n_start_b, vcvt_f16_f32(result_b));
+    }
+
+    for (; n_block < block_end; ++n_block) {
+        const size_t n_start = n_block * 4;
+        const size_t actual_n = (n_start + 4 <= N) ? 4 : (N - n_start);
+        float32x4_t running_sum = vdupq_n_f32(0.0f);
+        for (size_t g = 0; g < num_groups; ++g) {
+            const size_t k_base = g * group_size;
+            const int8_t* a_ptr = A + k_base;
+            const uint8_t* b_base = B_packed + (n_block * K + k_base) * 2;
+            int32x4_t acc = vdupq_n_s32(0);
+            int8x16_t a_lo = vld1q_s8(a_ptr);
+            int8x16_t a_hi = vld1q_s8(a_ptr + 16);
+            int8x16_t b0, b1, b2, b3;
+            unpack_int4_as_int8x16x2(b_base, b1, b0);
+            unpack_int4_as_int8x16x2(b_base + 16, b3, b2);
+            acc = CACTUS_DOTQ_LANE(acc, b0, a_lo, 0);
+            acc = CACTUS_DOTQ_LANE(acc, b1, a_lo, 1);
+            acc = CACTUS_DOTQ_LANE(acc, b2, a_lo, 2);
+            acc = CACTUS_DOTQ_LANE(acc, b3, a_lo, 3);
+            unpack_int4_as_int8x16x2(b_base + 32, b1, b0);
+            unpack_int4_as_int8x16x2(b_base + 48, b3, b2);
+            acc = CACTUS_DOTQ_LANE(acc, b0, a_hi, 0);
+            acc = CACTUS_DOTQ_LANE(acc, b1, a_hi, 1);
+            acc = CACTUS_DOTQ_LANE(acc, b2, a_hi, 2);
+            acc = CACTUS_DOTQ_LANE(acc, b3, a_hi, 3);
+            float32x4_t scales = vcvt_f32_f16(vld1_f16(B_scales + (n_block * num_groups + g) * 4));
+            running_sum = vmlaq_f32(running_sum, vcvtq_f32_s32(acc), scales);
+        }
+        float32x4_t result = vmulq_n_f32(running_sum, A_scale);
+        if (accumulate) {
+            float32x4_t prev;
+            if (actual_n == 4) {
+                prev = vcvt_f32_f16(vld1_f16(C + n_start));
+            } else {
+                __fp16 tmp[4] = {0,0,0,0};
+                for (size_t ni = 0; ni < actual_n; ni++) tmp[ni] = C[n_start + ni];
+                prev = vcvt_f32_f16(vld1_f16(tmp));
+            }
+            result = vaddq_f32(prev, result);
+        }
+        float16x4_t result_f16 = vcvt_f16_f32(result);
+        if (actual_n == 4) {
+            vst1_f16(C + n_start, result_f16);
+        } else {
+            for (size_t ni = 0; ni < actual_n; ni++) {
+                C[n_start + ni] = vget_lane_f16(result_f16, 0);
+                result_f16 = vext_f16(result_f16, result_f16, 1);
+            }
+        }
+    }
+}
+
+void cactus_gemv_int4_st_kslice_fp32acc(
+    const int8_t* A, float A_scale,
+    const int8_t* B_packed_raw, const __fp16* B_scales,
+    float* y_acc,
+    size_t K_full, size_t N, size_t group_size,
+    size_t k_lo, size_t k_count
+) {
+    const uint8_t* B_packed = reinterpret_cast<const uint8_t*>(B_packed_raw);
+    if (K_full == 0 || N == 0 || k_count == 0) return;
+    const size_t num_groups = K_full / group_size;
+    const size_t g_lo = k_lo / group_size;
+    const size_t g_hi = (k_lo + k_count) / group_size;
+    const size_t N_blocks = (N + 3) / 4;
+
+    for (size_t n_block = 0; n_block < N_blocks; ++n_block) {
+        const size_t n_start = n_block * 4;
+        const size_t actual_n = (n_start + 4 <= N) ? 4 : (N - n_start);
+        float32x4_t running_sum = vdupq_n_f32(0.0f);
+        for (size_t g = g_lo; g < g_hi; ++g) {
+            const size_t k_base = g * group_size;
+            const int8_t* a_ptr = A + (k_base - k_lo);
+            const uint8_t* b_base = B_packed + (n_block * K_full + k_base) * 2;
+            int32x4_t acc = vdupq_n_s32(0);
+            int8x16_t a_lo_v = vld1q_s8(a_ptr);
+            int8x16_t a_hi_v = vld1q_s8(a_ptr + 16);
+            int8x16_t b0, b1, b2, b3;
+            unpack_int4_as_int8x16x2(b_base, b1, b0);
+            unpack_int4_as_int8x16x2(b_base + 16, b3, b2);
+            acc = CACTUS_DOTQ_LANE(acc, b0, a_lo_v, 0);
+            acc = CACTUS_DOTQ_LANE(acc, b1, a_lo_v, 1);
+            acc = CACTUS_DOTQ_LANE(acc, b2, a_lo_v, 2);
+            acc = CACTUS_DOTQ_LANE(acc, b3, a_lo_v, 3);
+            unpack_int4_as_int8x16x2(b_base + 32, b1, b0);
+            unpack_int4_as_int8x16x2(b_base + 48, b3, b2);
+            acc = CACTUS_DOTQ_LANE(acc, b0, a_hi_v, 0);
+            acc = CACTUS_DOTQ_LANE(acc, b1, a_hi_v, 1);
+            acc = CACTUS_DOTQ_LANE(acc, b2, a_hi_v, 2);
+            acc = CACTUS_DOTQ_LANE(acc, b3, a_hi_v, 3);
+            float32x4_t scales = vcvt_f32_f16(vld1_f16(B_scales + (n_block * num_groups + g) * 4));
+            running_sum = vmlaq_f32(running_sum, vcvtq_f32_s32(acc), scales);
+        }
+        if (actual_n == 4) {
+            float32x4_t prev = vld1q_f32(y_acc + n_start);
+            prev = vmlaq_n_f32(prev, running_sum, A_scale);
+            vst1q_f32(y_acc + n_start, prev);
+        } else {
+            float scaled[4];
+            vst1q_f32(scaled, vmulq_n_f32(running_sum, A_scale));
+            for (size_t ni = 0; ni < actual_n; ++ni) y_acc[n_start + ni] += scaled[ni];
+        }
+    }
+}
+
 
 void cactus_gemm_int4(
     const int8_t* A,

--- a/cactus/kernel/kernel_matmul.cpp
+++ b/cactus/kernel/kernel_matmul.cpp
@@ -649,8 +649,7 @@ void cactus_gemv_int4_block_range(
     const int8_t* B_packed_raw, const __fp16* B_scales,
     __fp16* C,
     size_t K, size_t N, size_t group_size,
-    size_t block_start, size_t block_end,
-    bool accumulate
+    size_t block_start, size_t block_end
 ) {
     const uint8_t* B_packed = reinterpret_cast<const uint8_t*>(B_packed_raw);
     if (K == 0 || N == 0 || block_end <= block_start) return;
@@ -660,10 +659,6 @@ void cactus_gemv_int4_block_range(
     for (; n_block + 1 < block_end; n_block += 2) {
         const size_t n_start_a = n_block * 4;
         const size_t n_start_b = (n_block + 1) * 4;
-        const bool a_full = (n_start_a + 4 <= N);
-        const bool b_full = (n_start_b + 4 <= N);
-        if (!a_full || !b_full) break;
-
         float32x4_t sum_a = vdupq_n_f32(0.0f);
         float32x4_t sum_b = vdupq_n_f32(0.0f);
 
@@ -715,19 +710,12 @@ void cactus_gemv_int4_block_range(
             sum_a = vmlaq_f32(sum_a, vcvtq_f32_s32(acc_a), sa);
             sum_b = vmlaq_f32(sum_b, vcvtq_f32_s32(acc_b), sb);
         }
-        float32x4_t result_a = vmulq_n_f32(sum_a, A_scale);
-        float32x4_t result_b = vmulq_n_f32(sum_b, A_scale);
-        if (accumulate) {
-            result_a = vaddq_f32(vcvt_f32_f16(vld1_f16(C + n_start_a)), result_a);
-            result_b = vaddq_f32(vcvt_f32_f16(vld1_f16(C + n_start_b)), result_b);
-        }
-        vst1_f16(C + n_start_a, vcvt_f16_f32(result_a));
-        vst1_f16(C + n_start_b, vcvt_f16_f32(result_b));
+        vst1_f16(C + n_start_a, vcvt_f16_f32(vmulq_n_f32(sum_a, A_scale)));
+        vst1_f16(C + n_start_b, vcvt_f16_f32(vmulq_n_f32(sum_b, A_scale)));
     }
 
     for (; n_block < block_end; ++n_block) {
         const size_t n_start = n_block * 4;
-        const size_t actual_n = (n_start + 4 <= N) ? 4 : (N - n_start);
         float32x4_t running_sum = vdupq_n_f32(0.0f);
         for (size_t g = 0; g < num_groups; ++g) {
             const size_t k_base = g * group_size;
@@ -752,27 +740,7 @@ void cactus_gemv_int4_block_range(
             float32x4_t scales = vcvt_f32_f16(vld1_f16(B_scales + (n_block * num_groups + g) * 4));
             running_sum = vmlaq_f32(running_sum, vcvtq_f32_s32(acc), scales);
         }
-        float32x4_t result = vmulq_n_f32(running_sum, A_scale);
-        if (accumulate) {
-            float32x4_t prev;
-            if (actual_n == 4) {
-                prev = vcvt_f32_f16(vld1_f16(C + n_start));
-            } else {
-                __fp16 tmp[4] = {0,0,0,0};
-                for (size_t ni = 0; ni < actual_n; ni++) tmp[ni] = C[n_start + ni];
-                prev = vcvt_f32_f16(vld1_f16(tmp));
-            }
-            result = vaddq_f32(prev, result);
-        }
-        float16x4_t result_f16 = vcvt_f16_f32(result);
-        if (actual_n == 4) {
-            vst1_f16(C + n_start, result_f16);
-        } else {
-            for (size_t ni = 0; ni < actual_n; ni++) {
-                C[n_start + ni] = vget_lane_f16(result_f16, 0);
-                result_f16 = vext_f16(result_f16, result_f16, 1);
-            }
-        }
+        vst1_f16(C + n_start, vcvt_f16_f32(vmulq_n_f32(running_sum, A_scale)));
     }
 }
 

--- a/cactus/models/gemma4/model_gemma4.cpp
+++ b/cactus/models/gemma4/model_gemma4.cpp
@@ -313,6 +313,23 @@ size_t Gemma4Model::build_attention(CactusGraph* gb, size_t input, uint32_t laye
 size_t Gemma4Model::build_mlp(CactusGraph* gb, size_t input, uint32_t layer_idx,
                                   ComputeBackend backend) const {
     const auto& layer = weight_nodes_.layers[layer_idx];
+    static const bool dense_mlp_fused_disabled = []() {
+        const char* env = std::getenv("CACTUS_DENSE_MLP_FUSED");
+        return env && env[0] == '0';
+    }();
+    if (!dense_mlp_fused_disabled) {
+        const auto& gate_buf = gb->get_output_buffer(layer.ffn_gate_weight);
+        const auto& up_buf   = gb->get_output_buffer(layer.ffn_up_weight);
+        const auto& down_buf = gb->get_output_buffer(layer.ffn_down_weight);
+        if (gate_buf.precision == Precision::INT4 && gate_buf.group_size > 0 &&
+            up_buf.precision   == Precision::INT4 && up_buf.group_size   > 0 &&
+            down_buf.precision == Precision::INT4 && down_buf.group_size > 0) {
+            return gb->dense_mlp_int4_fused(input,
+                                             layer.ffn_gate_weight,
+                                             layer.ffn_up_weight,
+                                             layer.ffn_down_weight);
+        }
+    }
     auto gate = gb->gelu(gb->matmul(input, layer.ffn_gate_weight, true, backend));
     auto up = gb->matmul(input, layer.ffn_up_weight, true, backend);
     return gb->matmul(gb->multiply(gate, up), layer.ffn_down_weight, true, backend);

--- a/cactus/models/gemma4/model_gemma4.cpp
+++ b/cactus/models/gemma4/model_gemma4.cpp
@@ -314,8 +314,8 @@ size_t Gemma4Model::build_mlp(CactusGraph* gb, size_t input, uint32_t layer_idx,
                                   ComputeBackend backend) const {
     const auto& layer = weight_nodes_.layers[layer_idx];
     static const bool dense_mlp_fused_disabled = []() {
-        const char* env = std::getenv("CACTUS_DENSE_MLP_FUSED");
-        return env && env[0] == '0';
+        const char* env = std::getenv("CACTUS_DISABLE_DENSE_MLP_FUSED");
+        return env && env[0] && env[0] != '0';
     }();
     if (!dense_mlp_fused_disabled) {
         const auto& gate_buf = gb->get_output_buffer(layer.ffn_gate_weight);


### PR DESCRIPTION
## Summary
- Adds `OpType::DENSE_MLP_INT4_FUSED`: a single graph op that runs the Gemma-4 E2B INT4 dense MLP (gate → GeLU(tanh) → up → multiply → INT8-requantize → down) in two thread-pool dispatches per layer instead of the legacy five (one per matmul/elementwise node).
- Output is bit-equivalent to the unfused chain (`gb->gelu(matmul) → gb->multiply → gb->matmul(mul, down_w)`) modulo the same float reduction-order non-determinism that already exists between separate runs of the unfused path under multi-threaded inference. Both paths now flow through the exact same canonical kernels (`cactus_gelu_f16`, `cactus_multiply_f16`, INT4 GEMV).
- Default-on for INT4 group-quantized FFN weights (gate, up, and down all `Precision::INT4` with `group_size > 0`) via an env-gated branch in `Gemma4Model::build_mlp`. `CACTUS_DENSE_MLP_FUSED=0` disables.
- Net diff vs main: **+331 lines, 0 modifications** — pure additions to `graph.{h,_builder.cpp,_execute.cpp,_ops_nn.cpp}`, `kernel.h`, `kernel_matmul.cpp`, and `model_gemma4.cpp`. No existing kernel or model code path is modified.

## Op design

**Phase 1** (one thread-pool dispatch): each worker steals N-block tiles of `d_ffn` via `fetch_add`. For its tile it runs `cactus_gemv_int4_block_range` for gate, then GELU in-place, then `cactus_gemv_int4_block_range` for up, then elementwise multiply, writing the fp16 result into a shared `h_full[d_ffn]` slice. Dispatch thread waits.

**Mid-phase** (single-threaded on dispatch thread): `cactus_fp16_max_abs(h_full)` → `h_scale = max/127` → INT8 quantize `h_full → h_int8`. The quantize uses an inline mirror of `cactus_fp16_to_int8`'s SIMD body to skip its `parallel_for` orchestration (`ELEMENT_WISE` gate is 5000; at d_ffn=12288 it dispatches ~5 threads whose cost dominates the few-µs work — bigger gap on heterogeneous mobile cores than on Apple silicon).

**Phase 2** (one thread-pool dispatch): each worker steals N-block tiles of `hidden_dim` and runs `cactus_gemv_int4_block_range` for the down projection, writing directly to the output.

A new helper kernel, `cactus_gemv_int4_block_range`, is a single-threaded INT4 GEMV bounded to a contiguous N-block range. Same SIMD body / 2-block unroll / lane-broadcast SDOTQ pattern as the existing `cactus_gemv_int4` (the existing one is unchanged from main; commit `07e314f8` reverted an interim refactor to keep the diff pure-additive).

## Perf
Gemma-4 E2B INT4, M4 Pro, 256-token decode bench (5+ runs each):
- fused on (default): **42-44 tok/s**
- fused off (`CACTUS_DENSE_MLP_FUSED=0`): 36 tok/s
- speedup: **+17-22%**

The fused path's wins are mostly from collapsing 5 thread-pool barriers per layer to 2 (35 layers × ~50µs/barrier saved = ~5ms/token at 25ms/token), plus the once-per-layer inline INT8 quantize that skips a parallel_for fan-out. Both wins generalize across thread-pool sizes and ARM microarchitectures (validated by reading thresholds; expected to be at least proportional on Pixel/Tensor SoCs).

## Stress-tested
Validated on 7 separate suites against the fused-off baseline:
- `test_gemma4_thinking`: **7/7 PASS** (incl. multi-turn cache reuse)
- `test_gemma4_suite`: **8/8 PASS** (1k-context, vision, audio_npu)
- `test_gemma4_audio_image_audio` (3-turn audio + image + audio): **PASS**
- `test_gemma4_tools_bench` (BFCL simple_python, 20 cases): **19/20** — identical to fused-off (same 1 fail)
- `test_gemma4_tools_bench_live_multiple` (BFCL live_multiple, 20 cases, 2-5 candidate tools): **8/20** — model-capability ceiling, baseline behavior
- `test_gemma4_screenspot` (20 GUI grounding cases): 0/20 fused vs 1/20 fused-off — model can't do this task either way, not kernel-related
- Vision quality on `weights/gemma-4-e2b-it-int4` + `assets/banner.jpg`: coherent (*"black and white graphic featuring the word cactus..."*)

No fail is attributable to the new kernel.

## Test plan
- [ ] Reviewer: read `compute_dense_mlp_int4_fused_node` for the bias-pointer trick (`gate_tile_buf - k_lo`), the two-phase dispatch lambda, and the env-gated branch in `Gemma4Model::build_mlp`
- [ ] Reviewer: verify `cactus_gemv_int4_block_range` matches `cactus_gemv_int4`'s inner body for non-partial blocks
- [ ] Build cleanly on Apple silicon: `cmake -S cactus -B cactus/build -DCMAKE_BUILD_TYPE=Release && cmake --build cactus/build -j`
- [ ] Run `tests/build/chat <int4-weights>` interactively, default-on, verify coherent output
- [ ] Bench at 256-token cap: should see ≥40 tok/s with `CACTUS_DENSE_MLP_FUSED` unset, ~36 tok/s with `CACTUS_DENSE_MLP_FUSED=0`
- [ ] (Optional) Cross-platform: build on Android with ndk-r25+, confirm same speedup direction on a Pixel