### PR TITLE
inner 1 fast path

### DIFF
--- a/cactus/kernel/kernel_reduce.cpp
+++ b/cactus/kernel/kernel_reduce.cpp
@@ -7,6 +7,35 @@ template<typename FinalizeFn>
 static void axis_reduce_f32_impl(const __fp16* input, __fp16* output,
                                  size_t outer_size, size_t axis_size, size_t inner_size,
                                  FinalizeFn finalize) {
+    if (inner_size == 1) {
+        CactusThreading::parallel_for(outer_size, CactusThreading::Thresholds::AXIS_REDUCE,
+            [&](size_t start_outer, size_t end_outer) {
+                constexpr size_t W = SIMD_F16_WIDTH;
+                const size_t vec_axis = simd_align(axis_size);
+
+                for (size_t outer = start_outer; outer < end_outer; ++outer) {
+                    const __fp16* row = input + outer * axis_size;
+                    float32x4_t sum_lo = vdupq_n_f32(0.0f);
+                    float32x4_t sum_hi = vdupq_n_f32(0.0f);
+
+                    for (size_t a = 0; a < vec_axis; a += W) {
+                        float32x4_t lo, hi;
+                        f16x8_split_f32(vld1q_f16(row + a), lo, hi);
+                        sum_lo = vaddq_f32(sum_lo, lo);
+                        sum_hi = vaddq_f32(sum_hi, hi);
+                    }
+
+                    float total = vaddvq_f32(vaddq_f32(sum_lo, sum_hi));
+                    for (size_t a = vec_axis; a < axis_size; ++a) {
+                        total += static_cast<float>(row[a]);
+                    }
+
+                    output[outer] = static_cast<__fp16>(finalize(total, axis_size));
+                }
+            });
+        return;
+    }
+
     CactusThreading::parallel_for_2d(outer_size, inner_size, CactusThreading::Thresholds::AXIS_REDUCE,
         [&](size_t outer, size_t inner) {
             constexpr size_t W = SIMD_F16_WIDTH;
@@ -41,6 +70,37 @@ static void axis_reduce_f16_impl(const __fp16* input, __fp16* output,
                                  size_t outer_size, size_t axis_size, size_t inner_size,
                                  float16x8_t init_vec, __fp16 init_scalar,
                                  SimdReduceOp simd_reduce, ScalarReduceOp scalar_reduce) {
+    if (inner_size == 1) {
+        CactusThreading::parallel_for(outer_size, CactusThreading::Thresholds::AXIS_REDUCE,
+            [&](size_t start_outer, size_t end_outer) {
+                constexpr size_t W = SIMD_F16_WIDTH;
+                const size_t vec_axis = simd_align(axis_size);
+
+                for (size_t outer = start_outer; outer < end_outer; ++outer) {
+                    const __fp16* row = input + outer * axis_size;
+                    float16x8_t acc = init_vec;
+
+                    for (size_t a = 0; a < vec_axis; a += W) {
+                        acc = simd_reduce(acc, vld1q_f16(row + a));
+                    }
+
+                    __fp16 result = init_scalar;
+                    __fp16 arr[W];
+                    vst1q_f16(arr, acc);
+                    for (size_t j = 0; j < W; ++j) {
+                        result = scalar_reduce(result, arr[j]);
+                    }
+
+                    for (size_t a = vec_axis; a < axis_size; ++a) {
+                        result = scalar_reduce(result, row[a]);
+                    }
+
+                    output[outer] = result;
+                }
+            });
+        return;
+    }
+
     CactusThreading::parallel_for_2d(outer_size, inner_size, CactusThreading::Thresholds::AXIS_REDUCE,
         [&](size_t outer, size_t inner) {
             constexpr size_t W = SIMD_F16_WIDTH;
@@ -154,6 +214,44 @@ double cactus_variance_all_f16(const __fp16* data, size_t num_elements) {
 }
 
 void cactus_variance_axis_f16(const __fp16* input, __fp16* output, size_t outer_size, size_t axis_size, size_t inner_size) {
+    if (inner_size == 1) {
+        CactusThreading::parallel_for(outer_size, CactusThreading::Thresholds::AXIS_REDUCE,
+            [&](size_t start_outer, size_t end_outer) {
+                constexpr size_t W = SIMD_F16_WIDTH;
+                const size_t vec_axis = simd_align(axis_size);
+
+                for (size_t outer = start_outer; outer < end_outer; ++outer) {
+                    const __fp16* row = input + outer * axis_size;
+                    float32x4_t sum_lo = vdupq_n_f32(0.0f);
+                    float32x4_t sum_hi = vdupq_n_f32(0.0f);
+                    float32x4_t sq_lo = vdupq_n_f32(0.0f);
+                    float32x4_t sq_hi = vdupq_n_f32(0.0f);
+
+                    for (size_t a = 0; a < vec_axis; a += W) {
+                        float32x4_t lo, hi;
+                        f16x8_split_f32(vld1q_f16(row + a), lo, hi);
+                        sum_lo = vaddq_f32(sum_lo, lo);
+                        sum_hi = vaddq_f32(sum_hi, hi);
+                        sq_lo = vfmaq_f32(sq_lo, lo, lo);
+                        sq_hi = vfmaq_f32(sq_hi, hi, hi);
+                    }
+
+                    float sum = vaddvq_f32(vaddq_f32(sum_lo, sum_hi));
+                    float sum_sq = vaddvq_f32(vaddq_f32(sq_lo, sq_hi));
+                    for (size_t a = vec_axis; a < axis_size; ++a) {
+                        float x = static_cast<float>(row[a]);
+                        sum += x;
+                        sum_sq += x * x;
+                    }
+
+                    float mean = sum / static_cast<float>(axis_size);
+                    float mean_sq = sum_sq / static_cast<float>(axis_size);
+                    output[outer] = static_cast<__fp16>(mean_sq - mean * mean);
+                }
+            });
+        return;
+    }
+
     CactusThreading::parallel_for_2d(outer_size, inner_size, CactusThreading::Thresholds::AXIS_REDUCE,
         [&](size_t outer, size_t inner) {
             float sum = 0.0f, sum_sq = 0.0f;

--- a/tests/test_kernel.cpp
+++ b/tests/test_kernel.cpp
@@ -130,6 +130,7 @@ bool test_neon_sum_axis_inner1_correctness() {
         1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f,
         2.0f, 4.0f, 6.0f, 8.0f, 10.0f, 12.0f, 14.0f, 16.0f, 18.0f
     };
+
     std::vector<__fp16> output(outer_size * inner_size);
     std::vector<__fp16> expected = {45.0f, 90.0f};
 

--- a/tests/test_kernel.cpp
+++ b/tests/test_kernel.cpp
@@ -121,6 +121,116 @@ bool test_neon_reduction_correctness() {
     return true;
 }
 
+bool test_neon_sum_axis_inner1_correctness() {
+    const size_t outer_size = 2;
+    const size_t axis_size = 9;
+    const size_t inner_size = 1;
+
+    std::vector<__fp16> input = {
+        1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f,
+        2.0f, 4.0f, 6.0f, 8.0f, 10.0f, 12.0f, 14.0f, 16.0f, 18.0f
+    };
+    std::vector<__fp16> output(outer_size * inner_size);
+    std::vector<__fp16> expected = {45.0f, 90.0f};
+
+    cactus_sum_axis_f16(input.data(), output.data(), outer_size, axis_size, inner_size);
+    return TestUtils::compare_arrays(output.data(), expected.data(), expected.size(), 1e-2f);
+}
+
+bool test_neon_mean_axis_inner1_correctness() {
+    const size_t outer_size = 2;
+    const size_t axis_size = 9;
+    const size_t inner_size = 1;
+
+    std::vector<__fp16> input = {
+        1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f,
+        2.0f, 4.0f, 6.0f, 8.0f, 10.0f, 12.0f, 14.0f, 16.0f, 18.0f
+    };
+    std::vector<__fp16> output(outer_size * inner_size);
+    std::vector<__fp16> expected = {5.0f, 10.0f};
+
+    cactus_mean_axis_f16(input.data(), output.data(), outer_size, axis_size, inner_size);
+    return TestUtils::compare_arrays(output.data(), expected.data(), expected.size(), 1e-2f);
+}
+
+bool test_neon_variance_axis_inner1_correctness() {
+    const size_t outer_size = 2;
+    const size_t axis_size = 9;
+    const size_t inner_size = 1;
+
+    std::vector<__fp16> input = {
+        1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f,
+        2.0f, 4.0f, 6.0f, 8.0f, 10.0f, 12.0f, 14.0f, 16.0f, 18.0f
+    };
+    std::vector<__fp16> output(outer_size * inner_size);
+    std::vector<__fp16> expected = {6.6667f, 26.6667f};
+
+    cactus_variance_axis_f16(input.data(), output.data(), outer_size, axis_size, inner_size);
+    return TestUtils::compare_arrays(output.data(), expected.data(), expected.size(), 0.05f);
+}
+
+bool test_neon_variance_axis_non_inner1_correctness() {
+    const size_t outer_size = 2;
+    const size_t axis_size = 9;
+    const size_t inner_size = 3;
+
+    std::vector<__fp16> input(outer_size * axis_size * inner_size);
+    auto idx = [&](size_t outer, size_t axis, size_t inner) {
+        return outer * axis_size * inner_size + axis * inner_size + inner;
+    };
+
+    for (size_t a = 0; a < axis_size; ++a) {
+        input[idx(0, a, 0)] = static_cast<__fp16>(1.0f + static_cast<float>(a));
+        input[idx(0, a, 1)] = static_cast<__fp16>(2.0f + static_cast<float>(a));
+        input[idx(0, a, 2)] = static_cast<__fp16>(-4.0f + static_cast<float>(a));
+
+        input[idx(1, a, 0)] = static_cast<__fp16>(2.0f + 2.0f * static_cast<float>(a));
+        input[idx(1, a, 1)] = static_cast<__fp16>(3.0f + 2.0f * static_cast<float>(a));
+        input[idx(1, a, 2)] = static_cast<__fp16>(-8.0f + 2.0f * static_cast<float>(a));
+    }
+
+    std::vector<__fp16> output(outer_size * inner_size);
+    std::vector<__fp16> expected = {
+        6.6667f, 6.6667f, 6.6667f,
+        26.6667f, 26.6667f, 26.6667f
+    };
+
+    cactus_variance_axis_f16(input.data(), output.data(), outer_size, axis_size, inner_size);
+    return TestUtils::compare_arrays(output.data(), expected.data(), expected.size(), 0.05f);
+}
+
+bool test_neon_min_axis_inner1_correctness() {
+    const size_t outer_size = 2;
+    const size_t axis_size = 9;
+    const size_t inner_size = 1;
+
+    std::vector<__fp16> input = {
+        1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f,
+        2.0f, 4.0f, 6.0f, 8.0f, 10.0f, 12.0f, 14.0f, 16.0f, 18.0f
+    };
+    std::vector<__fp16> output(outer_size * inner_size);
+    std::vector<__fp16> expected = {1.0f, 2.0f};
+
+    cactus_min_axis_f16(input.data(), output.data(), outer_size, axis_size, inner_size);
+    return TestUtils::compare_arrays(output.data(), expected.data(), expected.size(), 1e-2f);
+}
+
+bool test_neon_max_axis_inner1_correctness() {
+    const size_t outer_size = 2;
+    const size_t axis_size = 9;
+    const size_t inner_size = 1;
+
+    std::vector<__fp16> input = {
+        1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f,
+        2.0f, 4.0f, 6.0f, 8.0f, 10.0f, 12.0f, 14.0f, 16.0f, 18.0f
+    };
+    std::vector<__fp16> output(outer_size * inner_size);
+    std::vector<__fp16> expected = {9.0f, 18.0f};
+
+    cactus_max_axis_f16(input.data(), output.data(), outer_size, axis_size, inner_size);
+    return TestUtils::compare_arrays(output.data(), expected.data(), expected.size(), 1e-2f);
+}
+
 bool test_neon_transpose_fp16_correctness() {
     const size_t M = 3, N = 4;
     std::vector<__fp16> input = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
@@ -499,6 +609,12 @@ int main() {
     runner.run_test("Kernel Multiply FP16 Correctness", test_neon_multiply_fp16_correctness());
     runner.run_test("Kernel Scalar Ops FP16 Correctness", test_neon_scalar_operations_fp16_correctness());
     runner.run_test("Kernel Reduction Correctness", test_neon_reduction_correctness());
+    runner.run_test("Kernel Sum Axis Inner1 FP16 Correctness", test_neon_sum_axis_inner1_correctness());
+    runner.run_test("Kernel Mean Axis Inner1 FP16 Correctness", test_neon_mean_axis_inner1_correctness());
+    runner.run_test("Kernel Variance Axis Inner1 FP16 Correctness", test_neon_variance_axis_inner1_correctness());
+    runner.run_test("Kernel Variance Axis Non-Inner1 FP16 Correctness", test_neon_variance_axis_non_inner1_correctness());
+    runner.run_test("Kernel Min Axis Inner1 FP16 Correctness", test_neon_min_axis_inner1_correctness());
+    runner.run_test("Kernel Max Axis Inner1 FP16 Correctness", test_neon_max_axis_inner1_correctness());
     runner.run_test("Kernel Transpose FP16 Correctness", test_neon_transpose_fp16_correctness());
     runner.run_test("Kernel Softmax Correctness", test_neon_softmax_correctness());
     runner.run_test("Kernel RoPE Correctness", test_neon_rope_correctness());

--- a/tests/test_performance.cpp
+++ b/tests/test_performance.cpp
@@ -430,6 +430,73 @@ void benchmark_reduction_ops(TestUtils::TestRunner& runner, const BenchmarkConfi
 }
 
 template<typename T>
+void benchmark_axis_reduction_inner1_ops(TestUtils::TestRunner& runner, const BenchmarkConfig& config) {
+    const std::vector<std::pair<std::string, std::function<size_t(CactusGraph&, size_t)>>> ops = {
+        {"Axis Sum", [](CactusGraph& b, size_t a) { return b.sum(a, 1); }},
+        {"Axis Mean", [](CactusGraph& b, size_t a) { return b.mean(a, 1); }},
+        {"Axis Variance", [](CactusGraph& b, size_t a) { return b.variance(a, 1); }},
+        {"Axis Min", [](CactusGraph& b, size_t a) { return b.min(a, 1); }},
+        {"Axis Max", [](CactusGraph& b, size_t a) { return b.max(a, 1); }}
+    };
+
+    Precision precision = TestUtils::default_precision<T>();
+
+    for (const auto& [op_name, op_func] : ops) {
+        for (size_t dim : config.dimensions) {
+            size_t total_elements = dim * dim;
+
+            TestUtils::TestFixture<T> fixture(op_name);
+            size_t input_a = fixture.create_input({dim, dim}, precision);
+
+            std::vector<T> data_a(total_elements);
+            setup_random_data(data_a);
+            fixture.set_input_data(input_a, data_a, precision);
+
+            op_func(fixture.graph(), input_a);
+
+            double time_ms = time_operation<T>([&]() {
+                fixture.execute();
+            }, config.iterations);
+
+            double gb_per_sec = (total_elements * PrecisionTraits::size_of(precision)) / (time_ms * 1e6);
+
+            std::ostringstream details;
+            details << std::fixed << std::setprecision(3) << time_ms << "ms, "
+                    << std::setprecision(2) << gb_per_sec << " GB/s";
+            runner.log_performance(op_name + " " + std::to_string(dim) + "x" + std::to_string(dim),
+                                   details.str());
+        }
+    }
+
+    for (size_t dim : config.dimensions) {
+        const size_t channels = 4;
+        size_t total_elements = dim * dim * channels;
+
+        TestUtils::TestFixture<T> fixture("Axis Variance Non-Inner1");
+        size_t input_a = fixture.create_input({dim, dim, channels}, precision);
+
+        std::vector<T> data_a(total_elements);
+        setup_random_data(data_a);
+        fixture.set_input_data(input_a, data_a, precision);
+
+        fixture.graph().variance(input_a, 1);
+
+        double time_ms = time_operation<T>([&]() {
+            fixture.execute();
+        }, config.iterations);
+
+        double gb_per_sec = (total_elements * PrecisionTraits::size_of(precision)) / (time_ms * 1e6);
+
+        std::ostringstream details;
+        details << std::fixed << std::setprecision(3) << time_ms << "ms, "
+                << std::setprecision(2) << gb_per_sec << " GB/s";
+        runner.log_performance("Axis Variance Non-Inner1 " + std::to_string(dim) + "x" +
+                               std::to_string(dim) + "x" + std::to_string(channels),
+                               details.str());
+    }
+}
+
+template<typename T>
 void benchmark_advanced_ops(TestUtils::TestRunner& runner, const BenchmarkConfig& config) {
     Precision precision = TestUtils::default_precision<T>();
 
@@ -1027,6 +1094,12 @@ bool test_reduction_operations_performance(TestUtils::TestRunner& runner) {
     return true;
 }
 
+bool test_axis_reduction_inner1_operations_performance(TestUtils::TestRunner& runner) {
+    BenchmarkConfig config;
+    benchmark_axis_reduction_inner1_ops<__fp16>(runner, config);
+    return true;
+}
+
 bool test_advanced_operations_performance(TestUtils::TestRunner& runner) {
     BenchmarkConfig config;
     benchmark_advanced_ops<__fp16>(runner, config);
@@ -1195,6 +1268,7 @@ int main() {
     runner.run_test("Grouped INT8 MatMul", test_grouped_int8_matmul_performance(runner));
     runner.run_test("Unary Operations", test_unary_operations_performance(runner));
     runner.run_test("Reduction Operations", test_reduction_operations_performance(runner));
+    runner.run_test("Axis Reduction Inner1 Operations", test_axis_reduction_inner1_operations_performance(runner));
     runner.run_test("Advanced Operations", test_advanced_operations_performance(runner));
     runner.run_test("Engine Operations", test_engine_operations_performance(runner));
     runner.run_test("Gather Operations", test_gather_operations_performance(runner));


### PR DESCRIPTION
# Axis Reductions Fast Path when inner=1
- instead of gathering values manually, add a fast path for when inner_size = 1 to load all axis elements simultaneously into  the vector register, saves a lot of memory overhead and latency per reduction kernel (see benchmarks)
- softmax, rmsnorm, layernorm all use reduction operations, should see some performance gains for overall model inference
- worked on this issue a couple months ago but never merged

# Summary 
- Added fast-path for all axis functions (cactus_min_axis, cactus_max_axis, cactus_mean_axis, cactus_sum_axis) for when inner_size == 1
- Modified cactus_variance_axis to use 2-accumulator NEON pass matching for both inner_size == 1 and other cases (currently all scalar)
- Added 6 benchmark cases to test_performance.cpp, all related to axis reductions (axis sum, mean, max, min, variance), all specifically for benchmarking kernel reductions for inner_size = 1. Also added 1 benchmark for variance when inner_size is not 1
- Added correctness tests specifically for when inner_size == 1 for axis reductions in test_kernel.cpp

# Benchmark (M4 Mac)
## Axis Reduction Performance Comparison (1024x1024)

| Operation                         | Old Time (ms) | New Time (ms) | Speedup (×) | Old GB/s | New GB/s | BW Gain (×) |
|-----------------------------------|---------------|---------------|-------------|----------|----------|-------------|
| Axis Sum                          | 0.067        | 0.038        | **1.76×**   | 31.30    | 55.19    | **1.76×**   |
| Axis Mean                         | 0.055        | 0.038        | **1.45×**   | 38.13    | 55.19    | **1.45×**   |
| Axis Variance                     | 0.327        | 0.058        | **5.64×**   | 6.41     | 36.16    | **5.64×**   |
| Axis Min                          | 0.054        | 0.032        | **1.69×**   | 38.84    | 65.54    | **1.69×**   |
| Axis Max                          | 0.056        | 0.043        | **1.30×**   | 37.45    | 48.77    | **1.30×**   |
| Axis Variance (Non-Inner1 1024x1024x4) | 0.480 | 0.144 | **3.33×** | 17.48 | 58.25 | **3.33×** |

---

### Highlights
- **Variance (inner_size == 1)** improved by **5.6×**
- **Non-Inner1 variance** improved by **3.3×**