### PR TITLE
Fused dense CQ4 MLP op for Gemma-4 decode

### DIFF
--- a/cactus-engine/models/gemma4/model_gemma4.cpp
+++ b/cactus-engine/models/gemma4/model_gemma4.cpp
@@ -312,6 +312,20 @@ size_t Gemma4Model::build_attention(CactusGraph* gb, size_t input, uint32_t laye
 size_t Gemma4Model::build_mlp(CactusGraph* gb, size_t input, uint32_t layer_idx,
                                   ComputeBackend backend) const {
     const auto& layer = weight_nodes_.layers[layer_idx];
+    const auto& gate_buf = gb->get_output_buffer(layer.ffn_gate_weight);
+    const auto& up_buf   = gb->get_output_buffer(layer.ffn_up_weight);
+    const auto& down_buf = gb->get_output_buffer(layer.ffn_down_weight);
+    if (gate_buf.is_cq() && up_buf.is_cq() && down_buf.is_cq() &&
+        PrecisionTraits::cq_bits(gate_buf.precision) == 4 &&
+        PrecisionTraits::cq_bits(up_buf.precision) == 4 &&
+        PrecisionTraits::cq_bits(down_buf.precision) == 4 &&
+        gate_buf.group_size == up_buf.group_size &&
+        gate_buf.group_size == down_buf.group_size) {
+        return gb->dense_mlp_cq_fused(input,
+                                      layer.ffn_gate_weight,
+                                      layer.ffn_up_weight,
+                                      layer.ffn_down_weight);
+    }
     auto gate = gb->gelu(gb->matmul(input, layer.ffn_gate_weight, true, backend));
     auto up = gb->matmul(input, layer.ffn_up_weight, true, backend);
     return gb->matmul(gb->multiply(gate, up), layer.ffn_down_weight, true, backend);

--- a/cactus-graph/cactus_graph.h
+++ b/cactus-graph/cactus_graph.h
@@ -111,7 +111,8 @@ enum class OpType {
     CONV_CACHE_STATE, CONV_CACHE_APPEND,
     RFFT, IRFFT, MEL_FILTER_BANK, SPECTROGRAM,
     IMAGE_PREPROCESS,
-    CLAMP
+    CLAMP,
+    DENSE_MLP_CQ_FUSED
 };
 
 struct PrecisionTraits {
@@ -666,6 +667,8 @@ public:
         Activation activation);
     size_t stats_pool(size_t input);
     size_t weighted_stats_pool(size_t input, size_t weights);
+    size_t dense_mlp_cq_fused(size_t hidden, size_t gate_weight,
+                               size_t up_weight, size_t down_weight);
 
     size_t sample(
         size_t logits, float temperature = 0.6f, float top_p = 0.95f, size_t top_k = 20,

--- a/cactus-graph/src/builder.cpp
+++ b/cactus-graph/src/builder.cpp
@@ -1677,6 +1677,31 @@ size_t CactusGraph::weighted_stats_pool(size_t input, size_t weights) {
     return add_node(OpType::WEIGHTED_STATS_POOL, {input, weights}, {batch, features * 2});
 }
 
+size_t CactusGraph::dense_mlp_cq_fused(size_t hidden, size_t gate_weight,
+                                        size_t up_weight, size_t down_weight) {
+    const auto& hidden_buf = get_output_buffer(hidden);
+    if (hidden_buf.shape.size() < 2) {
+        throw std::runtime_error("dense_mlp_cq_fused requires hidden of rank >= 2");
+    }
+    const auto& down_buf = get_output_buffer(down_weight);
+    size_t hidden_dim;
+    if (down_buf.is_interleaved && down_buf.original_N > 0) {
+        hidden_dim = down_buf.original_N;
+    } else {
+        hidden_dim = down_buf.shape[0];
+    }
+
+    std::vector<size_t> output_shape = hidden_buf.shape;
+    output_shape[output_shape.size() - 1] = hidden_dim;
+
+    OpParams params;
+    params.output_precision = Precision::FP16;
+
+    return add_node(OpType::DENSE_MLP_CQ_FUSED,
+                    {hidden, gate_weight, up_weight, down_weight},
+                    output_shape, params);
+}
+
 size_t CactusGraph::kv_cache_state(size_t max_seq_len, size_t num_kv_heads, size_t head_dim,
                                     size_t window_size, size_t sink_size) {
     size_t num_groups = (head_dim + KV_QUANT_GROUP_SIZE - 1) / KV_QUANT_GROUP_SIZE;

--- a/cactus-graph/src/execute.cpp
+++ b/cactus-graph/src/execute.cpp
@@ -197,33 +197,32 @@ static inline void dispatch_node(GraphNode& node, const nodes_vector& nodes, con
 static const char* op_type_names[] = {
     "INPUT", "PRECISION_CAST",
     "ADD", "ADD_CLIPPED", "SUBTRACT", "MULTIPLY", "DIVIDE",
-    "MATMUL", "TRANSPOSE", "RESHAPE", "SLICE", "GATHER", "EMBEDDING", "VIEW", "FLATTEN",
+    "ABS", "POW", "FLATTEN", "VIEW",
+    "MATMUL", "TRANSPOSE", "RESHAPE", "SLICE", "GATHER", "EMBEDDING",
     "BILINEAR_INTERPOLATION",
     "SUM", "MEAN", "VARIANCE", "MIN", "MAX",
-    "RMS_NORM", "ROPE", "ROPE_GPTJ", "SOFTMAX", "ATTENTION", "ATTENTION_INT8_HYBRID", "REL_POS_BIAS", "CONV1D_CAUSAL", "CONV1D_K3", "CONV1D_K7S3", "CONV1D", "CONV1D_SAME_DEPTHWISE_K9", "CONV1D_POINTWISE", "CONV2D_K3S2P1", "CONV2D_DEPTHWISE_K3S2P1", "CONV2D_POINTWISE_1X1", "GLU", "BATCHNORM",
+    "RMS_NORM", "ROPE", "ROPE_GPTJ", "SOFTMAX",
+    "ATTENTION", "ATTENTION_INT8_HYBRID", "REL_POS_BIAS",
+    "CONV1D_CAUSAL", "CONV1D_K3", "CONV1D_K7S3", "CONV1D",
+    "CONV1D_SAME_DEPTHWISE_K9", "CONV1D_POINTWISE",
+    "CONV2D_K3S2P1", "CONV2D_DEPTHWISE_K3S2P1", "CONV2D_POINTWISE_1X1",
+    "GLU", "BATCHNORM",
     "SCALAR_ADD", "SCALAR_SUBTRACT", "SCALAR_MULTIPLY", "SCALAR_DIVIDE",
     "SCALAR_EXP", "SCALAR_SQRT", "SCALAR_COS", "SCALAR_SIN", "SCALAR_LOG",
-    "ABS", "POW", 
     "RELU", "SILU", "GELU", "GELU_ERF", "SIGMOID", "TANH",
-    "SAMPLE", "CONCAT",
-    "SCATTER_TOPK",
-    "TOPK", "LAYERNORM", "GROUPNORM",
-    "MOE_LAYER",
-    "INDEX",
-    "PERSISTENT",
-    "LSTM_CELL",
-    "GATED_DELTANET_DECODE",
-    "GATED_DELTANET_PREFILL",
-    "STFT",
-    "ALTUP_PREDICT",
-    "ALTUP_CORRECT",
-    "GAUSSIAN_TOPK",
-    "MAXPOOL1D",
-    "BILSTM_SEQUENCE",
-    "LEAKY_RELU",
-    "CONV2D_K3S1P1",
-    "STATS_POOL",
-    "WEIGHTED_STATS_POOL"
+    "SAMPLE", "CONCAT", "CAT",
+    "SCATTER_TOPK", "TOPK", "LAYERNORM", "GROUPNORM",
+    "MOE_LAYER", "INDEX", "PERSISTENT",
+    "LSTM_CELL", "GATED_DELTANET_DECODE", "GATED_DELTANET_PREFILL",
+    "STFT", "ALTUP_PREDICT", "ALTUP_CORRECT", "GAUSSIAN_TOPK",
+    "MAXPOOL1D", "BILSTM_SEQUENCE", "LEAKY_RELU",
+    "CONV2D_K3S1P1", "STATS_POOL", "WEIGHTED_STATS_POOL",
+    "KV_CACHE_STATE", "KV_CACHE_APPEND", "ATTENTION_CACHED",
+    "CONV_CACHE_STATE", "CONV_CACHE_APPEND",
+    "RFFT", "IRFFT", "MEL_FILTER_BANK", "SPECTROGRAM",
+    "IMAGE_PREPROCESS",
+    "CLAMP",
+    "DENSE_MLP_CQ_FUSED"
 };
 
 static const char* get_op_name(OpType op) {
@@ -397,7 +396,12 @@ void CactusGraph::execute(const std::string& profile_file) {
             node->output_buffer.allocate_from_pool(pool);
         }
 
-        if (enable_profiling && node->op_type != OpType::INPUT) {
+        if (node->op_type == OpType::INPUT) {
+            // INPUT nodes have no compute; their data is set externally.
+            continue;
+        }
+
+        if (enable_profiling) {
             auto start = std::chrono::high_resolution_clock::now();
             dispatch_node(*node, nodes_, node_index_map_);
             if (node->op_type == OpType::PERSISTENT) {

--- a/cactus-graph/src/execute.cpp
+++ b/cactus-graph/src/execute.cpp
@@ -80,10 +80,11 @@ DECLARE_COMPUTE(compute_rfft_node);
 DECLARE_COMPUTE(compute_irfft_node);
 DECLARE_COMPUTE(compute_mel_filter_bank_node);
 DECLARE_COMPUTE(compute_spectrogram_node);
+DECLARE_COMPUTE(compute_dense_mlp_cq_fused_node);
 extern void shrink_thread_local_buffers();
 #undef DECLARE_COMPUTE
 
-static constexpr int OP_TYPE_COUNT = static_cast<int>(OpType::CLAMP) + 1;
+static constexpr int OP_TYPE_COUNT = static_cast<int>(OpType::DENSE_MLP_CQ_FUSED) + 1;
 static_assert(OP_TYPE_COUNT <= 256, "OpType dispatch table overflow");
 static ComputeFn dispatch_flat[OP_TYPE_COUNT] = {};
 
@@ -177,6 +178,7 @@ static bool init_dispatch() {
     dispatch_flat[static_cast<int>(OpType::IRFFT)] = compute_irfft_node;
     dispatch_flat[static_cast<int>(OpType::MEL_FILTER_BANK)] = compute_mel_filter_bank_node;
     dispatch_flat[static_cast<int>(OpType::SPECTROGRAM)] = compute_spectrogram_node;
+    dispatch_flat[static_cast<int>(OpType::DENSE_MLP_CQ_FUSED)] = compute_dense_mlp_cq_fused_node;
     return true;
 }
 

--- a/cactus-graph/src/ops_nn.cpp
+++ b/cactus-graph/src/ops_nn.cpp
@@ -362,6 +362,41 @@ void compute_moe_layer_node(GraphNode& node, const std::vector<std::unique_ptr<G
     }
 }
 
+void compute_dense_mlp_cq_fused_node(GraphNode& node, const std::vector<std::unique_ptr<GraphNode>>& nodes, const std::unordered_map<size_t, size_t>& node_index_map) {
+    const auto& hidden_buf = get_input(node, 0, nodes, node_index_map);
+    const auto& gate_buf   = get_input(node, 1, nodes, node_index_map);
+    const auto& up_buf     = get_input(node, 2, nodes, node_index_map);
+    const auto& down_buf   = get_input(node, 3, nodes, node_index_map);
+
+    if (hidden_buf.precision != Precision::FP16 || node.output_buffer.precision != Precision::FP16) {
+        throw std::runtime_error("dense_mlp_cq_fused expects FP16 hidden/output");
+    }
+    if (!gate_buf.is_cq() || !up_buf.is_cq() || !down_buf.is_cq()) {
+        throw std::runtime_error("dense_mlp_cq_fused expects CQ-quantized gate/up/down weights");
+    }
+    if (gate_buf.group_size != up_buf.group_size || gate_buf.group_size != down_buf.group_size) {
+        throw std::runtime_error("dense_mlp_cq_fused: gate/up/down group_size must match");
+    }
+    if (PrecisionTraits::cq_bits(gate_buf.precision) != 4 ||
+        PrecisionTraits::cq_bits(up_buf.precision)   != 4 ||
+        PrecisionTraits::cq_bits(down_buf.precision) != 4) {
+        throw std::runtime_error("dense_mlp_cq_fused currently only supports CQ4");
+    }
+
+    const auto& shape = hidden_buf.shape;
+    size_t M = 1;
+    for (size_t i = 0; i + 1 < shape.size(); ++i) M *= shape[i];
+
+    const __fp16* x = hidden_buf.data_as<__fp16>();
+    __fp16* y = node.output_buffer.data_as<__fp16>();
+
+    CactusQuantMatrix gate_mat = gate_buf.to_cq_matrix();
+    CactusQuantMatrix up_mat   = up_buf.to_cq_matrix();
+    CactusQuantMatrix down_mat = down_buf.to_cq_matrix();
+
+    cactus_dense_mlp_cq_fused(&gate_mat, &up_mat, &down_mat, x, static_cast<uint32_t>(M), y);
+}
+
 void compute_rms_norm_node(GraphNode& node, const std::vector<std::unique_ptr<GraphNode>>& nodes, const std::unordered_map<size_t, size_t>& node_index_map) {
     const auto& input_buffer = get_input(node, 0, nodes, node_index_map);
     const auto& weight_buffer = get_input(node, 1, nodes, node_index_map);

--- a/cactus-graph/tests/test_nn.cpp
+++ b/cactus-graph/tests/test_nn.cpp
@@ -835,6 +835,200 @@ bool run_benchmarks() {
         g.set_input(ii, in.data(), Precision::FP16);
         bench("softmax 1024x1024", []{}, [&]{ g.execute(); });
     }
+    {
+        // 30-layer transformer block: rms_norm, attn (Q/K/V/O fp16) with kv-cache,
+        // MLP (CQ4 fused or canonical chain), residuals, post-norms. Weights are
+        // reused across all 30 layers to keep the bench under ~30 MB.
+        using dense_mlp_cq4_test::CQ4;
+        constexpr uint32_t num_layers = 30;
+        constexpr uint32_t M = 1;
+        constexpr uint32_t hidden = 2304, d_ffn = 9216, gs = 128;
+        constexpr uint32_t num_heads = 8, num_kv_heads = 2, head_dim = 256;
+        constexpr uint32_t q_dim = num_heads * head_dim;
+        constexpr uint32_t kv_dim = num_kv_heads * head_dim;
+        constexpr uint32_t cache_len = 256;
+
+        CQ4 gate(hidden, d_ffn, gs, 171);
+        CQ4 up  (hidden, d_ffn, gs, 172);
+        CQ4 down(d_ffn, hidden, gs, 173);
+        gate.preexpand();
+        up.preexpand();
+        down.preexpand();
+
+        std::mt19937 wgen(901);
+        std::uniform_real_distribution<float> wdist(-0.03f, 0.03f);
+        auto rand_fp16 = [&](size_t n) {
+            std::vector<__fp16> v(n);
+            for (auto& x : v) x = static_cast<__fp16>(wdist(wgen));
+            return v;
+        };
+        std::vector<__fp16> wq = rand_fp16(static_cast<size_t>(q_dim) * hidden);
+        std::vector<__fp16> wk = rand_fp16(static_cast<size_t>(kv_dim) * hidden);
+        std::vector<__fp16> wv = rand_fp16(static_cast<size_t>(kv_dim) * hidden);
+        std::vector<__fp16> wo = rand_fp16(static_cast<size_t>(hidden) * q_dim);
+        std::vector<__fp16> rn_input(hidden, static_cast<__fp16>(1.0f));
+        std::vector<__fp16> rn_post_attn(hidden, static_cast<__fp16>(1.0f));
+        std::vector<__fp16> rn_pre_ffn(hidden, static_cast<__fp16>(1.0f));
+        std::vector<__fp16> rn_post_ffn(hidden, static_cast<__fp16>(1.0f));
+
+        std::vector<__fp16> x0(M * hidden);
+        for (auto& v : x0) v = static_cast<__fp16>(wdist(wgen));
+
+        const float attn_scale = 1.0f / std::sqrt(static_cast<float>(head_dim));
+
+        auto attach_cq4 = [&](CactusGraph& g, size_t node_id, const CQ4& w) {
+            g.set_external_input(node_id, const_cast<uint8_t*>(w.packed.data()), Precision::CQ4);
+            g.set_grouped_scales(node_id, w.group_size, w.num_groups,
+                                 const_cast<__fp16*>(w.norms.data()));
+            BufferDesc& buf = const_cast<BufferDesc&>(g.get_output_buffer(node_id));
+            buf.cq_codebook = w.codebook.data();
+            buf.cq_input_scale = w.input_scale.data();
+            buf.cq_input_scale_recip = w.input_scale_recip.data();
+            buf.cq_norms = w.norms.data();
+            buf.cq_left_signs = w.left_signs.data();
+            buf.cq_right_signs = w.right_signs.data();
+            buf.cq_permutation = w.permutation.data();
+            buf.cq_flags = CACTUS_QUANT_FLAG_CODE_ORDERED_INDICES;
+            // Without these owned copies, every CQ matmul rebuilds the int8 GEMV
+            // layout from packed indices on each call.
+            if (!w.expanded.empty()) {
+                auto exp_owned = std::make_unique<int8_t[]>(w.expanded.size());
+                std::memcpy(exp_owned.get(), w.expanded.data(), w.expanded.size());
+                buf.cq_expanded = std::move(exp_owned);
+            }
+            if (!w.norm_f32.empty()) {
+                auto nf_owned = std::make_unique<float[]>(w.norm_f32.size());
+                std::memcpy(nf_owned.get(), w.norm_f32.data(), w.norm_f32.size() * sizeof(float));
+                buf.cq_norm_f32 = std::move(nf_owned);
+            }
+        };
+
+        auto build_decode_graph = [&](CactusGraph& g, bool fused,
+                                      std::vector<size_t>& k_caches,
+                                      std::vector<size_t>& v_caches,
+                                      size_t& x_in_node) {
+            size_t wq_n = g.input({q_dim, hidden}, Precision::FP16);
+            size_t wk_n = g.input({kv_dim, hidden}, Precision::FP16);
+            size_t wv_n = g.input({kv_dim, hidden}, Precision::FP16);
+            size_t wo_n = g.input({hidden, q_dim}, Precision::FP16);
+            size_t rn_in_n   = g.input({hidden}, Precision::FP16);
+            size_t rn_pa_n   = g.input({hidden}, Precision::FP16);
+            size_t rn_pre_n  = g.input({hidden}, Precision::FP16);
+            size_t rn_post_n = g.input({hidden}, Precision::FP16);
+
+            size_t gate_n = g.input({d_ffn, hidden}, Precision::CQ4);
+            size_t up_n   = g.input({d_ffn, hidden}, Precision::CQ4);
+            size_t down_n = g.input({hidden, d_ffn}, Precision::CQ4);
+            attach_cq4(g, gate_n, gate);
+            attach_cq4(g, up_n,   up);
+            attach_cq4(g, down_n, down);
+
+            x_in_node = g.input({M, hidden}, Precision::FP16);
+            size_t hidden_node = x_in_node;
+
+            k_caches.resize(num_layers);
+            v_caches.resize(num_layers);
+
+            for (uint32_t L = 0; L < num_layers; ++L) {
+                k_caches[L] = g.kv_cache_state(cache_len, num_kv_heads, head_dim, cache_len, 0);
+                v_caches[L] = g.kv_cache_state(cache_len, num_kv_heads, head_dim, cache_len, 0);
+
+                size_t normed = g.rms_norm(hidden_node, rn_in_n, 1e-6f);
+
+                size_t q = g.matmul(normed, wq_n, true);
+                size_t k = g.matmul(normed, wk_n, true);
+                size_t v = g.matmul(normed, wv_n, true);
+
+                size_t q4 = g.reshape(q, {1, M, num_heads, head_dim});
+                size_t k4 = g.reshape(k, {1, M, num_kv_heads, head_dim});
+                size_t v4 = g.reshape(v, {1, M, num_kv_heads, head_dim});
+
+                g.kv_cache_append(k4, k_caches[L], cache_len, 0);
+                g.kv_cache_append(v4, v_caches[L], cache_len, 0);
+                size_t attn = g.attention_cached(q4, k4, v4,
+                                                 k_caches[L], v_caches[L],
+                                                 attn_scale, cache_len, 0);
+
+                size_t attn2 = g.reshape(attn, {M, q_dim});
+                size_t o = g.matmul(attn2, wo_n, true);
+
+                size_t post_attn = g.rms_norm(o, rn_pa_n, 1e-6f);
+                size_t residual = g.add(hidden_node, post_attn);
+
+                size_t pre_ffn = g.rms_norm(residual, rn_pre_n, 1e-6f);
+                size_t mlp_raw;
+                if (fused) {
+                    mlp_raw = g.dense_mlp_cq_fused(pre_ffn, gate_n, up_n, down_n);
+                } else {
+                    size_t gate_proj = g.matmul(pre_ffn, gate_n, true);
+                    size_t gated = g.gelu(gate_proj);
+                    size_t up_proj = g.matmul(pre_ffn, up_n, true);
+                    size_t hffn = g.multiply(gated, up_proj);
+                    mlp_raw = g.matmul(hffn, down_n, true);
+                }
+                size_t post_ffn = g.rms_norm(mlp_raw, rn_post_n, 1e-6f);
+                hidden_node = g.add(residual, post_ffn);
+            }
+
+            g.set_input(wq_n, wq.data(), Precision::FP16);
+            g.set_input(wk_n, wk.data(), Precision::FP16);
+            g.set_input(wv_n, wv.data(), Precision::FP16);
+            g.set_input(wo_n, wo.data(), Precision::FP16);
+            g.set_input(rn_in_n,   rn_input.data(),     Precision::FP16);
+            g.set_input(rn_pa_n,   rn_post_attn.data(), Precision::FP16);
+            g.set_input(rn_pre_n,  rn_pre_ffn.data(),   Precision::FP16);
+            g.set_input(rn_post_n, rn_post_ffn.data(),  Precision::FP16);
+        };
+
+        // Set CacheMetadata.current_seq_len at the head of the buffer so each step
+        // hits the sliding-window eviction path and runs attention at full window.
+        auto prewarm = [&](CactusGraph& g, const std::vector<size_t>& caches) {
+            for (size_t cn : caches) {
+                auto* raw = static_cast<uint8_t*>(g.get_output(cn));
+                if (!raw) continue;
+                *reinterpret_cast<uint64_t*>(raw + 0) = static_cast<uint64_t>(cache_len);
+            }
+        };
+
+        auto run_variant = [&](bool fused) {
+            CactusGraph g;
+            std::vector<size_t> k_caches, v_caches;
+            size_t x_in_node = 0;
+            build_decode_graph(g, fused, k_caches, v_caches, x_in_node);
+            g.set_input(x_in_node, x0.data(), Precision::FP16);
+
+            g.execute();
+            prewarm(g, k_caches);
+            prewarm(g, v_caches);
+            g.execute();
+
+            constexpr int iters = 100;
+            TestUtils::Timer t;
+            for (int i = 0; i < iters; ++i) {
+                prewarm(g, k_caches);
+                prewarm(g, v_caches);
+                g.execute();
+            }
+            return t.elapsed_ms() / static_cast<double>(iters);
+        };
+
+        double ms_unfused = run_variant(false);
+        double ms_fused   = run_variant(true);
+        double tps_unfused = 1000.0 / ms_unfused;
+        double tps_fused   = 1000.0 / ms_fused;
+        double delta_pct = (tps_fused - tps_unfused) / tps_unfused * 100.0;
+
+        std::cout << "  ⚡ " << std::left << std::setw(34)
+                  << "gemma4-e2b decode unfused (30L)"
+                  << std::fixed << std::setprecision(3) << ms_unfused << " ms   "
+                  << std::setprecision(1) << tps_unfused << " tok/s\n";
+        std::cout << "  ⚡ " << std::left << std::setw(34)
+                  << "gemma4-e2b decode fused   (30L)"
+                  << std::fixed << std::setprecision(3) << ms_fused << " ms   "
+                  << std::setprecision(1) << tps_fused << " tok/s   ("
+                  << std::showpos << std::setprecision(1) << delta_pct
+                  << std::noshowpos << "% tok/s)\n";
+    }
     return true;
 }
 

--- a/cactus-graph/tests/test_nn.cpp
+++ b/cactus-graph/tests/test_nn.cpp
@@ -1,4 +1,5 @@
 #include "test_utils.h"
+#include <array>
 #include <cassert>
 #include <cmath>
 #include <iostream>
@@ -89,6 +90,236 @@ bool test_matmul_cq() {
         if (std::abs(static_cast<float>(C[i])) > 1e-6f) has_nonzero = true;
     }
     return has_nonzero;
+}
+
+namespace dense_mlp_cq4_test {
+
+struct CQ4 {
+    uint32_t K, N;
+    uint32_t group_size, num_groups;
+    std::vector<__fp16> codebook;
+    std::vector<__fp16> input_scale;
+    std::vector<__fp16> input_scale_recip;
+    std::vector<__fp16> norms;
+    std::vector<int8_t> left_signs;
+    std::vector<int8_t> right_signs;
+    std::vector<uint32_t> permutation;
+    std::vector<uint8_t> packed;
+
+    std::vector<int8_t> expanded;
+    std::vector<float>  norm_f32;
+
+    CQ4(uint32_t k, uint32_t n, uint32_t gs, uint32_t seed)
+        : K(k), N(n), group_size(gs), num_groups(k / gs) {
+        std::mt19937 gen(seed);
+        std::uniform_real_distribution<float> dist(-1.f, 1.f);
+        constexpr uint32_t cb_size = 16;
+
+        codebook.resize(cb_size);
+        for (auto& v : codebook) v = static_cast<__fp16>(dist(gen));
+
+        input_scale.resize(K);
+        input_scale_recip.resize(K);
+        for (uint32_t i = 0; i < K; i++) {
+            float s = 0.5f + std::abs(dist(gen));
+            input_scale[i] = static_cast<__fp16>(s);
+            input_scale_recip[i] = static_cast<__fp16>(1.f / s);
+        }
+
+        norms.resize(static_cast<size_t>(N) * num_groups);
+        for (auto& v : norms) v = static_cast<__fp16>(dist(gen) * 0.1f);
+
+        left_signs.resize(group_size);
+        right_signs.resize(group_size);
+        for (auto& v : left_signs) v = (gen() & 1) ? 1 : -1;
+        for (auto& v : right_signs) v = (gen() & 1) ? 1 : -1;
+
+        permutation.resize(group_size);
+        for (uint32_t i = 0; i < group_size; i++) permutation[i] = i;
+
+        const uint32_t pgb = cactus_quant_packed_group_bytes(4, group_size);
+        packed.resize(static_cast<size_t>(N) * num_groups * pgb);
+        for (auto& v : packed) v = static_cast<uint8_t>(gen() & 0xFF);
+    }
+
+    // Mirrors io.cpp's on-load expansion so benches don't repeatedly rebuild it.
+    void preexpand() {
+        constexpr uint32_t bits = 4;
+        constexpr uint32_t cb_size = 16;
+        int8_t cb_i8[16] = {};
+        float cb_max = 0.f;
+        for (uint32_t i = 0; i < cb_size; i++) {
+            float v = std::abs(static_cast<float>(codebook[i]));
+            if (v > cb_max) cb_max = v;
+        }
+        float cb_sc = cb_max / 127.f;
+        if (cb_sc < 1e-10f) cb_sc = 1e-10f;
+        for (uint32_t i = 0; i < cb_size; i++)
+            cb_i8[i] = static_cast<int8_t>(std::round(static_cast<float>(codebook[i]) / cb_sc));
+
+        const size_t N_blocks = (N + 3) / 4;
+        const uint32_t pgb = cactus_quant_packed_group_bytes(bits, group_size);
+        expanded.assign(N_blocks * num_groups * group_size * 4, 0);
+        norm_f32.assign(N_blocks * num_groups * 4, 0.f);
+
+        auto unpack16 = [&](const uint8_t* p) {
+            uint8_t u[16];
+            for (int i = 0; i < 8; i++) {
+                u[2*i]     = (p[i] & 0x0F);
+                u[2*i + 1] = (p[i] >> 4);
+            }
+            std::array<int8_t, 16> r{};
+            for (int i = 0; i < 16; i++) r[i] = cb_i8[u[i]];
+            return r;
+        };
+
+        for (size_t nb = 0; nb < N_blocks; ++nb) {
+            size_t n_start = nb * 4;
+            size_t valid_n = std::min(size_t(4), static_cast<size_t>(N) - n_start);
+            for (uint32_t g = 0; g < num_groups; ++g) {
+                std::array<std::array<std::array<int8_t,16>,16>,4> exp4{};
+                uint32_t n_vecs = group_size / 16;
+                for (size_t ni = 0; ni < valid_n; ++ni) {
+                    const uint8_t* pk = packed.data() + (static_cast<size_t>(n_start+ni)*num_groups+g)*pgb;
+                    for (uint32_t v = 0; v < n_vecs; ++v) {
+                        exp4[ni][v] = unpack16(pk + (v*16*bits)/8);
+                    }
+                }
+                int8_t* dst = expanded.data() + (nb*num_groups+g)*group_size*4;
+                for (uint32_t v = 0; v < n_vecs; ++v) {
+                    for (uint32_t k = 0; k < 16; k++) {
+                        for (size_t ni = 0; ni < 4; ni++) {
+                            dst[v*64 + k*4 + ni] = exp4[ni][v][k];
+                        }
+                    }
+                }
+                float* nd = norm_f32.data() + (nb*num_groups+g)*4;
+                for (size_t ni = 0; ni < 4; ++ni)
+                    nd[ni] = (n_start+ni < N) ? static_cast<float>(norms[(n_start+ni)*num_groups+g]) * cb_sc : 0.f;
+            }
+        }
+    }
+
+    CactusQuantMatrix matrix() const {
+        return CactusQuantMatrix{
+            .bits = 4, .K = K, .N = N,
+            .group_size = group_size, .num_groups = num_groups,
+            .flags = CACTUS_QUANT_FLAG_CODE_ORDERED_INDICES,
+            .codebook = codebook.data(),
+            .input_scale = input_scale.data(),
+            .input_scale_recip = input_scale_recip.data(),
+            .norms = norms.data(),
+            .packed_indices = packed.data(),
+            .left_signs = left_signs.data(),
+            .right_signs = right_signs.data(),
+            .permutation = permutation.data(),
+            .expanded = expanded.empty() ? nullptr : expanded.data(),
+            .norm_f32 = norm_f32.empty() ? nullptr : norm_f32.data(),
+        };
+    }
+};
+
+}  // namespace dense_mlp_cq4_test
+
+bool test_dense_mlp_cq4_fused_vs_unfused() {
+    using dense_mlp_cq4_test::CQ4;
+    constexpr uint32_t M = 1;
+    constexpr uint32_t hidden = 256, d_ffn = 512, gs = 128;
+
+    CQ4 gate(hidden, d_ffn, gs, /*seed=*/11);
+    CQ4 up  (hidden, d_ffn, gs, /*seed=*/22);
+    CQ4 down(d_ffn, hidden, gs, /*seed=*/33);
+
+    std::mt19937 gen(101);
+    std::uniform_real_distribution<float> dist(-0.5f, 0.5f);
+    std::vector<__fp16> x(M * hidden);
+    for (auto& v : x) v = static_cast<__fp16>(dist(gen));
+
+    auto gate_W = gate.matrix();
+    auto up_W = up.matrix();
+    auto down_W = down.matrix();
+
+    std::vector<__fp16> gate_out(M * d_ffn), up_out(M * d_ffn), h_full(M * d_ffn);
+    std::vector<__fp16> y_unfused(M * hidden, static_cast<__fp16>(0));
+    cactus_quant_matmul(&gate_W, x.data(), M, gate_out.data());
+    cactus_gelu_f16(gate_out.data(), gate_out.data(), M * d_ffn);
+    cactus_quant_matmul(&up_W, x.data(), M, up_out.data());
+    cactus_multiply_f16(gate_out.data(), up_out.data(), h_full.data(), M * d_ffn);
+    cactus_quant_matmul(&down_W, h_full.data(), M, y_unfused.data());
+
+    std::vector<__fp16> y_fused(M * hidden, static_cast<__fp16>(0));
+    cactus_dense_mlp_cq_fused(&gate_W, &up_W, &down_W, x.data(), M, y_fused.data());
+
+    float max_abs_diff = 0.f;
+    for (size_t i = 0; i < y_unfused.size(); ++i) {
+        if (!std::isfinite(static_cast<float>(y_fused[i]))) return false;
+        float d = std::fabs(static_cast<float>(y_fused[i]) - static_cast<float>(y_unfused[i]));
+        if (d > max_abs_diff) max_abs_diff = d;
+    }
+    if (max_abs_diff > 1e-3f) {
+        std::cout << "  fused vs unfused max_abs_diff=" << max_abs_diff << "\n";
+        return false;
+    }
+    return true;
+}
+
+bool test_dense_mlp_cq4_fused_graph() {
+    using dense_mlp_cq4_test::CQ4;
+    constexpr uint32_t M = 1;
+    constexpr uint32_t hidden = 256, d_ffn = 512, gs = 128;
+    CQ4 gate(hidden, d_ffn, gs, 44);
+    CQ4 up  (hidden, d_ffn, gs, 55);
+    CQ4 down(d_ffn, hidden, gs, 66);
+
+    std::mt19937 gen(202);
+    std::uniform_real_distribution<float> dist(-0.5f, 0.5f);
+    std::vector<__fp16> x(M * hidden);
+    for (auto& v : x) v = static_cast<__fp16>(dist(gen));
+
+    CactusGraph g;
+    size_t hidden_node = g.input({M, hidden}, Precision::FP16);
+    size_t gate_node = g.input({d_ffn, hidden}, Precision::CQ4);
+    size_t up_node   = g.input({d_ffn, hidden}, Precision::CQ4);
+    size_t down_node = g.input({hidden, d_ffn}, Precision::CQ4);
+
+    auto attach_cq4 = [&](size_t node_id, const CQ4& w) {
+        g.set_external_input(node_id, const_cast<uint8_t*>(w.packed.data()), Precision::CQ4);
+        g.set_grouped_scales(node_id, w.group_size, w.num_groups,
+                             const_cast<__fp16*>(w.norms.data()));
+        BufferDesc& buf = const_cast<BufferDesc&>(g.get_output_buffer(node_id));
+        buf.cq_codebook = w.codebook.data();
+        buf.cq_input_scale = w.input_scale.data();
+        buf.cq_input_scale_recip = w.input_scale_recip.data();
+        buf.cq_norms = w.norms.data();
+        buf.cq_left_signs = w.left_signs.data();
+        buf.cq_right_signs = w.right_signs.data();
+        buf.cq_permutation = w.permutation.data();
+        buf.cq_flags = CACTUS_QUANT_FLAG_CODE_ORDERED_INDICES;
+    };
+    attach_cq4(gate_node, gate);
+    attach_cq4(up_node, up);
+    attach_cq4(down_node, down);
+
+    size_t y_node = g.dense_mlp_cq_fused(hidden_node, gate_node, up_node, down_node);
+    g.set_input(hidden_node, x.data(), Precision::FP16);
+    g.execute();
+
+    __fp16* result = static_cast<__fp16*>(g.get_output(y_node));
+    for (size_t i = 0; i < M * hidden; i++) {
+        if (!std::isfinite(static_cast<float>(result[i]))) return false;
+    }
+
+    auto gate_W = gate.matrix();
+    auto up_W = up.matrix();
+    auto down_W = down.matrix();
+    std::vector<__fp16> y_ref(M * hidden, static_cast<__fp16>(0));
+    cactus_dense_mlp_cq_fused(&gate_W, &up_W, &down_W, x.data(), M, y_ref.data());
+    float max_abs_diff = 0.f;
+    for (size_t i = 0; i < M * hidden; ++i) {
+        float d = std::fabs(static_cast<float>(result[i]) - static_cast<float>(y_ref[i]));
+        if (d > max_abs_diff) max_abs_diff = d;
+    }
+    return max_abs_diff <= 1e-3f;
 }
 
 bool test_attention_int8_hybrid() {
@@ -551,6 +782,37 @@ bool run_benchmarks() {
         bench("attention_int8 cache=512", []{}, [&]{ g.execute(); });
     }
     {
+        using dense_mlp_cq4_test::CQ4;
+        constexpr uint32_t M = 1;
+        constexpr uint32_t hidden = 2304, d_ffn = 9216, gs = 128;
+        CQ4 gate(hidden, d_ffn, gs, 71);
+        CQ4 up  (hidden, d_ffn, gs, 72);
+        CQ4 down(d_ffn, hidden, gs, 73);
+        gate.preexpand();
+        up.preexpand();
+        down.preexpand();
+        auto gate_W = gate.matrix();
+        auto up_W = up.matrix();
+        auto down_W = down.matrix();
+        std::vector<__fp16> x(M * hidden);
+        std::mt19937 bgen(101);
+        std::uniform_real_distribution<float> bdist(-0.5f, 0.5f);
+        for (auto& v : x) v = static_cast<__fp16>(bdist(bgen));
+
+        std::vector<__fp16> gate_out(M * d_ffn), up_out(M * d_ffn), h_full(M * d_ffn);
+        std::vector<__fp16> y(M * hidden);
+        bench("dense_mlp_cq4 unfused 1x2304x9216", []{}, [&]{
+            cactus_quant_matmul(&gate_W, x.data(), M, gate_out.data());
+            cactus_gelu_f16(gate_out.data(), gate_out.data(), M * d_ffn);
+            cactus_quant_matmul(&up_W, x.data(), M, up_out.data());
+            cactus_multiply_f16(gate_out.data(), up_out.data(), h_full.data(), M * d_ffn);
+            cactus_quant_matmul(&down_W, h_full.data(), M, y.data());
+        });
+        bench("dense_mlp_cq4 fused   1x2304x9216", []{}, [&]{
+            cactus_dense_mlp_cq_fused(&gate_W, &up_W, &down_W, x.data(), M, y.data());
+        });
+    }
+    {
         const size_t batch = 1024, dim = 1024;
         std::vector<__fp16> in(batch * dim), w(dim);
         TestUtils::fill_random_fp16(in);
@@ -581,6 +843,8 @@ int main() {
 
     runner.run_test("Matrix Multiplication", test_matrix_multiplication());
     runner.run_test("MatMul CQ", test_matmul_cq());
+    runner.run_test("Dense MLP CQ4 fused vs unfused", test_dense_mlp_cq4_fused_vs_unfused());
+    runner.run_test("Dense MLP CQ4 fused (graph)", test_dense_mlp_cq4_fused_graph());
     runner.run_test("Transpose", test_transpose());
     runner.run_test("Reshape", test_reshape());
     runner.run_test("RMS Norm", test_rms_norm());

--- a/cactus-kernels/cactus_kernels.h
+++ b/cactus-kernels/cactus_kernels.h
@@ -274,6 +274,14 @@ void cactus_quant_matmul(
     uint32_t M,
     __fp16* C);
 
+void cactus_dense_mlp_cq_fused(
+    const CactusQuantMatrix* gate_W,
+    const CactusQuantMatrix* up_W,
+    const CactusQuantMatrix* down_W,
+    const __fp16* x,
+    uint32_t M,
+    __fp16* y);
+
 void cactus_rms_norm_f16(
     const __fp16* input,
     const __fp16* weight,

--- a/cactus-kernels/src/matmul.cpp
+++ b/cactus-kernels/src/matmul.cpp
@@ -1,6 +1,7 @@
 #include "../cactus_kernels.h"
 #include "threading.h"
 #include <arm_neon.h>
+#include <atomic>
 #include <cstdint>
 #include <cstring>
 #include <algorithm>
@@ -1080,6 +1081,25 @@ static inline float tq_quantize_group_i8(const __fp16* src, int8_t* dst, uint32_
 }
 
 
+static void cactus_quant_prepare_activations_internal(
+    const CactusQuantMatrix& W,
+    const __fp16* A,
+    uint32_t M,
+    __fp16* code_basis,
+    int8_t* act_i8,
+    float* act_scales) {
+    cactus_quant_transform_hadamard_activations(W, A, M, code_basis);
+    const uint32_t gs = W.group_size;
+    const uint32_t num_groups = W.num_groups;
+    for (uint32_t m = 0; m < M; m++) {
+        for (uint32_t g = 0; g < num_groups; g++) {
+            act_scales[m * num_groups + g] = tq_quantize_group_i8(
+                code_basis + m * W.K + g * gs,
+                act_i8 + m * W.K + g * gs, gs);
+        }
+    }
+}
+
 static inline int8x16_t tq_expand_i8_16(const uint8_t* packed, uint32_t bits, int8x16_t cb_lut) {
     if (bits == 4) {
         uint8x8_t bytes = vld1_u8(packed);
@@ -1123,6 +1143,160 @@ static inline int8x16_t tq_expand_i8_16(const uint8_t* packed, uint32_t bits, in
     }
 }
 
+static void cactus_quant_build_expanded_internal(
+    const CactusQuantMatrix& W,
+    int8x16_t cb_lut,
+    float cb_scale,
+    std::vector<int8_t>& w_il_buf,
+    std::vector<float>& n_f32_buf,
+    const int8_t** w_il_out,
+    const float** n_f32_out) {
+    if (W.expanded != nullptr && W.norm_f32 != nullptr) {
+        *w_il_out = W.expanded;
+        *n_f32_out = W.norm_f32;
+        return;
+    }
+
+    const uint32_t gs = W.group_size;
+    const uint32_t bits = W.bits;
+    const uint32_t num_groups = W.num_groups;
+    const uint32_t pgb = cactus_quant_packed_group_bytes(bits, gs);
+    const size_t N_blocks = (W.N + 3) / 4;
+
+    w_il_buf.resize(N_blocks * num_groups * gs * 4);
+    n_f32_buf.resize(N_blocks * num_groups * 4);
+
+    for (size_t nb = 0; nb < N_blocks; ++nb) {
+        size_t n_start = nb * 4;
+        size_t valid_n = std::min(size_t(4), static_cast<size_t>(W.N) - n_start);
+        for (uint32_t g = 0; g < num_groups; ++g) {
+            int8x16_t exp4[4][16];
+            uint32_t n_vecs = gs / 16;
+            for (size_t ni = 0; ni < valid_n; ++ni) {
+                const uint8_t* p = W.packed_indices + (static_cast<size_t>(n_start+ni)*num_groups+g)*pgb;
+                for (uint32_t v = 0; v < n_vecs; ++v)
+                    exp4[ni][v] = tq_expand_i8_16(p + (v*16*bits)/8, bits, cb_lut);
+            }
+            for (size_t ni = valid_n; ni < 4; ++ni)
+                for (uint32_t v = 0; v < n_vecs; ++v) exp4[ni][v] = vdupq_n_s8(0);
+
+            int8_t* dst = w_il_buf.data() + (nb*num_groups+g)*gs*4;
+            for (uint32_t v = 0; v < n_vecs; ++v) {
+                int32x4_t r0=vreinterpretq_s32_s8(exp4[0][v]), r1=vreinterpretq_s32_s8(exp4[1][v]);
+                int32x4_t r2=vreinterpretq_s32_s8(exp4[2][v]), r3=vreinterpretq_s32_s8(exp4[3][v]);
+                int32x4_t t01l=vzip1q_s32(r0,r1), t01h=vzip2q_s32(r0,r1);
+                int32x4_t t23l=vzip1q_s32(r2,r3), t23h=vzip2q_s32(r2,r3);
+                vst1q_s8(dst+v*64,    vreinterpretq_s8_s64(vzip1q_s64(vreinterpretq_s64_s32(t01l),vreinterpretq_s64_s32(t23l))));
+                vst1q_s8(dst+v*64+16, vreinterpretq_s8_s64(vzip2q_s64(vreinterpretq_s64_s32(t01l),vreinterpretq_s64_s32(t23l))));
+                vst1q_s8(dst+v*64+32, vreinterpretq_s8_s64(vzip1q_s64(vreinterpretq_s64_s32(t01h),vreinterpretq_s64_s32(t23h))));
+                vst1q_s8(dst+v*64+48, vreinterpretq_s8_s64(vzip2q_s64(vreinterpretq_s64_s32(t01h),vreinterpretq_s64_s32(t23h))));
+            }
+            float* nd = n_f32_buf.data() + (nb*num_groups+g)*4;
+            for (size_t ni = 0; ni < 4; ++ni)
+                nd[ni] = (n_start+ni < W.N) ? static_cast<float>(W.norms[(n_start+ni)*num_groups+g]) * cb_scale : 0.f;
+        }
+    }
+    *w_il_out = w_il_buf.data();
+    *n_f32_out = n_f32_buf.data();
+}
+
+// Stores at C[n_block*4 - c_n_offset]; tile callers pass block_start*4, full-N callers 0.
+static void cactus_quant_gemv_int8_block_range(
+    const int8_t* w_il,
+    const float* n_f32,
+    const int8_t* act_i8,
+    const float* act_scales,
+    __fp16* C,
+    uint32_t N,
+    uint32_t group_size,
+    uint32_t num_groups,
+    size_t block_start,
+    size_t block_end,
+    size_t c_n_offset) {
+    const uint32_t gs = group_size;
+
+    for (size_t n_block = block_start; n_block < block_end; ++n_block) {
+        float32x4_t running_sum = vdupq_n_f32(0.f);
+        const size_t nb_off = n_block * num_groups;
+
+        uint32_t g = 0;
+        for (; g + 1 < num_groups; g += 2) {
+            const int8_t* a0 = act_i8 + g * gs;
+            const int8_t* a1 = act_i8 + (g + 1) * gs;
+            const int8_t* b0 = w_il + (nb_off + g) * gs * 4;
+            const int8_t* b1 = w_il + (nb_off + g + 1) * gs * 4;
+            __builtin_prefetch(b1 + gs * 4, 0, 3);
+
+            int32x4_t acc0 = vdupq_n_s32(0);
+            int32x4_t acc1 = vdupq_n_s32(0);
+
+            for (uint32_t k = 0; k < gs; k += 32) {
+                int8x16_t av = vld1q_s8(a0 + k);
+                acc0 = CACTUS_DOTQ_LANE(acc0, vld1q_s8(b0 + k*4),      av, 0);
+                acc0 = CACTUS_DOTQ_LANE(acc0, vld1q_s8(b0 + k*4 + 16), av, 1);
+                acc0 = CACTUS_DOTQ_LANE(acc0, vld1q_s8(b0 + k*4 + 32), av, 2);
+                acc0 = CACTUS_DOTQ_LANE(acc0, vld1q_s8(b0 + k*4 + 48), av, 3);
+                av = vld1q_s8(a0 + k + 16);
+                acc0 = CACTUS_DOTQ_LANE(acc0, vld1q_s8(b0 + k*4 + 64), av, 0);
+                acc0 = CACTUS_DOTQ_LANE(acc0, vld1q_s8(b0 + k*4 + 80), av, 1);
+                acc0 = CACTUS_DOTQ_LANE(acc0, vld1q_s8(b0 + k*4 + 96), av, 2);
+                acc0 = CACTUS_DOTQ_LANE(acc0, vld1q_s8(b0 + k*4 + 112),av, 3);
+            }
+
+            for (uint32_t k = 0; k < gs; k += 32) {
+                int8x16_t av = vld1q_s8(a1 + k);
+                acc1 = CACTUS_DOTQ_LANE(acc1, vld1q_s8(b1 + k*4),      av, 0);
+                acc1 = CACTUS_DOTQ_LANE(acc1, vld1q_s8(b1 + k*4 + 16), av, 1);
+                acc1 = CACTUS_DOTQ_LANE(acc1, vld1q_s8(b1 + k*4 + 32), av, 2);
+                acc1 = CACTUS_DOTQ_LANE(acc1, vld1q_s8(b1 + k*4 + 48), av, 3);
+                av = vld1q_s8(a1 + k + 16);
+                acc1 = CACTUS_DOTQ_LANE(acc1, vld1q_s8(b1 + k*4 + 64), av, 0);
+                acc1 = CACTUS_DOTQ_LANE(acc1, vld1q_s8(b1 + k*4 + 80), av, 1);
+                acc1 = CACTUS_DOTQ_LANE(acc1, vld1q_s8(b1 + k*4 + 96), av, 2);
+                acc1 = CACTUS_DOTQ_LANE(acc1, vld1q_s8(b1 + k*4 + 112),av, 3);
+            }
+
+            float32x4_t s0 = vmulq_n_f32(vld1q_f32(n_f32 + (nb_off + g) * 4), act_scales[g]);
+            float32x4_t s1 = vmulq_n_f32(vld1q_f32(n_f32 + (nb_off + g + 1) * 4), act_scales[g + 1]);
+            running_sum = vmlaq_f32(running_sum, vcvtq_f32_s32(acc0), s0);
+            running_sum = vmlaq_f32(running_sum, vcvtq_f32_s32(acc1), s1);
+        }
+
+        for (; g < num_groups; ++g) {
+            const int8_t* a_group = act_i8 + g * gs;
+            const int8_t* b_base = w_il + (nb_off + g) * gs * 4;
+            int32x4_t acc = vdupq_n_s32(0);
+            for (uint32_t k = 0; k < gs; k += 32) {
+                int8x16_t av = vld1q_s8(a_group + k);
+                acc = CACTUS_DOTQ_LANE(acc, vld1q_s8(b_base + k*4),      av, 0);
+                acc = CACTUS_DOTQ_LANE(acc, vld1q_s8(b_base + k*4 + 16), av, 1);
+                acc = CACTUS_DOTQ_LANE(acc, vld1q_s8(b_base + k*4 + 32), av, 2);
+                acc = CACTUS_DOTQ_LANE(acc, vld1q_s8(b_base + k*4 + 48), av, 3);
+                av = vld1q_s8(a_group + k + 16);
+                acc = CACTUS_DOTQ_LANE(acc, vld1q_s8(b_base + k*4 + 64), av, 0);
+                acc = CACTUS_DOTQ_LANE(acc, vld1q_s8(b_base + k*4 + 80), av, 1);
+                acc = CACTUS_DOTQ_LANE(acc, vld1q_s8(b_base + k*4 + 96), av, 2);
+                acc = CACTUS_DOTQ_LANE(acc, vld1q_s8(b_base + k*4 + 112),av, 3);
+            }
+            float32x4_t scale = vmulq_n_f32(vld1q_f32(n_f32 + (nb_off + g) * 4), act_scales[g]);
+            running_sum = vmlaq_f32(running_sum, vcvtq_f32_s32(acc), scale);
+        }
+
+        const size_t n_start = n_block * 4;
+        const size_t store_at = n_start - c_n_offset;
+        const size_t actual_n = std::min(size_t(4), static_cast<size_t>(N) - n_start);
+        float16x4_t result = vcvt_f16_f32(running_sum);
+        if (actual_n == 4) {
+            vst1_f16(C + store_at, result);
+        } else {
+            for (size_t ni = 0; ni < actual_n; ni++) {
+                C[store_at + ni] = vget_lane_f16(result, 0);
+                result = vext_f16(result, result, 1);
+            }
+        }
+    }
+}
+
 void cactus_quant_matmul(
     const CactusQuantMatrix* W,
     const __fp16* A,
@@ -1133,7 +1307,6 @@ void cactus_quant_matmul(
     const uint32_t gs = W->group_size;
     const uint32_t bits = W->bits;
     const uint32_t num_groups = W->num_groups;
-    const uint32_t pgb = cactus_quant_packed_group_bytes(bits, gs);
 
     int8_t cb_i8[16] = {};
     float cb_scale = tq_quantize_codebook_i8(W->codebook, cb_i8, 1u << bits);
@@ -1170,59 +1343,16 @@ void cactus_quant_matmul(
         act_scales_ptr = heap_act_scales.data();
     }
 
-    cactus_quant_transform_hadamard_activations(*W, A, M, code_basis_ptr);
-
-    for (uint32_t m = 0; m < M; m++) {
-        for (uint32_t g = 0; g < num_groups; g++) {
-            act_scales_ptr[m * num_groups + g] = tq_quantize_group_i8(
-                code_basis_ptr + m * W->K + g * gs,
-                act_i8_ptr + m * W->K + g * gs, gs);
-        }
-    }
+    cactus_quant_prepare_activations_internal(*W, A, M, code_basis_ptr, act_i8_ptr, act_scales_ptr);
 
     const size_t N_blocks = (W->N + 3) / 4;
 
-    const int8_t* w_il = W->expanded;
-    const float* n_f32 = W->norm_f32;
-
+    const int8_t* w_il;
+    const float* n_f32;
     std::vector<int8_t> w_il_buf;
     std::vector<float> n_f32_buf;
-    if (!w_il) {
-        w_il_buf.resize(N_blocks * num_groups * gs * 4);
-        n_f32_buf.resize(N_blocks * num_groups * 4);
-        for (size_t nb = 0; nb < N_blocks; ++nb) {
-            size_t n_start = nb * 4;
-            size_t valid_n = std::min(size_t(4), static_cast<size_t>(W->N) - n_start);
-            for (uint32_t g = 0; g < num_groups; ++g) {
-                int8x16_t exp4[4][16];
-                uint32_t n_vecs = gs / 16;
-                for (size_t ni = 0; ni < valid_n; ++ni) {
-                    const uint8_t* p = W->packed_indices + (static_cast<size_t>(n_start+ni)*num_groups+g)*pgb;
-                    for (uint32_t v = 0; v < n_vecs; ++v)
-                        exp4[ni][v] = tq_expand_i8_16(p + (v*16*bits)/8, bits, cb_lut);
-                }
-                for (size_t ni = valid_n; ni < 4; ++ni)
-                    for (uint32_t v = 0; v < n_vecs; ++v) exp4[ni][v] = vdupq_n_s8(0);
-
-                int8_t* dst = w_il_buf.data() + (nb*num_groups+g)*gs*4;
-                for (uint32_t v = 0; v < n_vecs; ++v) {
-                    int32x4_t r0=vreinterpretq_s32_s8(exp4[0][v]), r1=vreinterpretq_s32_s8(exp4[1][v]);
-                    int32x4_t r2=vreinterpretq_s32_s8(exp4[2][v]), r3=vreinterpretq_s32_s8(exp4[3][v]);
-                    int32x4_t t01l=vzip1q_s32(r0,r1), t01h=vzip2q_s32(r0,r1);
-                    int32x4_t t23l=vzip1q_s32(r2,r3), t23h=vzip2q_s32(r2,r3);
-                    vst1q_s8(dst+v*64,    vreinterpretq_s8_s64(vzip1q_s64(vreinterpretq_s64_s32(t01l),vreinterpretq_s64_s32(t23l))));
-                    vst1q_s8(dst+v*64+16, vreinterpretq_s8_s64(vzip2q_s64(vreinterpretq_s64_s32(t01l),vreinterpretq_s64_s32(t23l))));
-                    vst1q_s8(dst+v*64+32, vreinterpretq_s8_s64(vzip1q_s64(vreinterpretq_s64_s32(t01h),vreinterpretq_s64_s32(t23h))));
-                    vst1q_s8(dst+v*64+48, vreinterpretq_s8_s64(vzip2q_s64(vreinterpretq_s64_s32(t01h),vreinterpretq_s64_s32(t23h))));
-                }
-                float* nd = n_f32_buf.data() + (nb*num_groups+g)*4;
-                for (size_t ni = 0; ni < 4; ++ni)
-                    nd[ni] = (n_start+ni < W->N) ? static_cast<float>(W->norms[(n_start+ni)*num_groups+g]) * cb_scale : 0.f;
-            }
-        }
-        w_il = w_il_buf.data();
-        n_f32 = n_f32_buf.data();
-    }
+    cactus_quant_build_expanded_internal(*W, cb_lut, cb_scale,
+                                          w_il_buf, n_f32_buf, &w_il, &n_f32);
 
     if (M == 1) {
         const int8_t* a_ptr = act_i8_ptr;
@@ -1233,89 +1363,9 @@ void cactus_quant_matmul(
         num_threads = std::min(num_threads, N_blocks);
 
         auto process_blocks = [&](size_t block_start, size_t block_end) {
-            for (size_t n_block = block_start; n_block < block_end; ++n_block) {
-                float32x4_t running_sum = vdupq_n_f32(0.f);
-                const size_t nb_off = n_block * num_groups;
-
-                uint32_t g = 0;
-                for (; g + 1 < num_groups; g += 2) {
-                    const int8_t* a0 = a_ptr + g * gs;
-                    const int8_t* a1 = a_ptr + (g + 1) * gs;
-                    const int8_t* b0 = w_il + (nb_off + g) * gs * 4;
-                    const int8_t* b1 = w_il + (nb_off + g + 1) * gs * 4;
-
-                    __builtin_prefetch(b1 + gs * 4, 0, 3);
-
-                    int32x4_t acc0 = vdupq_n_s32(0);
-                    int32x4_t acc1 = vdupq_n_s32(0);
-
-                    for (uint32_t k = 0; k < gs; k += 32) {
-                        int8x16_t av = vld1q_s8(a0 + k);
-                        acc0 = CACTUS_DOTQ_LANE(acc0, vld1q_s8(b0 + k*4),      av, 0);
-                        acc0 = CACTUS_DOTQ_LANE(acc0, vld1q_s8(b0 + k*4 + 16), av, 1);
-                        acc0 = CACTUS_DOTQ_LANE(acc0, vld1q_s8(b0 + k*4 + 32), av, 2);
-                        acc0 = CACTUS_DOTQ_LANE(acc0, vld1q_s8(b0 + k*4 + 48), av, 3);
-                        av = vld1q_s8(a0 + k + 16);
-                        acc0 = CACTUS_DOTQ_LANE(acc0, vld1q_s8(b0 + k*4 + 64), av, 0);
-                        acc0 = CACTUS_DOTQ_LANE(acc0, vld1q_s8(b0 + k*4 + 80), av, 1);
-                        acc0 = CACTUS_DOTQ_LANE(acc0, vld1q_s8(b0 + k*4 + 96), av, 2);
-                        acc0 = CACTUS_DOTQ_LANE(acc0, vld1q_s8(b0 + k*4 + 112),av, 3);
-                    }
-
-
-                    for (uint32_t k = 0; k < gs; k += 32) {
-                        int8x16_t av = vld1q_s8(a1 + k);
-                        acc1 = CACTUS_DOTQ_LANE(acc1, vld1q_s8(b1 + k*4),      av, 0);
-                        acc1 = CACTUS_DOTQ_LANE(acc1, vld1q_s8(b1 + k*4 + 16), av, 1);
-                        acc1 = CACTUS_DOTQ_LANE(acc1, vld1q_s8(b1 + k*4 + 32), av, 2);
-                        acc1 = CACTUS_DOTQ_LANE(acc1, vld1q_s8(b1 + k*4 + 48), av, 3);
-                        av = vld1q_s8(a1 + k + 16);
-                        acc1 = CACTUS_DOTQ_LANE(acc1, vld1q_s8(b1 + k*4 + 64), av, 0);
-                        acc1 = CACTUS_DOTQ_LANE(acc1, vld1q_s8(b1 + k*4 + 80), av, 1);
-                        acc1 = CACTUS_DOTQ_LANE(acc1, vld1q_s8(b1 + k*4 + 96), av, 2);
-                        acc1 = CACTUS_DOTQ_LANE(acc1, vld1q_s8(b1 + k*4 + 112),av, 3);
-                    }
-
-                    float32x4_t s0 = vmulq_n_f32(vld1q_f32(n_f32 + (nb_off + g) * 4), a_sc_ptr[g]);
-                    float32x4_t s1 = vmulq_n_f32(vld1q_f32(n_f32 + (nb_off + g + 1) * 4), a_sc_ptr[g + 1]);
-                    running_sum = vmlaq_f32(running_sum, vcvtq_f32_s32(acc0), s0);
-                    running_sum = vmlaq_f32(running_sum, vcvtq_f32_s32(acc1), s1);
-                }
-
-                for (; g < num_groups; ++g) {
-                    const int8_t* a_group = a_ptr + g * gs;
-                    const int8_t* b_base = w_il + (nb_off + g) * gs * 4;
-
-                    int32x4_t acc = vdupq_n_s32(0);
-                    for (uint32_t k = 0; k < gs; k += 32) {
-                        int8x16_t av = vld1q_s8(a_group + k);
-                        acc = CACTUS_DOTQ_LANE(acc, vld1q_s8(b_base + k*4),      av, 0);
-                        acc = CACTUS_DOTQ_LANE(acc, vld1q_s8(b_base + k*4 + 16), av, 1);
-                        acc = CACTUS_DOTQ_LANE(acc, vld1q_s8(b_base + k*4 + 32), av, 2);
-                        acc = CACTUS_DOTQ_LANE(acc, vld1q_s8(b_base + k*4 + 48), av, 3);
-                        av = vld1q_s8(a_group + k + 16);
-                        acc = CACTUS_DOTQ_LANE(acc, vld1q_s8(b_base + k*4 + 64), av, 0);
-                        acc = CACTUS_DOTQ_LANE(acc, vld1q_s8(b_base + k*4 + 80), av, 1);
-                        acc = CACTUS_DOTQ_LANE(acc, vld1q_s8(b_base + k*4 + 96), av, 2);
-                        acc = CACTUS_DOTQ_LANE(acc, vld1q_s8(b_base + k*4 + 112),av, 3);
-                    }
-
-                    float32x4_t scale = vmulq_n_f32(vld1q_f32(n_f32 + (nb_off + g) * 4), a_sc_ptr[g]);
-                    running_sum = vmlaq_f32(running_sum, vcvtq_f32_s32(acc), scale);
-                }
-
-                const size_t n_start = n_block * 4;
-                const size_t actual_n = std::min(size_t(4), static_cast<size_t>(W->N) - n_start);
-                float16x4_t result = vcvt_f16_f32(running_sum);
-                if (actual_n == 4) {
-                    vst1_f16(C + n_start, result);
-                } else {
-                    for (size_t ni = 0; ni < actual_n; ni++) {
-                        C[n_start + ni] = vget_lane_f16(result, 0);
-                        result = vext_f16(result, result, 1);
-                    }
-                }
-            }
+            cactus_quant_gemv_int8_block_range(
+                w_il, n_f32, a_ptr, a_sc_ptr, C,
+                W->N, gs, num_groups, block_start, block_end, /*c_n_offset=*/0);
         };
 
         if (num_threads <= 1) {
@@ -1417,6 +1467,165 @@ void cactus_quant_matmul(
                     }
                 }
             });
+    }
+}
+
+void cactus_dense_mlp_cq_fused(
+    const CactusQuantMatrix* gate_W,
+    const CactusQuantMatrix* up_W,
+    const CactusQuantMatrix* down_W,
+    const __fp16* x,
+    uint32_t M,
+    __fp16* y) {
+    if (M == 0) return;
+    if (!cactus_quant_valid_common(gate_W, x, y)) return;
+    if (!cactus_quant_valid_common(up_W, x, y))   return;
+    if (!cactus_quant_valid_common(down_W, x, y)) return;
+
+    const uint32_t hidden_dim   = gate_W->K;
+    const uint32_t d_ffn        = gate_W->N;
+    const uint32_t group_size   = gate_W->group_size;
+    const uint32_t in_groups    = gate_W->num_groups;
+    const uint32_t out_groups   = down_W->num_groups;
+    const size_t   in_N_blocks  = (d_ffn + 3) / 4;
+    const size_t   out_N_blocks = (hidden_dim + 3) / 4;
+    if (group_size % 32 != 0) return;
+
+    int8_t gate_cb_i8[16] = {}, up_cb_i8[16] = {}, down_cb_i8[16] = {};
+    float gate_cb_scale = tq_quantize_codebook_i8(gate_W->codebook, gate_cb_i8, 1u << gate_W->bits);
+    float up_cb_scale   = tq_quantize_codebook_i8(up_W->codebook,   up_cb_i8,   1u << up_W->bits);
+    float down_cb_scale = tq_quantize_codebook_i8(down_W->codebook, down_cb_i8, 1u << down_W->bits);
+    int8x16_t gate_cb_lut = vld1q_s8(gate_cb_i8);
+    int8x16_t up_cb_lut   = vld1q_s8(up_cb_i8);
+    int8x16_t down_cb_lut = vld1q_s8(down_cb_i8);
+
+    std::vector<int8_t> gate_w_il_buf, up_w_il_buf, down_w_il_buf;
+    std::vector<float>  gate_n_f32_buf, up_n_f32_buf, down_n_f32_buf;
+    const int8_t *gate_w_il, *up_w_il, *down_w_il;
+    const float  *gate_n_f32, *up_n_f32, *down_n_f32;
+    cactus_quant_build_expanded_internal(*gate_W, gate_cb_lut, gate_cb_scale,
+                                          gate_w_il_buf, gate_n_f32_buf,
+                                          &gate_w_il, &gate_n_f32);
+    cactus_quant_build_expanded_internal(*up_W, up_cb_lut, up_cb_scale,
+                                          up_w_il_buf, up_n_f32_buf,
+                                          &up_w_il, &up_n_f32);
+    cactus_quant_build_expanded_internal(*down_W, down_cb_lut, down_cb_scale,
+                                          down_w_il_buf, down_n_f32_buf,
+                                          &down_w_il, &down_n_f32);
+
+    static thread_local std::vector<__fp16> tl_xg_basis;
+    static thread_local std::vector<int8_t> tl_xg_i8;
+    static thread_local std::vector<float>  tl_xg_scales;
+    static thread_local std::vector<__fp16> tl_xu_basis;
+    static thread_local std::vector<int8_t> tl_xu_i8;
+    static thread_local std::vector<float>  tl_xu_scales;
+    static thread_local std::vector<__fp16> tl_h_full;
+    static thread_local std::vector<__fp16> tl_h_basis;
+    static thread_local std::vector<int8_t> tl_h_i8;
+    static thread_local std::vector<float>  tl_h_scales;
+
+    const size_t x_size       = static_cast<size_t>(M) * hidden_dim;
+    const size_t h_size       = static_cast<size_t>(M) * d_ffn;
+    const size_t x_scales_sz  = static_cast<size_t>(M) * in_groups;
+    const size_t h_scales_sz  = static_cast<size_t>(M) * out_groups;
+
+    if (tl_xg_basis.size()  < x_size)      tl_xg_basis.resize(x_size);
+    if (tl_xg_i8.size()     < x_size)      tl_xg_i8.resize(x_size);
+    if (tl_xg_scales.size() < x_scales_sz) tl_xg_scales.resize(x_scales_sz);
+    if (tl_xu_basis.size()  < x_size)      tl_xu_basis.resize(x_size);
+    if (tl_xu_i8.size()     < x_size)      tl_xu_i8.resize(x_size);
+    if (tl_xu_scales.size() < x_scales_sz) tl_xu_scales.resize(x_scales_sz);
+    if (tl_h_full.size()    < h_size)      tl_h_full.resize(h_size);
+    if (tl_h_basis.size()   < h_size)      tl_h_basis.resize(h_size);
+    if (tl_h_i8.size()      < h_size)      tl_h_i8.resize(h_size);
+    if (tl_h_scales.size()  < h_scales_sz) tl_h_scales.resize(h_scales_sz);
+
+    // Gate and up may carry different Hadamard params, so x is prepared twice.
+    cactus_quant_prepare_activations_internal(*gate_W, x, M,
+        tl_xg_basis.data(), tl_xg_i8.data(), tl_xg_scales.data());
+    cactus_quant_prepare_activations_internal(*up_W, x, M,
+        tl_xu_basis.data(), tl_xu_i8.data(), tl_xu_scales.data());
+
+    auto& pool = CactusThreading::get_thread_pool();
+    const size_t pool_size = pool.num_workers();
+
+    constexpr size_t TILE_BLOCKS = 32;
+    const size_t p1_tile_count = (in_N_blocks  + TILE_BLOCKS - 1) / TILE_BLOCKS;
+    const size_t p2_tile_count = (out_N_blocks + TILE_BLOCKS - 1) / TILE_BLOCKS;
+    size_t p1_threads = std::min(pool_size, p1_tile_count);
+    size_t p2_threads = std::min(pool_size, p2_tile_count);
+
+    for (uint32_t t = 0; t < M; ++t) {
+        const int8_t* xg_i8     = tl_xg_i8.data()     + static_cast<size_t>(t) * hidden_dim;
+        const float*  xg_scales = tl_xg_scales.data() + static_cast<size_t>(t) * in_groups;
+        const int8_t* xu_i8     = tl_xu_i8.data()     + static_cast<size_t>(t) * hidden_dim;
+        const float*  xu_scales = tl_xu_scales.data() + static_cast<size_t>(t) * in_groups;
+        __fp16*       h_full    = tl_h_full.data()    + static_cast<size_t>(t) * d_ffn;
+        __fp16*       y_row     = y                   + static_cast<size_t>(t) * hidden_dim;
+
+        std::atomic<size_t> p1_next{0};
+        auto p1_task = [&](size_t /*worker_id*/) {
+            __fp16 gate_tile[TILE_BLOCKS * 4];
+            __fp16 up_tile  [TILE_BLOCKS * 4];
+            while (true) {
+                size_t tile_id = p1_next.fetch_add(1, std::memory_order_relaxed);
+                if (tile_id >= p1_tile_count) break;
+                size_t blk_start = tile_id * TILE_BLOCKS;
+                size_t blk_end   = std::min(blk_start + TILE_BLOCKS, in_N_blocks);
+                size_t k_lo      = blk_start * 4;
+                size_t k_count   = (blk_end - blk_start) * 4;
+
+                cactus_quant_gemv_int8_block_range(
+                    gate_w_il, gate_n_f32, xg_i8, xg_scales, gate_tile,
+                    d_ffn, group_size, in_groups, blk_start, blk_end, /*c_n_offset=*/k_lo);
+                cactus_gelu_f16(gate_tile, gate_tile, k_count);
+                cactus_quant_gemv_int8_block_range(
+                    up_w_il, up_n_f32, xu_i8, xu_scales, up_tile,
+                    d_ffn, group_size, in_groups, blk_start, blk_end, /*c_n_offset=*/k_lo);
+                cactus_multiply_f16(gate_tile, up_tile, h_full + k_lo, k_count);
+            }
+        };
+
+        if (p1_threads <= 1) {
+            p1_task(0);
+        } else {
+            pool.enqueue_n_threads(p1_threads - 1, p1_threads - 1,
+                [&](size_t s, size_t e) {
+                    for (size_t w = s; w < e; ++w) p1_task(w + 1);
+                });
+            p1_task(0);
+            pool.wait_all();
+        }
+
+        cactus_quant_prepare_activations_internal(*down_W, h_full, 1,
+            tl_h_basis.data(), tl_h_i8.data(), tl_h_scales.data());
+
+        const int8_t* h_i8     = tl_h_i8.data();
+        const float*  h_scales = tl_h_scales.data();
+
+        std::atomic<size_t> p2_next{0};
+        auto p2_task = [&](size_t /*worker_id*/) {
+            while (true) {
+                size_t tile_id = p2_next.fetch_add(1, std::memory_order_relaxed);
+                if (tile_id >= p2_tile_count) break;
+                size_t blk_start = tile_id * TILE_BLOCKS;
+                size_t blk_end   = std::min(blk_start + TILE_BLOCKS, out_N_blocks);
+                cactus_quant_gemv_int8_block_range(
+                    down_w_il, down_n_f32, h_i8, h_scales, y_row,
+                    hidden_dim, group_size, out_groups, blk_start, blk_end, /*c_n_offset=*/0);
+            }
+        };
+
+        if (p2_threads <= 1) {
+            p2_task(0);
+        } else {
+            pool.enqueue_n_threads(p2_threads - 1, p2_threads - 1,
+                [&](size_t s, size_t e) {
+                    for (size_t w = s; w < e; ++w) p2_task(w + 1);
+                });
+            p2_task(0);
+            pool.wait_all();
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- **Fused dense CQ4 MLP kernel** (`cactus_dense_mlp_cq_fused`) that collapses the 5-step `gate -> GeLU(tanh) -> up -> multiply -> down` chain into two thread-pool dispatches instead of five barriers. Refactors the M==1 path of `cactus_quant_matmul` into three reusable static helpers (prepare-activations, build-expanded, gemv-int8-block-range) so the new kernel and the existing matmul share one source of truth. Wired through the graph layer (new `OpType::DENSE_MLP_CQ_FUSED` appended to keep serialized OpType values stable, builder method, dispatch entry, compute node) and substituted into `Gemma4Model::build_mlp` automatically when gate/up/down are CQ4 with matching `group_size`.
- **Synthetic 30-layer Gemma-4 E2B decode benchmark** in `cactus-graph/tests/test_nn.cpp run_benchmarks()` issuing one transformer block per layer (rms_norm, fp16 Q/K/V/O matmuls, `attention_cached` with kv-cache, MLP variant, residuals) at realistic shapes (hidden=2304, d_ffn=9216, num_heads=8, num_kv_heads=2, head_dim=256, gs=128, kv-cache window=256). Reports per-step ms and tok/s for fused vs unfused.
- **Two pre-existing profile-path bugs in the graph executor** uncovered while wiring up that bench: `op_type_names[]` was missing ~10 entries and had ABS/POW out of order (profile output mislabeled ops); the profile loop dispatched INPUT nodes and threw "Unknown operation type: 0". Neither affects the default non-profile path.

## Numbers (M4 Pro, 8 perf cores)

Single dense MLP at gemma-4-E2B FFN shape (M=1, hidden=2304, d_ffn=9216, gs=128):

| | ms |
| --- | --- |
| unfused | ~0.66 |
| fused | ~0.55 |
| **delta** | **-15 to -18%** |

Synthetic 30-layer decode (run-to-run jitter is wide because we're shaving ~2 ms out of a ~50 ms step):

| | ms/step | tok/s |
| --- | --- | --- |
| unfused | ~50 | ~20 |
| fused | ~47 | ~21 |
| **delta** | -2 to -4 ms | +4 to +16% |

End-to-end gain is smaller than the kernel-level -15% because the FFN chain is only ~1/3 of the per-step cost in this synthetic; fp16 Q/K/V/O attention projections dominate alongside MLP. Real-model decode with NPU prefill / fused QKV / GQA shape would shift this fraction, but the kernel win is what it is.

Both correctness tests pass: `Dense MLP CQ4 fused vs unfused` (kernel-level: max-abs diff < 1e-3 vs the canonical `gelu+matmul+matmul+multiply+matmul` chain) and `Dense MLP CQ4 fused (graph)` (same comparison via the graph builder + execute path). Activations are prepared twice in the fused kernel (once each for gate / up Hadamard params) since CQ4 weights may carry different `input_scale` / signs / permutation across matrices; the fusion win is from collapsing the four inter-op barriers, not from sharing activation prep.

## Test plan

- [x] `cd cactus-kernels && ./test.sh` — all 7 suites pass
- [x] `cd cactus-graph && ./test.sh` — all 6 suites pass; the two new precision tests and the new bench lines all show up in `test_nn` output
- [x] `cd cactus-engine && cmake build` — compiles cleanly with the gemma4 `build_mlp` change