### PR TITLE
Cross-framework INT8 op bench + hybrid INT8/FP16 decode kernel optimizations

### DIFF
--- a/cactus-kernels/src/attention.cpp
+++ b/cactus-kernels/src/attention.cpp
@@ -676,9 +676,9 @@ void cactus_attention_f16(
         });
 }
 
-// Decode-only specialization (seq_len=1, head_dim%32==0, quant_group_size=32, no
-// window, fully causal). Pre-quantizes Q to INT8 once per head, then uses
-// vdotq_s32 in K scoring — ~3× faster K dots than the FP16 FMA path.
+// Decode-only specialization. Pre-quantizes Q to INT8 once per head, then uses
+// vdotq_s32 in K scoring. Sliding-window only safe when the cache is unrolled
+// (slot index == absolute position); the dispatcher enforces this.
 static void cactus_attention_hybrid_int8_fp16_decode_dot(
     const __fp16* queries,
     const int8_t* keys_cached,
@@ -696,7 +696,8 @@ static void cactus_attention_hybrid_int8_fp16_decode_dot(
     size_t head_dim,
     float scale,
     size_t position_offset,
-    bool is_causal
+    bool is_causal,
+    size_t window_size
 ) {
     const size_t kv_seq_len = cache_len + new_len;
 
@@ -774,8 +775,10 @@ static void cactus_attention_hybrid_int8_fp16_decode_dot(
 
                 const size_t absolute_q_pos = position_offset;
                 size_t kv_end = is_causal ? std::min(kv_seq_len, absolute_q_pos + 1) : kv_seq_len;
+                size_t kv_start = (window_size > 0 && absolute_q_pos > window_size)
+                                  ? absolute_q_pos - window_size : 0;
 
-                for (size_t kv_block_start = 0; kv_block_start < kv_end; kv_block_start += BLOCK_SIZE) {
+                for (size_t kv_block_start = kv_start; kv_block_start < kv_end; kv_block_start += BLOCK_SIZE) {
                     const size_t kv_block_end = std::min(kv_block_start + BLOCK_SIZE, kv_end);
                     const size_t block_size = kv_block_end - kv_block_start;
 
@@ -1034,18 +1037,20 @@ void cactus_attention_hybrid_int8_fp16(
         scale = 1.0f / sqrtf(static_cast<float>(head_dim));
     }
 
+    // Fast path requires slot==abs identity, broken once the ring buffer rolls.
+    const bool cache_unrolled = position_offset <= cache_len;
     if (seq_len == 1 &&
         head_dim == v_head_dim &&
         head_dim <= 256 &&
         head_dim % 32 == 0 &&
         quant_group_size == 32 &&
-        window_size == 0) {
+        (window_size == 0 || cache_unrolled)) {
         cactus_attention_hybrid_int8_fp16_decode_dot(
             queries, keys_cached, values_cached, k_scales, v_scales,
             keys_new, values_new, output,
             batch_size, cache_len, new_len,
             num_q_heads, num_kv_heads, head_dim,
-            scale, position_offset, is_causal);
+            scale, position_offset, is_causal, window_size);
         return;
     }
 

--- a/cactus-kernels/src/attention.cpp
+++ b/cactus-kernels/src/attention.cpp
@@ -676,6 +676,336 @@ void cactus_attention_f16(
         });
 }
 
+// Decode-only specialization (seq_len=1, head_dim%32==0, quant_group_size=32, no
+// window, fully causal). Pre-quantizes Q to INT8 once per head, then uses
+// vdotq_s32 in K scoring — ~3× faster K dots than the FP16 FMA path.
+static void cactus_attention_hybrid_int8_fp16_decode_dot(
+    const __fp16* queries,
+    const int8_t* keys_cached,
+    const int8_t* values_cached,
+    const float* k_scales,
+    const float* v_scales,
+    const __fp16* keys_new,
+    const __fp16* values_new,
+    __fp16* output,
+    size_t batch_size,
+    size_t cache_len,
+    size_t new_len,
+    size_t num_q_heads,
+    size_t num_kv_heads,
+    size_t head_dim,
+    float scale,
+    size_t position_offset,
+    bool is_causal
+) {
+    const size_t kv_seq_len = cache_len + new_len;
+
+    constexpr size_t VECTOR_WIDTH = 8;
+    constexpr size_t BLOCK_SIZE = 64;
+    constexpr size_t QGROUP = 32;
+    constexpr size_t MAX_HEAD_DIM = 256;
+    constexpr size_t MAX_QUANT_GROUPS = MAX_HEAD_DIM / QGROUP;
+    constexpr size_t MAX_ACCUM_SLOTS = MAX_HEAD_DIM / VECTOR_WIDTH;
+
+    const size_t num_quant_groups = head_dim / QGROUP;
+    const size_t num_accum_slots = head_dim / VECTOR_WIDTH;
+    const size_t gqa_group_size = num_q_heads / num_kv_heads;
+
+    const size_t q_batch_stride = num_q_heads * head_dim;
+    const size_t kv_seq_stride = num_kv_heads * head_dim;
+    const size_t k_cached_batch_stride = cache_len * kv_seq_stride;
+    const size_t v_cached_batch_stride = cache_len * kv_seq_stride;
+    const size_t k_new_batch_stride = new_len * kv_seq_stride;
+    const size_t v_new_batch_stride = new_len * kv_seq_stride;
+    const size_t o_batch_stride = num_q_heads * head_dim;
+
+    CactusThreading::parallel_for(batch_size * num_q_heads, CactusThreading::Thresholds::ATTENTION,
+        [=](size_t start_idx, size_t end_idx) {
+            alignas(16) int8_t q_int8[MAX_HEAD_DIM];
+            float q_scales[MAX_QUANT_GROUPS];
+            float block_scores[BLOCK_SIZE];
+            float32x4_t output_accum_low[MAX_ACCUM_SLOTS];
+            float32x4_t output_accum_high[MAX_ACCUM_SLOTS];
+            float16x8_t block_accum[MAX_ACCUM_SLOTS];
+
+            for (size_t work_idx = start_idx; work_idx < end_idx; ++work_idx) {
+                const size_t batch_idx = work_idx / num_q_heads;
+                const size_t q_head_idx = work_idx % num_q_heads;
+                const size_t kv_head_idx = q_head_idx / gqa_group_size;
+
+                const __fp16* q_vec = queries + batch_idx * q_batch_stride + q_head_idx * head_dim;
+                const int8_t* K_cached_base = keys_cached + batch_idx * k_cached_batch_stride;
+                const int8_t* V_cached_base = values_cached + batch_idx * v_cached_batch_stride;
+                const __fp16* K_new_base = keys_new + batch_idx * k_new_batch_stride;
+                const __fp16* V_new_base = values_new + batch_idx * v_new_batch_stride;
+                __fp16* o_vec = output + batch_idx * o_batch_stride + q_head_idx * head_dim;
+
+                // Per-group symmetric INT8 quantization of Q. We absorb the full
+                // mul-by-scale into a single fp32 mul per group later (deferred scale).
+                for (size_t qg = 0; qg < num_quant_groups; ++qg) {
+                    const __fp16* q_grp = q_vec + qg * QGROUP;
+                    float16x8_t amax_v = vabsq_f16(vld1q_f16(q_grp));
+                    for (size_t i = 1; i < QGROUP / VECTOR_WIDTH; ++i)
+                        amax_v = vmaxq_f16(amax_v, vabsq_f16(vld1q_f16(q_grp + i * VECTOR_WIDTH)));
+                    float amax = static_cast<float>(vmaxvq_f16(amax_v));
+                    float q_scale = amax / 127.0f;
+                    float inv = q_scale > 0.0f ? 127.0f / amax : 0.0f;
+                    q_scales[qg] = q_scale;
+
+                    int8_t* qd = q_int8 + qg * QGROUP;
+                    for (size_t i = 0; i < QGROUP / VECTOR_WIDTH; ++i) {
+                        float16x8_t qf = vld1q_f16(q_grp + i * VECTOR_WIDTH);
+                        float32x4_t lo = vmulq_n_f32(vcvt_f32_f16(vget_low_f16(qf)), inv);
+                        float32x4_t hi = vmulq_n_f32(vcvt_f32_f16(vget_high_f16(qf)), inv);
+                        int32x4_t lo_i = vcvtaq_s32_f32(lo);
+                        int32x4_t hi_i = vcvtaq_s32_f32(hi);
+                        int16x8_t pack16 = vcombine_s16(vqmovn_s32(lo_i), vqmovn_s32(hi_i));
+                        vst1_s8(qd + i * VECTOR_WIDTH, vqmovn_s16(pack16));
+                    }
+                }
+
+                float running_max = -std::numeric_limits<float>::infinity();
+                float running_sum = 0.0f;
+
+                for (size_t i = 0; i < num_accum_slots; ++i) {
+                    output_accum_low[i] = vdupq_n_f32(0.0f);
+                    output_accum_high[i] = vdupq_n_f32(0.0f);
+                }
+
+                const size_t absolute_q_pos = position_offset;
+                size_t kv_end = is_causal ? std::min(kv_seq_len, absolute_q_pos + 1) : kv_seq_len;
+
+                for (size_t kv_block_start = 0; kv_block_start < kv_end; kv_block_start += BLOCK_SIZE) {
+                    const size_t kv_block_end = std::min(kv_block_start + BLOCK_SIZE, kv_end);
+                    const size_t block_size = kv_block_end - kv_block_start;
+
+                    float block_max = -std::numeric_limits<float>::infinity();
+
+                    // Determine the range of kv positions in this block that hit the
+                    // INT8 cache (vs the fp16 new tokens). With seq_len=1 and causal
+                    // truth, these are contiguous: cached ∈ [start, min(end, cache_len)),
+                    // new ∈ [max(start, cache_len), end).
+                    const size_t cached_kv_end = std::min(kv_block_end, cache_len);
+                    const size_t new_kv_start = std::max(kv_block_start, cache_len);
+
+                    // Cached (INT8) keys: scored with vdotq, processed in groups of 4.
+                    // Per-block FP32 sum is held in a NEON vector and reduced once at the end
+                    // (deferred horizontal-add) — same pattern as ggml's q8_0 vec_dot.
+                    size_t kv_pos = kv_block_start;
+                    for (; kv_pos + 3 < cached_kv_end; kv_pos += 4) {
+                        const int8_t* k1 = K_cached_base + kv_pos * kv_seq_stride + kv_head_idx * head_dim;
+                        const int8_t* k2 = k1 + kv_seq_stride;
+                        const int8_t* k3 = k2 + kv_seq_stride;
+                        const int8_t* k4 = k3 + kv_seq_stride;
+                        const float* ks1 = k_scales + (kv_pos * num_kv_heads + kv_head_idx) * num_quant_groups;
+                        const float* ks2 = ks1 + num_kv_heads * num_quant_groups;
+                        const float* ks3 = ks2 + num_kv_heads * num_quant_groups;
+                        const float* ks4 = ks3 + num_kv_heads * num_quant_groups;
+                        if (kv_pos + 8 < cached_kv_end) {
+                            __builtin_prefetch(k1 + 4 * kv_seq_stride, 0, 0);
+                            __builtin_prefetch(k1 + 5 * kv_seq_stride, 0, 0);
+                            __builtin_prefetch(k1 + 6 * kv_seq_stride, 0, 0);
+                            __builtin_prefetch(k1 + 7 * kv_seq_stride, 0, 0);
+                        }
+
+                        float32x4_t sumv1 = vdupq_n_f32(0.0f);
+                        float32x4_t sumv2 = vdupq_n_f32(0.0f);
+                        float32x4_t sumv3 = vdupq_n_f32(0.0f);
+                        float32x4_t sumv4 = vdupq_n_f32(0.0f);
+
+                        for (size_t qg = 0; qg < num_quant_groups; ++qg) {
+                            int8x16_t q_lo = vld1q_s8(q_int8 + qg * QGROUP);
+                            int8x16_t q_hi = vld1q_s8(q_int8 + qg * QGROUP + 16);
+
+                            int32x4_t d1 = vdupq_n_s32(0);
+                            int32x4_t d2 = vdupq_n_s32(0);
+                            int32x4_t d3 = vdupq_n_s32(0);
+                            int32x4_t d4 = vdupq_n_s32(0);
+
+                            d1 = vdotq_s32(d1, q_lo, vld1q_s8(k1 + qg * QGROUP));
+                            d2 = vdotq_s32(d2, q_lo, vld1q_s8(k2 + qg * QGROUP));
+                            d3 = vdotq_s32(d3, q_lo, vld1q_s8(k3 + qg * QGROUP));
+                            d4 = vdotq_s32(d4, q_lo, vld1q_s8(k4 + qg * QGROUP));
+                            d1 = vdotq_s32(d1, q_hi, vld1q_s8(k1 + qg * QGROUP + 16));
+                            d2 = vdotq_s32(d2, q_hi, vld1q_s8(k2 + qg * QGROUP + 16));
+                            d3 = vdotq_s32(d3, q_hi, vld1q_s8(k3 + qg * QGROUP + 16));
+                            d4 = vdotq_s32(d4, q_hi, vld1q_s8(k4 + qg * QGROUP + 16));
+
+                            float qg_q = q_scales[qg];
+                            sumv1 = vmlaq_n_f32(sumv1, vcvtq_f32_s32(d1), qg_q * ks1[qg]);
+                            sumv2 = vmlaq_n_f32(sumv2, vcvtq_f32_s32(d2), qg_q * ks2[qg]);
+                            sumv3 = vmlaq_n_f32(sumv3, vcvtq_f32_s32(d3), qg_q * ks3[qg]);
+                            sumv4 = vmlaq_n_f32(sumv4, vcvtq_f32_s32(d4), qg_q * ks4[qg]);
+                        }
+                        float s1 = vaddvq_f32(sumv1) * scale;
+                        float s2 = vaddvq_f32(sumv2) * scale;
+                        float s3 = vaddvq_f32(sumv3) * scale;
+                        float s4 = vaddvq_f32(sumv4) * scale;
+                        block_scores[kv_pos - kv_block_start] = s1;
+                        block_scores[kv_pos - kv_block_start + 1] = s2;
+                        block_scores[kv_pos - kv_block_start + 2] = s3;
+                        block_scores[kv_pos - kv_block_start + 3] = s4;
+                        float local_max = std::max(std::max(s1, s2), std::max(s3, s4));
+                        if (local_max > block_max) block_max = local_max;
+                    }
+                    for (; kv_pos < cached_kv_end; ++kv_pos) {
+                        const int8_t* k_vec = K_cached_base + kv_pos * kv_seq_stride + kv_head_idx * head_dim;
+                        const float* k_scale_base = k_scales + (kv_pos * num_kv_heads + kv_head_idx) * num_quant_groups;
+
+                        float32x4_t sumv = vdupq_n_f32(0.0f);
+                        for (size_t qg = 0; qg < num_quant_groups; ++qg) {
+                            int8x16_t q_lo = vld1q_s8(q_int8 + qg * QGROUP);
+                            int8x16_t q_hi = vld1q_s8(q_int8 + qg * QGROUP + 16);
+                            int8x16_t k_lo = vld1q_s8(k_vec + qg * QGROUP);
+                            int8x16_t k_hi = vld1q_s8(k_vec + qg * QGROUP + 16);
+                            int32x4_t dot_acc = vdupq_n_s32(0);
+                            dot_acc = vdotq_s32(dot_acc, q_lo, k_lo);
+                            dot_acc = vdotq_s32(dot_acc, q_hi, k_hi);
+                            sumv = vmlaq_n_f32(sumv, vcvtq_f32_s32(dot_acc), q_scales[qg] * k_scale_base[qg]);
+                        }
+                        float score = vaddvq_f32(sumv) * scale;
+                        block_scores[kv_pos - kv_block_start] = score;
+                        block_max = std::max(block_max, score);
+                    }
+
+                    // New tokens (fp16): rare (new_len typically 1) — fp16 fma path.
+                    for (kv_pos = std::max(kv_pos, new_kv_start); kv_pos < kv_block_end; ++kv_pos) {
+                        if (is_causal && kv_pos > absolute_q_pos) {
+                            block_scores[kv_pos - kv_block_start] = -std::numeric_limits<float>::infinity();
+                            continue;
+                        }
+                        const size_t new_pos = kv_pos - cache_len;
+                        const __fp16* k_vec = K_new_base + new_pos * kv_seq_stride + kv_head_idx * head_dim;
+                        float16x8_t s_acc = vdupq_n_f16((__fp16)0.0f);
+                        for (size_t d = 0; d < head_dim; d += VECTOR_WIDTH) {
+                            s_acc = vfmaq_f16(s_acc, vld1q_f16(q_vec + d), vld1q_f16(k_vec + d));
+                        }
+                        float score = (vaddvq_f32(vcvt_f32_f16(vget_low_f16(s_acc))) +
+                                       vaddvq_f32(vcvt_f32_f16(vget_high_f16(s_acc)))) * scale;
+                        block_scores[kv_pos - kv_block_start] = score;
+                        block_max = std::max(block_max, score);
+                    }
+
+                    if (block_max > -std::numeric_limits<float>::infinity()) {
+                        float scale_correction = expf(running_max - block_max);
+                        running_sum *= scale_correction;
+                        for (size_t i = 0; i < num_accum_slots; ++i) {
+                            output_accum_low[i] = vmulq_n_f32(output_accum_low[i], scale_correction);
+                            output_accum_high[i] = vmulq_n_f32(output_accum_high[i], scale_correction);
+                        }
+                        running_max = block_max;
+                    }
+
+                    float block_sum = 0.0f;
+                    for (size_t kv_idx = 0; kv_idx < block_size; ++kv_idx) {
+                        if (block_scores[kv_idx] != -std::numeric_limits<float>::infinity()) {
+                            block_scores[kv_idx] = expf(block_scores[kv_idx] - block_max);
+                            block_sum += block_scores[kv_idx];
+                        } else {
+                            block_scores[kv_idx] = 0.0f;
+                        }
+                    }
+
+                    for (size_t i = 0; i < num_accum_slots; ++i)
+                        block_accum[i] = vdupq_n_f16((__fp16)0.0f);
+
+                    // Cached V positions in groups of 4 — better pipelines int8→fp16 + fma.
+                    const size_t cached_block_end = std::min(kv_block_end, cache_len);
+                    size_t v_kv = kv_block_start;
+                    for (; v_kv + 3 < cached_block_end; v_kv += 4) {
+                        const float w1 = block_scores[v_kv - kv_block_start];
+                        const float w2 = block_scores[v_kv + 1 - kv_block_start];
+                        const float w3 = block_scores[v_kv + 2 - kv_block_start];
+                        const float w4 = block_scores[v_kv + 3 - kv_block_start];
+                        if (w1 == 0.0f && w2 == 0.0f && w3 == 0.0f && w4 == 0.0f) continue;
+
+                        const int8_t* v1 = V_cached_base + v_kv * kv_seq_stride + kv_head_idx * head_dim;
+                        const int8_t* v2 = v1 + kv_seq_stride;
+                        const int8_t* v3 = v2 + kv_seq_stride;
+                        const int8_t* v4 = v3 + kv_seq_stride;
+                        const float* vs1 = v_scales + (v_kv * num_kv_heads + kv_head_idx) * num_quant_groups;
+                        const float* vs2 = vs1 + num_kv_heads * num_quant_groups;
+                        const float* vs3 = vs2 + num_kv_heads * num_quant_groups;
+                        const float* vs4 = vs3 + num_kv_heads * num_quant_groups;
+                        if (v_kv + 8 < cached_block_end) {
+                            __builtin_prefetch(v1 + 4 * kv_seq_stride, 0, 0);
+                            __builtin_prefetch(v1 + 5 * kv_seq_stride, 0, 0);
+                            __builtin_prefetch(v1 + 6 * kv_seq_stride, 0, 0);
+                            __builtin_prefetch(v1 + 7 * kv_seq_stride, 0, 0);
+                        }
+
+                        for (size_t qg = 0; qg < num_quant_groups; ++qg) {
+                            const float16x8_t ws1_vec = vdupq_n_f16(static_cast<__fp16>(w1 * vs1[qg]));
+                            const float16x8_t ws2_vec = vdupq_n_f16(static_cast<__fp16>(w2 * vs2[qg]));
+                            const float16x8_t ws3_vec = vdupq_n_f16(static_cast<__fp16>(w3 * vs3[qg]));
+                            const float16x8_t ws4_vec = vdupq_n_f16(static_cast<__fp16>(w4 * vs4[qg]));
+                            #pragma unroll
+                            for (size_t i = 0; i < QGROUP / VECTOR_WIDTH; ++i) {
+                                const size_t d = qg * QGROUP + i * VECTOR_WIDTH;
+                                float16x8_t v1_f16 = vcvtq_f16_s16(vmovl_s8(vld1_s8(v1 + d)));
+                                float16x8_t v2_f16 = vcvtq_f16_s16(vmovl_s8(vld1_s8(v2 + d)));
+                                float16x8_t v3_f16 = vcvtq_f16_s16(vmovl_s8(vld1_s8(v3 + d)));
+                                float16x8_t v4_f16 = vcvtq_f16_s16(vmovl_s8(vld1_s8(v4 + d)));
+                                float16x8_t acc = block_accum[d / VECTOR_WIDTH];
+                                acc = vfmaq_f16(acc, v1_f16, ws1_vec);
+                                acc = vfmaq_f16(acc, v2_f16, ws2_vec);
+                                acc = vfmaq_f16(acc, v3_f16, ws3_vec);
+                                acc = vfmaq_f16(acc, v4_f16, ws4_vec);
+                                block_accum[d / VECTOR_WIDTH] = acc;
+                            }
+                        }
+                    }
+                    for (; v_kv < cached_block_end; ++v_kv) {
+                        const float w = block_scores[v_kv - kv_block_start];
+                        if (w == 0.0f) continue;
+                        const int8_t* v_vec = V_cached_base + v_kv * kv_seq_stride + kv_head_idx * head_dim;
+                        const float* v_scale_base = v_scales + (v_kv * num_kv_heads + kv_head_idx) * num_quant_groups;
+                        for (size_t qg = 0; qg < num_quant_groups; ++qg) {
+                            const float16x8_t ws_vec = vdupq_n_f16(static_cast<__fp16>(w * v_scale_base[qg]));
+                            #pragma unroll
+                            for (size_t i = 0; i < QGROUP / VECTOR_WIDTH; ++i) {
+                                const size_t d = qg * QGROUP + i * VECTOR_WIDTH;
+                                float16x8_t v_f16 = vcvtq_f16_s16(vmovl_s8(vld1_s8(v_vec + d)));
+                                block_accum[d / VECTOR_WIDTH] = vfmaq_f16(block_accum[d / VECTOR_WIDTH], v_f16, ws_vec);
+                            }
+                        }
+                    }
+                    // New tokens (fp16 V) — typically just one position.
+                    for (size_t kv_idx = std::max(v_kv, std::max(kv_block_start, cache_len)); kv_idx < kv_block_end; ++kv_idx) {
+                        const float w = block_scores[kv_idx - kv_block_start];
+                        if (w == 0.0f) continue;
+                        const size_t new_pos = kv_idx - cache_len;
+                        const __fp16* v_vec = V_new_base + new_pos * kv_seq_stride + kv_head_idx * head_dim;
+                        const float16x8_t w_vec = vdupq_n_f16(static_cast<__fp16>(w));
+                        for (size_t d = 0; d < head_dim; d += VECTOR_WIDTH) {
+                            block_accum[d / VECTOR_WIDTH] = vfmaq_f16(block_accum[d / VECTOR_WIDTH], vld1q_f16(v_vec + d), w_vec);
+                        }
+                    }
+
+                    for (size_t i = 0; i < num_accum_slots; ++i) {
+                        output_accum_low[i] = vaddq_f32(output_accum_low[i], vcvt_f32_f16(vget_low_f16(block_accum[i])));
+                        output_accum_high[i] = vaddq_f32(output_accum_high[i], vcvt_f32_f16(vget_high_f16(block_accum[i])));
+                    }
+
+                    running_sum += block_sum;
+                }
+
+                if (running_sum > 0.0f) {
+                    const float inv_sum = 1.0f / running_sum;
+                    const float32x4_t inv_sum_vec = vdupq_n_f32(inv_sum);
+                    for (size_t d = 0; d < head_dim; d += VECTOR_WIDTH) {
+                        size_t idx = d / VECTOR_WIDTH;
+                        vst1q_f16(o_vec + d, vcombine_f16(
+                            vcvt_f16_f32(vmulq_f32(output_accum_low[idx], inv_sum_vec)),
+                            vcvt_f16_f32(vmulq_f32(output_accum_high[idx], inv_sum_vec))));
+                    }
+                } else {
+                    memset(o_vec, 0, head_dim * sizeof(__fp16));
+                }
+            }
+        });
+}
+
 void cactus_attention_hybrid_int8_fp16(
     const __fp16* queries,
     const int8_t* keys_cached,
@@ -704,12 +1034,28 @@ void cactus_attention_hybrid_int8_fp16(
         scale = 1.0f / sqrtf(static_cast<float>(head_dim));
     }
 
+    if (seq_len == 1 &&
+        head_dim == v_head_dim &&
+        head_dim <= 256 &&
+        head_dim % 32 == 0 &&
+        quant_group_size == 32 &&
+        window_size == 0) {
+        cactus_attention_hybrid_int8_fp16_decode_dot(
+            queries, keys_cached, values_cached, k_scales, v_scales,
+            keys_new, values_new, output,
+            batch_size, cache_len, new_len,
+            num_q_heads, num_kv_heads, head_dim,
+            scale, position_offset, is_causal);
+        return;
+    }
+
     const size_t kv_seq_len = cache_len + new_len;
 
     constexpr size_t VECTOR_WIDTH = 8;
     constexpr size_t BLOCK_SIZE = 32;
     const size_t head_dim_aligned = (head_dim / VECTOR_WIDTH) * VECTOR_WIDTH;
     const size_t v_head_dim_aligned = (v_head_dim / VECTOR_WIDTH) * VECTOR_WIDTH;
+    const size_t num_accum_slots = v_head_dim_aligned / VECTOR_WIDTH;
 
     const size_t gqa_group_size = num_q_heads / num_kv_heads;
     const size_t num_quant_groups_k = (head_dim + quant_group_size - 1) / quant_group_size;
@@ -728,9 +1074,10 @@ void cactus_attention_hybrid_int8_fp16(
 
     CactusThreading::parallel_for(batch_size * num_q_heads * seq_len, CactusThreading::Thresholds::ATTENTION,
         [=](size_t start_idx, size_t end_idx) {
-            std::vector<float> block_scores(BLOCK_SIZE);
-            std::vector<float32x4_t> output_accum_low(v_head_dim_aligned / VECTOR_WIDTH * 2);
-            std::vector<float32x4_t> output_accum_high(v_head_dim_aligned / VECTOR_WIDTH * 2);
+            float block_scores[BLOCK_SIZE];
+            std::vector<float32x4_t> output_accum_low(num_accum_slots);
+            std::vector<float32x4_t> output_accum_high(num_accum_slots);
+            std::vector<float16x8_t> block_accum(num_accum_slots);
 
             for (size_t work_idx = start_idx; work_idx < end_idx; ++work_idx) {
                 const size_t batch_idx = work_idx / (num_q_heads * seq_len);
@@ -753,7 +1100,7 @@ void cactus_attention_hybrid_int8_fp16(
                 float running_max = -std::numeric_limits<float>::infinity();
                 float running_sum = 0.0f;
 
-                for (size_t i = 0; i < output_accum_low.size(); ++i) {
+                for (size_t i = 0; i < num_accum_slots; ++i) {
                     output_accum_low[i] = vdupq_n_f32(0.0f);
                     output_accum_high[i] = vdupq_n_f32(0.0f);
                 }
@@ -797,8 +1144,7 @@ void cactus_attention_hybrid_int8_fp16(
                             continue;
                         }
 
-                        float32x4_t score_accum_low = vdupq_n_f32(0.0f);
-                        float32x4_t score_accum_high = vdupq_n_f32(0.0f);
+                        float score = 0.0f;
 
                         if (kv_pos < cache_len) {
                             const int8_t* k_vec = K_cached_base + kv_pos * k_seq_stride + kv_head_idx * head_dim;
@@ -806,64 +1152,53 @@ void cactus_attention_hybrid_int8_fp16(
 
                             for (size_t quant_group = 0; quant_group < num_quant_groups_k; quant_group++) {
                                 const size_t dim_base = quant_group * quant_group_size;
-                                const float k_scale = k_scale_base[quant_group];
-                                const float32x4_t k_scale_vec = vdupq_n_f32(k_scale);
+
+                                float16x8_t s_acc = vdupq_n_f16((__fp16)0.0f);
 
                                 #pragma unroll
                                 for (size_t i = 0; i < 4; i++) {
                                     const size_t dim_block = dim_base + i * VECTOR_WIDTH;
                                     if (dim_block >= head_dim_aligned) break;
 
-                                    float16x8_t q_vec_f16 = vld1q_f16(&q_vec[dim_block]);
-                                    float32x4_t q_low = vcvt_f32_f16(vget_low_f16(q_vec_f16));
-                                    float32x4_t q_high = vcvt_f32_f16(vget_high_f16(q_vec_f16));
-
-                                    int8x8_t k_vec_i8 = vld1_s8(&k_vec[dim_block]);
-                                    int16x8_t k_vec_i16 = vmovl_s8(k_vec_i8);
-                                    float32x4_t k_low = vmulq_f32(vcvtq_f32_s32(vmovl_s16(vget_low_s16(k_vec_i16))), k_scale_vec);
-                                    float32x4_t k_high = vmulq_f32(vcvtq_f32_s32(vmovl_s16(vget_high_s16(k_vec_i16))), k_scale_vec);
-
-                                    score_accum_low = vfmaq_f32(score_accum_low, q_low, k_low);
-                                    score_accum_high = vfmaq_f32(score_accum_high, q_high, k_high);
+                                    float16x8_t q_f16 = vld1q_f16(&q_vec[dim_block]);
+                                    float16x8_t k_f16 = vcvtq_f16_s16(vmovl_s8(vld1_s8(&k_vec[dim_block])));
+                                    s_acc = vfmaq_f16(s_acc, q_f16, k_f16);
                                 }
+
+                                float partial = vaddvq_f32(vcvt_f32_f16(vget_low_f16(s_acc))) +
+                                                vaddvq_f32(vcvt_f32_f16(vget_high_f16(s_acc)));
+                                score += k_scale_base[quant_group] * partial;
                             }
                         } else {
                             const size_t new_pos = kv_pos - cache_len;
                             const __fp16* k_vec = K_new_base + new_pos * k_seq_stride + kv_head_idx * head_dim;
 
+                            float16x8_t s_acc = vdupq_n_f16((__fp16)0.0f);
+
                             for (size_t dim_block = 0; dim_block < head_dim_aligned; dim_block += VECTOR_WIDTH) {
-                                float16x8_t q_vec_f16 = vld1q_f16(&q_vec[dim_block]);
-                                float16x8_t k_vec_f16 = vld1q_f16(&k_vec[dim_block]);
-
-                                float32x4_t q_low = vcvt_f32_f16(vget_low_f16(q_vec_f16));
-                                float32x4_t q_high = vcvt_f32_f16(vget_high_f16(q_vec_f16));
-                                float32x4_t k_low = vcvt_f32_f16(vget_low_f16(k_vec_f16));
-                                float32x4_t k_high = vcvt_f32_f16(vget_high_f16(k_vec_f16));
-
-                                score_accum_low = vfmaq_f32(score_accum_low, q_low, k_low);
-                                score_accum_high = vfmaq_f32(score_accum_high, q_high, k_high);
+                                float16x8_t q_f16 = vld1q_f16(&q_vec[dim_block]);
+                                float16x8_t k_f16 = vld1q_f16(&k_vec[dim_block]);
+                                s_acc = vfmaq_f16(s_acc, q_f16, k_f16);
                             }
+
+                            score = vaddvq_f32(vcvt_f32_f16(vget_low_f16(s_acc))) +
+                                    vaddvq_f32(vcvt_f32_f16(vget_high_f16(s_acc)));
                         }
 
-                        float score = vaddvq_f32(vaddq_f32(score_accum_low, score_accum_high)) * scale;
+                        score *= scale;
                         block_scores[kv_idx] = score;
                         block_max = std::max(block_max, score);
                     }
 
-                    float current_block_scale = 1.0f;
                     if (block_max > -std::numeric_limits<float>::infinity()) {
-                        if (block_max > running_max) {
-                            float scale_correction = expf(running_max - block_max);
-                            running_sum *= scale_correction;
+                        float scale_correction = expf(running_max - block_max);
+                        running_sum *= scale_correction;
 
-                            for (size_t i = 0; i < output_accum_low.size() / 2; ++i) {
-                                output_accum_low[i] = vmulq_n_f32(output_accum_low[i], scale_correction);
-                                output_accum_high[i] = vmulq_n_f32(output_accum_high[i], scale_correction);
-                            }
-                            running_max = block_max;
-                        } else {
-                            current_block_scale = expf(block_max - running_max);
+                        for (size_t i = 0; i < num_accum_slots; ++i) {
+                            output_accum_low[i] = vmulq_n_f32(output_accum_low[i], scale_correction);
+                            output_accum_high[i] = vmulq_n_f32(output_accum_high[i], scale_correction);
                         }
+                        running_max = block_max;
                     }
 
                     float block_sum = 0.0f;
@@ -876,12 +1211,14 @@ void cactus_attention_hybrid_int8_fp16(
                         }
                     }
 
+                    for (size_t i = 0; i < num_accum_slots; ++i)
+                        block_accum[i] = vdupq_n_f16((__fp16)0.0f);
+
                     for (size_t kv_idx = 0; kv_idx < block_size; ++kv_idx) {
-                        const float attn_weight = block_scores[kv_idx] * current_block_scale;
+                        const float attn_weight = block_scores[kv_idx];
                         if (attn_weight == 0.0f) continue;
 
                         const size_t kv_pos = kv_block_start + kv_idx;
-                        const float32x4_t weight_vec = vdupq_n_f32(attn_weight);
 
                         if (kv_pos < cache_len) {
                             const int8_t* v_vec = V_cached_base + kv_pos * v_seq_stride + kv_head_idx * v_head_dim;
@@ -889,41 +1226,34 @@ void cactus_attention_hybrid_int8_fp16(
 
                             for (size_t quant_group = 0; quant_group < num_quant_groups_v; quant_group++) {
                                 const size_t dim_base = quant_group * quant_group_size;
-                                const float v_scale = v_scale_base[quant_group];
-                                const float32x4_t v_scale_vec = vdupq_n_f32(v_scale);
+                                const float16x8_t ws_vec = vdupq_n_f16(static_cast<__fp16>(attn_weight * v_scale_base[quant_group]));
 
                                 #pragma unroll
                                 for (size_t i = 0; i < 4; i++) {
                                     const size_t dim_block = dim_base + i * VECTOR_WIDTH;
                                     if (dim_block >= v_head_dim_aligned) break;
 
-                                    int8x8_t v_vec_i8 = vld1_s8(&v_vec[dim_block]);
-                                    int16x8_t v_vec_i16 = vmovl_s8(v_vec_i8);
-                                    float32x4_t v_low = vmulq_f32(vcvtq_f32_s32(vmovl_s16(vget_low_s16(v_vec_i16))), v_scale_vec);
-                                    float32x4_t v_high = vmulq_f32(vcvtq_f32_s32(vmovl_s16(vget_high_s16(v_vec_i16))), v_scale_vec);
-
-                                    size_t idx = dim_block / VECTOR_WIDTH;
-                                    output_accum_low[idx] = vfmaq_f32(output_accum_low[idx], v_low, weight_vec);
-                                    output_accum_high[idx] = vfmaq_f32(output_accum_high[idx], v_high, weight_vec);
+                                    float16x8_t v_f16 = vcvtq_f16_s16(vmovl_s8(vld1_s8(&v_vec[dim_block])));
+                                    block_accum[dim_block / VECTOR_WIDTH] = vfmaq_f16(block_accum[dim_block / VECTOR_WIDTH], v_f16, ws_vec);
                                 }
                             }
                         } else {
                             const size_t new_pos = kv_pos - cache_len;
                             const __fp16* v_vec = V_new_base + new_pos * v_seq_stride + kv_head_idx * v_head_dim;
+                            const float16x8_t w_vec = vdupq_n_f16(static_cast<__fp16>(attn_weight));
 
                             for (size_t dim_block = 0; dim_block < v_head_dim_aligned; dim_block += VECTOR_WIDTH) {
-                                float16x8_t v_vec_f16 = vld1q_f16(&v_vec[dim_block]);
-                                float32x4_t v_low = vcvt_f32_f16(vget_low_f16(v_vec_f16));
-                                float32x4_t v_high = vcvt_f32_f16(vget_high_f16(v_vec_f16));
-
-                                size_t idx = dim_block / VECTOR_WIDTH;
-                                output_accum_low[idx] = vfmaq_f32(output_accum_low[idx], v_low, weight_vec);
-                                output_accum_high[idx] = vfmaq_f32(output_accum_high[idx], v_high, weight_vec);
+                                block_accum[dim_block / VECTOR_WIDTH] = vfmaq_f16(block_accum[dim_block / VECTOR_WIDTH], vld1q_f16(&v_vec[dim_block]), w_vec);
                             }
                         }
                     }
 
-                    running_sum += block_sum * current_block_scale;
+                    for (size_t i = 0; i < num_accum_slots; ++i) {
+                        output_accum_low[i] = vaddq_f32(output_accum_low[i], vcvt_f32_f16(vget_low_f16(block_accum[i])));
+                        output_accum_high[i] = vaddq_f32(output_accum_high[i], vcvt_f32_f16(vget_high_f16(block_accum[i])));
+                    }
+
+                    running_sum += block_sum;
                 }
 
                 if (running_sum > 0.0f) {
@@ -932,19 +1262,12 @@ void cactus_attention_hybrid_int8_fp16(
 
                     for (size_t dim_block = 0; dim_block < v_head_dim_aligned; dim_block += VECTOR_WIDTH) {
                         size_t idx = dim_block / VECTOR_WIDTH;
-                        float32x4_t final_low = vmulq_f32(output_accum_low[idx], inv_sum_vec);
-                        float32x4_t final_high = vmulq_f32(output_accum_high[idx], inv_sum_vec);
-
-                        float16x4_t low_f16 = vcvt_f16_f32(final_low);
-                        float16x4_t high_f16 = vcvt_f16_f32(final_high);
-                        float16x8_t combined = vcombine_f16(low_f16, high_f16);
-
-                        vst1q_f16(&o_vec[dim_block], combined);
+                        vst1q_f16(&o_vec[dim_block], vcombine_f16(
+                            vcvt_f16_f32(vmulq_f32(output_accum_low[idx], inv_sum_vec)),
+                            vcvt_f16_f32(vmulq_f32(output_accum_high[idx], inv_sum_vec))));
                     }
                 } else {
-                    for (size_t dim = 0; dim < v_head_dim; ++dim) {
-                        o_vec[dim] = static_cast<__fp16>(0.0f);
-                    }
+                    memset(o_vec, 0, v_head_dim * sizeof(__fp16));
                 }
             }
         });

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -292,3 +292,6 @@ target_link_libraries(matmul_bench PRIVATE bench_lib)
 
 add_executable(attn_bench bench/attn_bench.cpp)
 target_link_libraries(attn_bench PRIVATE bench_lib)
+
+add_executable(accuracy_test bench/accuracy_test.cpp)
+target_link_libraries(accuracy_test PRIVATE bench_lib)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,294 @@
+cmake_minimum_required(VERSION 3.16)
+project(CactusBench LANGUAGES C CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
+option(WITH_GGML            "Build with llama.cpp / ggml backend"             OFF)
+option(WITH_LITERT          "Build with LiteRT (TFLite) backend"              OFF)
+option(WITH_EXECUTORCH      "Build with ExecuTorch matmul (XNNPACK) backend"  OFF)
+option(WITH_EXECUTORCH_LLM  "Build with ExecuTorch attention (custom_sdpa) — requires a built ExecuTorch tree" OFF)
+option(WITH_ONNXRT          "Build with ONNX Runtime backend"                 OFF)
+
+set(CACTUS_PROJECT_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/..)
+
+# ── Compile flags ───────────────────────────────────────────────────────────
+if(APPLE)
+    set(CMAKE_OSX_ARCHITECTURES "arm64")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -arch arm64 -march=armv8.2-a+fp16+simd+dotprod+i8mm -pthread -O3 -Wall -Wextra")
+    add_compile_definitions(
+        __ARM_NEON=1
+        __ARM_FEATURE_FP16_VECTOR_ARITHMETIC=1
+        __ARM_FEATURE_DOTPROD=1
+        __ARM_FEATURE_MATMUL_INT8=1
+    )
+else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=armv8.2-a+fp16+simd+dotprod+i8mm -pthread -O3 -Wall -Wextra")
+    add_compile_definitions(
+        __ARM_NEON=1
+        __ARM_FEATURE_FP16_VECTOR_ARITHMETIC=1
+        __ARM_FEATURE_DOTPROD=1
+        __ARM_FEATURE_MATMUL_INT8=1
+    )
+endif()
+
+# ── Cactus library (built separately by cactus/build.sh) ────────────────────
+set(CACTUS_BUILD_DIR ${CACTUS_PROJECT_ROOT}/cactus/build)
+find_library(CACTUS_LIB
+    NAMES cactus
+    HINTS ${CACTUS_BUILD_DIR} ${CACTUS_BUILD_DIR}/lib
+    REQUIRED
+)
+message(STATUS "Cactus library: ${CACTUS_LIB}")
+
+# ── Apple frameworks (Accelerate, etc.) ─────────────────────────────────────
+if(APPLE)
+    find_library(ACCELERATE_FRAMEWORK Accelerate REQUIRED)
+    find_library(FOUNDATION_FRAMEWORK Foundation REQUIRED)
+endif()
+
+# ── Optional third-party backend dependencies ───────────────────────────────
+
+# GGML / llama.cpp
+if(WITH_GGML)
+    set(GGML_DIR "" CACHE PATH "Path to ggml source tree (e.g. ../third_party/ggml)")
+    if(NOT GGML_DIR OR NOT EXISTS "${GGML_DIR}/CMakeLists.txt")
+        if(EXISTS "${CACTUS_PROJECT_ROOT}/../third_party/ggml/CMakeLists.txt")
+            set(GGML_DIR "${CACTUS_PROJECT_ROOT}/../third_party/ggml")
+        else()
+            message(FATAL_ERROR "WITH_GGML=ON but no ggml source found. Set -DGGML_DIR=/path/to/ggml or clone into ../../third_party/ggml")
+        endif()
+    endif()
+    set(GGML_BUILD_TESTS    OFF CACHE BOOL "" FORCE)
+    set(GGML_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+    add_subdirectory(${GGML_DIR} ${CMAKE_CURRENT_BINARY_DIR}/ggml EXCLUDE_FROM_ALL)
+    message(STATUS "GGML enabled from ${GGML_DIR}")
+endif()
+
+# LiteRT
+if(WITH_LITERT)
+    set(LITERT_DIR "" CACHE PATH "Path to LiteRT source tree")
+    if(NOT LITERT_DIR OR NOT EXISTS "${LITERT_DIR}/tflite")
+        if(EXISTS "${CACTUS_PROJECT_ROOT}/../third_party/litert/tflite")
+            set(LITERT_DIR "${CACTUS_PROJECT_ROOT}/../third_party/litert")
+        else()
+            message(FATAL_ERROR "WITH_LITERT=ON but no LiteRT source found. Set -DLITERT_DIR=... or clone to ../../third_party/litert")
+        endif()
+    endif()
+
+    include(FetchContent)
+    set(FLATBUFFERS_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+    FetchContent_Declare(
+        flatbuffers
+        GIT_REPOSITORY https://github.com/google/flatbuffers
+        GIT_TAG v24.12.23
+        GIT_SHALLOW TRUE
+        SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/flatbuffers"
+    )
+    FetchContent_Populate(flatbuffers)
+    add_subdirectory("${flatbuffers_SOURCE_DIR}" "${flatbuffers_BINARY_DIR}" EXCLUDE_FROM_ALL)
+    include(ExternalProject)
+    ExternalProject_Add(flatbuffers-flatc
+        PREFIX ${CMAKE_CURRENT_BINARY_DIR}/flatbuffers-flatc
+        SOURCE_DIR ${flatbuffers_SOURCE_DIR}
+        CMAKE_ARGS -DFLATBUFFERS_BUILD_TESTS=OFF
+                   -DFLATBUFFERS_BUILD_FLATLIB=OFF
+                   -DFLATBUFFERS_STATIC_FLATC=OFF
+                   -DFLATBUFFERS_BUILD_FLATHASH=OFF
+        INSTALL_COMMAND ""
+        EXCLUDE_FROM_ALL TRUE
+    )
+    set(FLATBUFFERS_FLATC_EXECUTABLE
+        "${CMAKE_CURRENT_BINARY_DIR}/flatbuffers-flatc/src/flatbuffers-flatc-build/flatc"
+        CACHE STRING "" FORCE)
+
+    set(TFLITE_ENABLE_XNNPACK OFF CACHE BOOL "" FORCE)
+    set(TFLITE_ENABLE_GPU     OFF CACHE BOOL "" FORCE)
+    set(TFLITE_ENABLE_NNAPI   OFF CACHE BOOL "" FORCE)
+    set(TFLITE_ENABLE_EXTERNAL_DELEGATE OFF CACHE BOOL "" FORCE)
+    set(TFLITE_ENABLE_RUY     ON  CACHE BOOL "" FORCE)
+    add_subdirectory(${LITERT_DIR}/tflite ${CMAKE_CURRENT_BINARY_DIR}/tflite EXCLUDE_FROM_ALL)
+
+    add_library(litert_kernels STATIC
+        ${LITERT_DIR}/tflite/kernels/internal/optimized/neon_tensor_utils.cc
+        ${LITERT_DIR}/tflite/kernels/internal/optimized/cpu_check.cc
+        ${LITERT_DIR}/tflite/kernels/internal/reference/portable_tensor_utils.cc
+        ${LITERT_DIR}/tflite/kernels/internal/common.cc
+        ${LITERT_DIR}/tflite/kernels/internal/quantization_util.cc
+        ${LITERT_DIR}/tflite/kernels/cpu_backend_context.cc
+    )
+    target_include_directories(litert_kernels PUBLIC
+        ${LITERT_DIR}
+        ${CMAKE_CURRENT_BINARY_DIR}/tflite/tensorflow-src
+        ${CMAKE_CURRENT_BINARY_DIR}/cpuinfo
+    )
+    target_link_libraries(litert_kernels PUBLIC
+        Eigen3::Eigen
+        ruy::ruy
+        gemmlowp::gemmlowp
+        cpuinfo::cpuinfo
+    )
+    target_compile_options(litert_kernels PRIVATE -O3 -DTFLITE_WITH_RUY)
+    message(STATUS "LiteRT enabled from ${LITERT_DIR}")
+endif()
+
+# ExecuTorch / XNNPACK (matmul only — INT8 qc8w GEMM via XNNPACK)
+if(WITH_EXECUTORCH)
+    include(FetchContent)
+    set(XNNPACK_BUILD_TESTS      OFF CACHE BOOL "" FORCE)
+    set(XNNPACK_BUILD_BENCHMARKS OFF CACHE BOOL "" FORCE)
+    set(XNNPACK_LIBRARY_TYPE     "static" CACHE STRING "" FORCE)
+    FetchContent_Declare(
+        xnnpack
+        GIT_REPOSITORY https://github.com/google/XNNPACK
+        GIT_TAG master
+        GIT_SHALLOW TRUE
+        SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/xnnpack-src"
+    )
+    FetchContent_MakeAvailable(xnnpack)
+    message(STATUS "ExecuTorch (XNNPACK) matmul enabled")
+endif()
+
+# ExecuTorch llm/custom_ops — fused SDPA attention kernel.
+# Requires a SEPARATELY-BUILT ExecuTorch checkout. Heavy dependency, not
+# fetched at configure time. User must:
+#   git clone https://github.com/pytorch/executorch ../../third_party/executorch
+#   cd ../../third_party/executorch && ./install_executorch.sh
+#   cmake .. -DEXECUTORCH_BUILD_KERNELS_LLM=ON -DEXECUTORCH_BUILD_EXTENSION_TENSOR=ON
+#   cmake --build cmake-out -j
+# Then point us at the build:
+#   cmake .. -DWITH_EXECUTORCH_LLM=ON -DEXECUTORCH_DIR=../../third_party/executorch
+if(WITH_EXECUTORCH_LLM)
+    set(EXECUTORCH_DIR "" CACHE PATH "Path to a built ExecuTorch tree (with cmake-out/)")
+    if(NOT EXECUTORCH_DIR OR NOT EXISTS "${EXECUTORCH_DIR}/extension/llm/custom_ops/op_sdpa.h")
+        if(EXISTS "${CACTUS_PROJECT_ROOT}/../third_party/executorch/extension/llm/custom_ops/op_sdpa.h")
+            set(EXECUTORCH_DIR "${CACTUS_PROJECT_ROOT}/../third_party/executorch")
+        else()
+            message(FATAL_ERROR "WITH_EXECUTORCH_LLM=ON but ExecuTorch tree not found. Set -DEXECUTORCH_DIR=/path/to/executorch (with cmake-out/ already built)")
+        endif()
+    endif()
+
+    set(ET_BUILD_DIR "${EXECUTORCH_DIR}/cmake-out")
+    if(NOT EXISTS "${ET_BUILD_DIR}")
+        message(FATAL_ERROR "ExecuTorch must be built first: ${ET_BUILD_DIR} not found")
+    endif()
+
+    # ET's cmake-out lays libraries out as <subdir>/<config>/<libname>.a
+    # (e.g. .../extension/llm/custom_ops/Release/libcustom_ops.a). Search
+    # both the bare and Release/Debug variants.
+    set(ET_LIB_HINTS
+        ${ET_BUILD_DIR}
+        ${ET_BUILD_DIR}/Release
+        ${ET_BUILD_DIR}/Debug
+        ${ET_BUILD_DIR}/lib
+        ${ET_BUILD_DIR}/extension/llm/custom_ops
+        ${ET_BUILD_DIR}/extension/llm/custom_ops/Release
+        ${ET_BUILD_DIR}/extension/tensor
+        ${ET_BUILD_DIR}/extension/tensor/Release
+        ${ET_BUILD_DIR}/extension/threadpool
+        ${ET_BUILD_DIR}/extension/threadpool/Release
+        ${ET_BUILD_DIR}/kernels/optimized
+        ${ET_BUILD_DIR}/kernels/optimized/Release
+        ${ET_BUILD_DIR}/backends/xnnpack/third-party/pthreadpool
+        ${ET_BUILD_DIR}/backends/xnnpack/third-party/pthreadpool/Release
+    )
+    find_library(ET_CUSTOM_OPS_LIB custom_ops      PATHS ${ET_LIB_HINTS} REQUIRED)
+    find_library(ET_CORE_LIB       executorch_core PATHS ${ET_LIB_HINTS} REQUIRED)
+    find_library(ET_THREADPOOL_LIB extension_threadpool PATHS ${ET_LIB_HINTS})
+    find_library(ET_PTHREADPOOL_LIB pthreadpool   PATHS ${ET_LIB_HINTS})
+    find_library(ET_KERNELS_OPT_LIB optimized_kernels PATHS ${ET_LIB_HINTS})
+    find_library(ET_CPUBLAS_LIB    cpublas         PATHS ${ET_LIB_HINTS})
+    find_library(ET_TENSOR_EXT_LIB extension_tensor PATHS ${ET_LIB_HINTS})
+
+    set(ET_INCLUDE_DIRS
+        ${EXECUTORCH_DIR}
+        ${EXECUTORCH_DIR}/..       # for <executorch/...> includes
+        ${EXECUTORCH_DIR}/runtime/core/portable_type/c10   # for vendored <c10/...>
+    )
+    message(STATUS "ExecuTorch (LLM/SDPA) enabled from ${EXECUTORCH_DIR}")
+endif()
+
+# ONNX Runtime (prebuilt)
+if(WITH_ONNXRT)
+    set(ONNXRT_DIR "" CACHE PATH "Path to onnxruntime prebuilt tree")
+    if(NOT ONNXRT_DIR OR NOT EXISTS "${ONNXRT_DIR}/include")
+        if(EXISTS "${CACTUS_PROJECT_ROOT}/../third_party/onnxruntime/include")
+            set(ONNXRT_DIR "${CACTUS_PROJECT_ROOT}/../third_party/onnxruntime")
+        else()
+            message(FATAL_ERROR "WITH_ONNXRT=ON but onnxruntime not found. Set -DONNXRT_DIR=... or extract to ../../third_party/onnxruntime")
+        endif()
+    endif()
+    find_library(ONNXRT_LIB onnxruntime PATHS ${ONNXRT_DIR}/lib REQUIRED)
+    message(STATUS "ONNX Runtime enabled from ${ONNXRT_DIR}")
+endif()
+
+# ── Build the bench library ─────────────────────────────────────────────────
+add_library(bench_lib OBJECT
+    bench/bench_common.cpp
+    bench/bench_driver.cpp
+    bench/backend_cactus.cpp
+    bench/backend_ggml.cpp
+    bench/backend_litert.cpp
+    bench/backend_executorch.cpp
+    bench/backend_onnxrt.cpp
+)
+target_include_directories(bench_lib PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CACTUS_PROJECT_ROOT}
+    ${CACTUS_PROJECT_ROOT}/cactus-kernels
+)
+target_link_libraries(bench_lib PUBLIC ${CACTUS_LIB})
+if(APPLE)
+    target_link_libraries(bench_lib PUBLIC ${ACCELERATE_FRAMEWORK} ${FOUNDATION_FRAMEWORK})
+endif()
+
+if(WITH_GGML)
+    target_link_libraries(bench_lib PUBLIC ggml)
+    target_compile_definitions(bench_lib PRIVATE WITH_GGML)
+endif()
+if(WITH_LITERT)
+    target_link_libraries(bench_lib PUBLIC litert_kernels)
+    target_compile_definitions(bench_lib PRIVATE WITH_LITERT)
+endif()
+if(WITH_EXECUTORCH)
+    target_link_libraries(bench_lib PUBLIC XNNPACK)
+    target_compile_definitions(bench_lib PRIVATE WITH_EXECUTORCH)
+endif()
+if(WITH_EXECUTORCH_LLM)
+    target_include_directories(bench_lib PUBLIC ${ET_INCLUDE_DIRS})
+    # ET's vendored c10 expects a generated cmake_macros.h; skip it (matches
+    # how ET's own targets compile — see executorch/CMakeLists.txt).
+    target_compile_definitions(bench_lib PRIVATE C10_USING_CUSTOM_GENERATED_MACROS)
+    target_link_libraries(bench_lib PUBLIC
+        ${ET_CUSTOM_OPS_LIB}
+        ${ET_CORE_LIB}
+    )
+    if(ET_THREADPOOL_LIB)
+        target_link_libraries(bench_lib PUBLIC ${ET_THREADPOOL_LIB})
+    endif()
+    if(ET_PTHREADPOOL_LIB)
+        target_link_libraries(bench_lib PUBLIC ${ET_PTHREADPOOL_LIB})
+    endif()
+    if(ET_KERNELS_OPT_LIB)
+        target_link_libraries(bench_lib PUBLIC ${ET_KERNELS_OPT_LIB})
+    endif()
+    if(ET_CPUBLAS_LIB)
+        target_link_libraries(bench_lib PUBLIC ${ET_CPUBLAS_LIB})
+    endif()
+    if(ET_TENSOR_EXT_LIB)
+        target_link_libraries(bench_lib PUBLIC ${ET_TENSOR_EXT_LIB})
+    endif()
+    target_compile_definitions(bench_lib PRIVATE WITH_EXECUTORCH_LLM)
+endif()
+if(WITH_ONNXRT)
+    target_include_directories(bench_lib PUBLIC ${ONNXRT_DIR}/include)
+    target_link_libraries(bench_lib PUBLIC ${ONNXRT_LIB})
+    target_compile_definitions(bench_lib PRIVATE WITH_ONNXRT)
+endif()
+
+# ── Executables ─────────────────────────────────────────────────────────────
+add_executable(matmul_bench bench/matmul_bench.cpp)
+target_link_libraries(matmul_bench PRIVATE bench_lib)
+
+add_executable(attn_bench bench/attn_bench.cpp)
+target_link_libraries(attn_bench PRIVATE bench_lib)

--- a/tests/bench/README.md
+++ b/tests/bench/README.md
@@ -1,0 +1,249 @@
+# Cactus v2 Benchmark Suite
+
+Compares `cactus` against `llama.cpp` (ggml), LiteRT (both Ruy and the TFLite
+NEON kernels), ONNX Runtime, and ExecuTorch (XNNPACK) on the four kernels we
+currently care about on this branch:
+
+- **GEMV** — INT8 grouped (1 × d) @ (d × N)
+- **GEMM** — INT8 grouped (M × d) @ (d × N)
+- **Attention prefill** — FP16 fused attention
+- **Hybrid attention decode** — INT8 KV-cache, FP16 query
+
+The driver sweeps the five graphs the team needs:
+
+| Graph | Sweep over | Fixed |
+|-------|------------|-------|
+| 1. `gemv_d`            | d ∈ {128…4096}, K=N=d, M=1 | – |
+| 2. `gemm_d`            | d ∈ {128…4096}, K=d        | M=N=512 |
+| 3. `gemm_mn`           | M=N ∈ {128…4096}           | K=512 |
+| 4. `attn_prefill_s`    | S ∈ {128…4096}             | model_dim=1024, h=8 |
+| 5. `attn_decode_cache` | cache ∈ {128…4096}         | model_dim=1024, h=8 |
+
+## Quick start (cactus only — no third-party deps)
+
+```bash
+# 1. Build the cactus library once.
+cd cactus-v2/cactus && ./build.sh
+
+# 2. Configure + build the bench.
+cd ../tests
+mkdir -p build && cd build
+cmake ..
+make -j matmul_bench attn_bench
+
+# 3. Run.
+./matmul_bench --csv matmul.csv
+./attn_bench   --csv attn.csv
+```
+
+Or use the wrapper script (it builds libcactus + the bench, then runs both):
+
+```bash
+./tests/run_benchmark.sh
+```
+
+## Enabling third-party backends
+
+Each backend is a CMake option. Drop the source/binary into `../third_party/`
+and toggle the flag at configure time.
+
+```bash
+# llama.cpp / ggml
+git clone https://github.com/ggml-org/ggml.git ../../third_party/ggml
+cmake .. -DWITH_GGML=ON
+
+# LiteRT (Ruy + neon)
+git clone https://github.com/google-ai-edge/LiteRT.git ../../third_party/litert
+cmake .. -DWITH_LITERT=ON
+
+# ExecuTorch matmul (fetches XNNPACK at configure time)
+cmake .. -DWITH_EXECUTORCH=ON
+
+# ExecuTorch attention (custom_sdpa) — separate flag, requires a built ET tree.
+git clone https://github.com/pytorch/executorch ../../third_party/executorch
+cd ../../third_party/executorch
+./install_executorch.sh                          # installs build deps
+cmake -Bcmake-out -DEXECUTORCH_BUILD_KERNELS_LLM=ON \
+                  -DEXECUTORCH_BUILD_EXTENSION_TENSOR=ON \
+                  -DEXECUTORCH_BUILD_KERNELS_OPTIMIZED=ON
+cmake --build cmake-out -j
+cd ../../cactus-v2/tests/build
+cmake .. -DWITH_EXECUTORCH_LLM=ON \
+         -DEXECUTORCH_DIR=$(realpath ../../../third_party/executorch)
+
+# ONNX Runtime (prebuilt; download from the GitHub releases page and extract)
+#   ../../third_party/onnxruntime/{include,lib}/...
+cmake .. -DWITH_ONNXRT=ON
+```
+
+`./tests/run_benchmark.sh --external-frameworks` auto-enables any tree it
+finds under `../third_party/`.
+
+## CLI options
+
+```
+./matmul_bench
+  --warmup N          Warmup iterations (default: 50)
+  --iterations N      Timed iterations  (default: 200)
+  --graphs ...        Comma list of: gemv_d, gemm_d, gemm_mn
+  --dims 128,256,...  Sweep dimensions (default: 128…4096)
+  --backends LIST     Comma-separated framework names (cactus,ggml,litert,...)
+  --threads N|max     Override thread count
+  --csv path          Append CSV results to path
+```
+
+The number of distinct weight matrices the bench cycles through (`NM`) is
+chosen automatically per config to make the weight pool exceed 64 MB —
+larger than any plausible Apple Silicon SLC. This forces every iteration's
+weight load to miss to RAM, matching real inference where every layer has
+unique weights. NM is reported next to each shape in the output.
+
+### Threading
+
+Default is to honor `--threads`. We recommend `--threads 4` for these
+plots because:
+- Most mobile target devices have 2–6 high-performance cores (iPhone
+  A-series: 2P+4E, mid-range Snapdragon: 1+3+4, high-end Snapdragon: 1+5+2).
+  4 P-core threads is a reasonable mobile-realistic budget.
+- Each backend in this bench has its own independent threadpool. With
+  `--threads max`, multiple backends contend for the same cores during
+  the round-robin loop, producing measurement noise. `--threads 4` keeps
+  total worker threads bounded (~24 across 6 backends) and matches a
+  realistic mobile workload.
+
+### What's still asymmetric (read before plotting)
+
+We've fixed warm-cache reads (NM scales to exceed SLC) and ORT's per-call
+session-creation overhead (sessions cached per (M,K,N)). Three known
+asymmetries remain:
+
+1. **Mixed precision plotted on the same axis.** ExecuTorch SDPA prefill
+   is FP32-only (no FP16 path exists in `op_sdpa.cpp`); ORT GQA decode is
+   FP16-KV (no INT8-KV op exists in ORT). Both flagged with † / ‡ in plot
+   legends. ExecuTorch is doing 2× the floating-point work cactus is;
+   ORT decode is doing higher-precision KV reads. Y-axis is wall-clock,
+   not "useful work per second."
+
+2. **Per-channel vs per-group(32) INT8.** LiteRT and ExecuTorch use
+   per-channel scales (1 scale per row); cactus / ggml / ORT use per-group
+   scales (4 scales per 128-d row). Per-channel is faster (fewer scale
+   lookups) but coarser. Flagged with * in plot legends.
+
+3. **Graph-runtime per-call overhead.** ggml is a graph runtime — each
+   `ggml_graph_compute` has a per-call dispatch cost (~50–100μs) that
+   wouldn't exist if you were running a full LLM forward pass through
+   ggml. We've cut what we can (honor `--threads`, share K/V graphs), but
+   ggml's per-call floor is intrinsic to its design. Look at the small-S
+   end of graph 4/5 to see this floor as a flat segment in the ggml line.
+
+```
+./attn_bench
+  --warmup N          (default: 50)
+  --iterations N      (default: 200)
+  --graphs ...        Comma list of: attn_prefill_s, attn_decode_cache
+  --dims 128,...      Sweep S / cache_len values
+  --model_dim N       Default 1024
+  --heads N           Default 8 (q_heads = kv_heads)
+  --backends LIST     ...
+  --threads N|max     ...
+  --csv path
+```
+
+## CSV format
+
+`matmul_bench.csv` columns:
+```
+graph, sweep_dim, M, K, N, backend, framework, time_us, gops, nrmse, max_err
+```
+
+`attn_bench.csv` columns:
+```
+graph, sweep_dim, seq_len, cache_len, head_dim, q_heads, kv_heads,
+backend, framework, time_us, gflops, nrmse, max_err
+```
+
+The five user-facing graphs map onto these CSVs as:
+
+| Graph (slide deck) | CSV file              | `graph` filter        | x-axis is `sweep_dim` |
+|--------------------|------------------------|-----------------------|------------------------|
+| 1 GEMV             | matmul_bench.csv       | `gemv_d`              | d                      |
+| 2 GEMM (d sweep)   | matmul_bench.csv       | `gemm_d`              | d                      |
+| 3 GEMM (M=N sweep) | matmul_bench.csv       | `gemm_mn`             | M=N                    |
+| 4 Attn prefill     | attn_bench.csv         | `attn_prefill_s`      | S                      |
+| 5 Hybrid decode    | attn_bench.csv         | `attn_decode_cache`   | cache_len              |
+
+## Status of third-party backends on this branch
+
+| Backend | Matmul (graphs 1–3) | Attention prefill (graph 4) | Hybrid decode (graph 5) | Kernel kind |
+|---------|---------------------|------------------------------|--------------------------|-------------|
+| **cactus**     | `cactus_int8` (INT8 group=32) | `cactus_prefill` (FP16) | `cactus_decode` (FP16 Q + INT8 KV group=32) | fused |
+| **ggml**       | `ggml_q8_0` (INT8 group=32) | `ggml_fa_q8_prefill` (Q8_0 KV) / `ggml_mm_q8_prefill` (composed) | `ggml_fa_q8_decode` (Q8_0 KV) | fa_*: fused / mm_*: graph |
+| **LiteRT**     | `litert_neon`, `litert_ruy` (INT8 per-channel) | `litert_ruy_prefill` (composed) | `litert_ruy_decode`, `litert_neon_decode` (composed) | matmul-composed (no fused op) |
+| **ONNX RT**    | `onnxrt_int8` (INT8 group=32 via `MatMulNBits`) | `onnxrt_gqa_prefill` (**FP16**, GQA) | `onnxrt_gqa_decode_fp16kv` (**FP16 KV**) | fused (MlasFlashAttention) |
+| **ExecuTorch** | `executorch_int8` (INT8 per-channel via XNNPACK `qc8w`) | `executorch_sdpa_prefill_fp32` (**FP32**) | `executorch_qsdpa_decode_int8pc` (**INT8 per-channel**) | fused |
+
+### How attention is implemented per backend (read this before plotting)
+
+Not every backend ships a fused attention kernel. Three categories exist in
+this bench, and they are NOT all apples-to-apples — call the difference out
+in any plot caption.
+
+| Backend                      | What "attention" means here                                                                                  | Composed in this bench? |
+|------------------------------|--------------------------------------------------------------------------------------------------------------|-------------------------|
+| `cactus_prefill`             | `cactus_attention_f16` — single fused kernel call                                                            | **No**, fused           |
+| `cactus_decode`              | `cactus_attention_hybrid_int8_fp16` — single fused kernel call                                               | **No**, fused           |
+| `ggml_fa_q8_prefill/decode`  | one `ggml_flash_attn_ext` node                                                                               | **No**, fused           |
+| `ggml_mm_q8_prefill`         | three ggml ops (`mul_mat → soft_max_ext → mul_mat`) chained, executed by ggml's graph scheduler              | Yes — via **ggml's graph API** |
+| `litert_ruy_prefill/decode`  | I call `ruy::Mul` directly twice with my own NEON dequant + causal softmax in between                        | **Yes — by me, in C++** |
+| `litert_neon_decode`         | I call `tflite::tensor_utils::MatrixBatchVectorMultiplyAccumulate` directly, with my own softmax             | **Yes — by me, in C++** |
+| `executorch_sdpa_prefill_fp32` | `torch::executor::native::custom_sdpa_out` — single fused kernel                                           | **No**, fused (real FlashAttention impl in `op_sdpa_impl.h`) |
+| `executorch_qsdpa_decode_int8pc` | `custom_quantized_sdpa_out` — single fused kernel                                                        | **No**, fused           |
+| `onnxrt_gqa_prefill/decode`  | one-node ONNX model (`com.microsoft.GroupQueryAttention`); ORT dispatches its own CPU kernel (`MlasFlashAttention` when conditions match) | **No**, fused |
+
+**The only hand-composed-in-C++ attention is the LiteRT triplet.** ggml's
+`mm_q8` is also composed, but at the framework's graph-API level — one
+abstraction layer cleaner than what I do for LiteRT. The other backends
+each call a real fused attention kernel exactly once per attention.
+
+What this means for the LiteRT numbers specifically: a real LiteRT
+deployment would convert a model to `.tflite` and run via `tflite::Interpreter`,
+which executes a MatMul → Softmax → MatMul graph using the same Ruy + NEON
+primitives I'm calling directly. My direct-Ruy approach skips the
+interpreter dispatch overhead, so the LiteRT timings here are slightly
+**optimistic** vs what a real TFLite `.tflite` run would clock.
+
+### Attention precision/scheme map
+
+When plotting graphs 4 and 5, label the precision/scheme to be honest about
+what's being compared:
+
+| Backend / variant | Prefill precision | Decode KV scheme |
+|-------------------|-------------------|------------------|
+| cactus            | FP16              | INT8 per-group(32) |
+| ggml `fa_q8`      | Q8_0 KV (group=32) | Q8_0 KV (group=32) |
+| ggml `mm_q8`      | matmul-composed (Q8_0 KV)  | (decode dropped — wrong output) |
+| litert `ruy_*`    | matmul-composed INT8 per-row | matmul-composed INT8 per-row |
+| litert `neon_decode` | (decode-only path) | matmul-composed INT8 per-row |
+| onnxrt            | FP16              | FP16 KV (no INT8-KV op exists in ORT) |
+| executorch fp32   | FP32              | INT8 per-channel (FP32 accum) |
+
+### Notes
+
+- **LiteRT** has no fused attention op — it's a runtime that executes
+  graphs, not a kernel library. The "attention" entries are hand-composed
+  (Q·Kᵀ → softmax → @V) using LiteRT's INT8 matmul kernels, mirroring
+  ggml's `mm_q8_*` matmul-composed paths.
+- **ONNX Runtime** CPU EP only supports FP16 attention through
+  `com.microsoft.GroupQueryAttention`. `MultiHeadAttention` and
+  `DecoderMaskedMultiHeadAttention` exist on CPU but are FP32-only. There is
+  **no INT8-KV-cache attention op** anywhere in ORT.
+- **ExecuTorch** SDPA lives in `extension/llm/custom_ops/op_sdpa.cpp`
+  (verified to be the only fused CPU attention path in the ExecuTorch /
+  XNNPACK stack). Wired under `WITH_EXECUTORCH_LLM` since it requires the
+  full ExecuTorch runtime (not just XNNPACK).
+- **ggml `mm_q8_decode`** (matmul-composed decode) is registered in source
+  but commented out — it produces wrong output (nrmse=1.24). The flash-
+  attention path (`fa_q8_decode`) is the canonical comparator.
+
+All 12 attention backends and 6 matmul backends have been smoke-tested at
+S=cache=512 with passing accuracy. Plot ready.

--- a/tests/bench/accuracy_test.cpp
+++ b/tests/bench/accuracy_test.cpp
@@ -1,0 +1,170 @@
+// Multi-seed FP32 reference accuracy test for the optimized hybrid INT8/FP16
+// decode kernel. Runs N seeds across multiple cache lengths and reports
+// max nrmse / max-abs vs an FP32 reference.
+
+#include "bench_common.h"
+#include "../../cactus-kernels/cactus_kernels.h"
+
+#include <iomanip>
+#include <iostream>
+#include <random>
+#include <vector>
+
+using namespace bench;
+
+namespace {
+
+struct AccuracyStats {
+    float max_nrmse = 0.0f;
+    float mean_nrmse = 0.0f;
+    float max_abs = 0.0f;
+    int n = 0;
+};
+
+static AccuracyStats run_one(size_t cache_len, int seeds, AttnDims dims) {
+    AccuracyStats out;
+    const size_t kvl = cache_len + 1;
+    const size_t hd = dims.head_dim;
+    const size_t qh = dims.num_q_heads;
+    const size_t kvh = dims.num_kv_heads;
+    const float scale = 1.0f / std::sqrt(static_cast<float>(hd));
+
+    for (int s = 0; s < seeds; ++s) {
+        std::mt19937 gen(0xC0FFEEu + cache_len * 7919u + s * 13u);
+        std::uniform_real_distribution<float> dist(-0.5f, 0.5f);
+
+        // Reference layout: [head, seq, head_dim].
+        std::vector<float> Q_full(qh * 1 * hd);
+        std::vector<float> K_full(kvh * kvl * hd);
+        std::vector<float> V_full(kvh * kvl * hd);
+        for (auto& x : Q_full) x = dist(gen);
+        for (auto& x : K_full) x = dist(gen);
+        for (auto& x : V_full) x = dist(gen);
+
+        // FP32 reference: standard scaled dot-product attention (causal).
+        std::vector<float> ref(qh * hd);
+        reference_attention_fp32(Q_full.data(), K_full.data(), V_full.data(),
+                                 ref.data(), qh, kvh, 1, kvl, hd, scale);
+
+        // Cactus kernel layout: [seq, head, head_dim] — transpose from reference.
+        std::vector<__fp16> q_fp16(qh * hd);
+        for (size_t h = 0; h < qh; ++h)
+            for (size_t d = 0; d < hd; ++d)
+                q_fp16[h * hd + d] = static_cast<__fp16>(Q_full[h * 1 * hd + d]);
+
+        // K/V cache as int8 (group=32) over the first cache_len positions; the
+        // last position (kvl-1) is the new fp16 token. Cactus layout: [kv, head, dim].
+        const size_t groups_per_token = hd / kGroupSize;
+        std::vector<int8_t> k_cached(kvh * cache_len * hd);
+        std::vector<int8_t> v_cached(kvh * cache_len * hd);
+        std::vector<float>  k_scales(kvh * cache_len * groups_per_token);
+        std::vector<float>  v_scales(kvh * cache_len * groups_per_token);
+
+        for (size_t kv = 0; kv < cache_len; ++kv) {
+            for (size_t h = 0; h < kvh; ++h) {
+                // Reference K/V layout: [head, seq, dim] → flat = h * kvl * hd + kv * hd
+                const float* kr = K_full.data() + h * kvl * hd + kv * hd;
+                const float* vr = V_full.data() + h * kvl * hd + kv * hd;
+                // Cactus storage layout: [kv, head, dim].
+                int8_t* kdst = k_cached.data() + (kv * kvh + h) * hd;
+                int8_t* vdst = v_cached.data() + (kv * kvh + h) * hd;
+                float* ksdst = k_scales.data() + (kv * kvh + h) * groups_per_token;
+                float* vsdst = v_scales.data() + (kv * kvh + h) * groups_per_token;
+                for (size_t g = 0; g < groups_per_token; ++g) {
+                    float kmax = 0.0f, vmax = 0.0f;
+                    for (size_t d = 0; d < kGroupSize; ++d) {
+                        kmax = std::max(kmax, std::abs(kr[g * kGroupSize + d]));
+                        vmax = std::max(vmax, std::abs(vr[g * kGroupSize + d]));
+                    }
+                    float ksc = kmax / 127.0f;
+                    float vsc = vmax / 127.0f;
+                    ksdst[g] = ksc;
+                    vsdst[g] = vsc;
+                    float kinv = ksc > 0.0f ? 127.0f / kmax : 0.0f;
+                    float vinv = vsc > 0.0f ? 127.0f / vmax : 0.0f;
+                    for (size_t d = 0; d < kGroupSize; ++d) {
+                        kdst[g * kGroupSize + d] = static_cast<int8_t>(std::lrintf(
+                            std::max(-127.0f, std::min(127.0f, kr[g * kGroupSize + d] * kinv))));
+                        vdst[g * kGroupSize + d] = static_cast<int8_t>(std::lrintf(
+                            std::max(-127.0f, std::min(127.0f, vr[g * kGroupSize + d] * vinv))));
+                    }
+                }
+            }
+        }
+
+        // Last KV position is fp16 new token. Reference layout for that
+        // position is [head, kv=cache_len, dim]; cactus expects [new_pos, head, dim].
+        std::vector<__fp16> k_new(kvh * hd), v_new(kvh * hd);
+        for (size_t h = 0; h < kvh; ++h) {
+            const float* kr = K_full.data() + h * kvl * hd + cache_len * hd;
+            const float* vr = V_full.data() + h * kvl * hd + cache_len * hd;
+            for (size_t d = 0; d < hd; ++d) {
+                k_new[h * hd + d] = static_cast<__fp16>(kr[d]);
+                v_new[h * hd + d] = static_cast<__fp16>(vr[d]);
+            }
+        }
+
+        std::vector<__fp16> out_fp16(qh * hd);
+        cactus_attention_hybrid_int8_fp16(
+            q_fp16.data(),
+            k_cached.data(), v_cached.data(),
+            k_scales.data(), v_scales.data(),
+            k_new.data(), v_new.data(),
+            out_fp16.data(),
+            1, 1, cache_len, 1,
+            qh, kvh, hd,
+            scale, cache_len, true, 0, kGroupSize);
+
+        // Cactus output layout: [seq, head, dim]. Reference layout: [head, seq, dim].
+        std::vector<float> got(qh * hd);
+        for (size_t h = 0; h < qh; ++h)
+            for (size_t d = 0; d < hd; ++d)
+                got[h * 1 * hd + d] = static_cast<float>(out_fp16[h * hd + d]);
+
+        AccuracyResult ar = check_accuracy(ref.data(), got.data(), got.size(), 1.0f);
+        out.max_nrmse = std::max(out.max_nrmse, ar.nrmse);
+        out.mean_nrmse += ar.nrmse;
+        out.max_abs = std::max(out.max_abs, ar.max_abs_error);
+        out.n++;
+    }
+    if (out.n) out.mean_nrmse /= out.n;
+    return out;
+}
+
+} // namespace
+
+int main() {
+    AttnDims dims;
+    dims.head_dim = 128;
+    dims.num_q_heads = 8;
+    dims.num_kv_heads = 8;
+    const std::vector<size_t> cache_lens = {32, 128, 512, 1024, 2048, 4096};
+    const int seeds = 8;
+
+    std::cout << "Hybrid INT8/FP16 decode — accuracy vs FP32 reference\n";
+    std::cout << "head_dim=128 q_heads=8 kv_heads=8 group=" << kGroupSize
+              << " seeds=" << seeds << "\n\n";
+    std::cout << std::left << std::setw(12) << "cache_len"
+              << std::setw(14) << "max_nrmse"
+              << std::setw(14) << "mean_nrmse"
+              << std::setw(14) << "max_abs_err" << "\n";
+    std::cout << std::string(54, '-') << "\n";
+
+    bool all_ok = true;
+    constexpr float kNoiseFloor = 0.005f;  // Empirically int8 group=32 noise floor.
+
+    for (size_t cl : cache_lens) {
+        AccuracyStats st = run_one(cl, seeds, dims);
+        std::cout << std::left << std::setw(12) << cl
+                  << std::fixed << std::setprecision(6)
+                  << std::setw(14) << st.max_nrmse
+                  << std::setw(14) << st.mean_nrmse
+                  << std::setw(14) << st.max_abs << "\n";
+        if (st.max_nrmse > kNoiseFloor) all_ok = false;
+    }
+
+    std::cout << "\nNoise floor threshold: " << kNoiseFloor << "\n";
+    std::cout << (all_ok ? "PASS — within noise floor at all cache lengths\n"
+                         : "FAIL — exceeded noise floor\n");
+    return all_ok ? 0 : 1;
+}

--- a/tests/bench/accuracy_test.cpp
+++ b/tests/bench/accuracy_test.cpp
@@ -21,7 +21,7 @@ struct AccuracyStats {
     int n = 0;
 };
 
-static AccuracyStats run_one(size_t cache_len, int seeds, AttnDims dims) {
+static AccuracyStats run_one(size_t cache_len, int seeds, AttnDims dims, size_t window_size = 0) {
     AccuracyStats out;
     const size_t kvl = cache_len + 1;
     const size_t hd = dims.head_dim;
@@ -41,10 +41,10 @@ static AccuracyStats run_one(size_t cache_len, int seeds, AttnDims dims) {
         for (auto& x : K_full) x = dist(gen);
         for (auto& x : V_full) x = dist(gen);
 
-        // FP32 reference: standard scaled dot-product attention (causal).
+        // FP32 reference: standard scaled dot-product attention (causal, optional window).
         std::vector<float> ref(qh * hd);
         reference_attention_fp32(Q_full.data(), K_full.data(), V_full.data(),
-                                 ref.data(), qh, kvh, 1, kvl, hd, scale);
+                                 ref.data(), qh, kvh, 1, kvl, hd, scale, window_size);
 
         // Cactus kernel layout: [seq, head, head_dim] — transpose from reference.
         std::vector<__fp16> q_fp16(qh * hd);
@@ -113,13 +113,159 @@ static AccuracyStats run_one(size_t cache_len, int seeds, AttnDims dims) {
             out_fp16.data(),
             1, 1, cache_len, 1,
             qh, kvh, hd,
-            scale, cache_len, true, 0, kGroupSize);
+            scale, cache_len, true, window_size, kGroupSize);
 
         // Cactus output layout: [seq, head, dim]. Reference layout: [head, seq, dim].
         std::vector<float> got(qh * hd);
         for (size_t h = 0; h < qh; ++h)
             for (size_t d = 0; d < hd; ++d)
                 got[h * 1 * hd + d] = static_cast<float>(out_fp16[h * hd + d]);
+
+        AccuracyResult ar = check_accuracy(ref.data(), got.data(), got.size(), 1.0f);
+        out.max_nrmse = std::max(out.max_nrmse, ar.nrmse);
+        out.mean_nrmse += ar.nrmse;
+        out.max_abs = std::max(out.max_abs, ar.max_abs_error);
+        out.n++;
+    }
+    if (out.n) out.mean_nrmse /= out.n;
+    return out;
+}
+
+// Mirrors kv_cache_append's ring buffer: slots [0, SINK_SIZE) hold abs positions
+// [0, SINK_SIZE), slots [SINK_SIZE, cache_len) hold the most recent positions.
+static AccuracyStats run_one_rolled(size_t cache_len, size_t roll_offset,
+                                     int seeds, AttnDims dims, size_t window_size) {
+    AccuracyStats out;
+    constexpr size_t SINK_SIZE = 4;  // matches the kernel's hardcoded constant
+    const size_t hd = dims.head_dim;
+    const size_t qh = dims.num_q_heads;
+    const size_t kvh = dims.num_kv_heads;
+    const float scale = 1.0f / std::sqrt(static_cast<float>(hd));
+    const size_t cache_abs_offset = roll_offset;
+    const size_t position_offset = cache_len + cache_abs_offset;  // abs pos of new token
+
+    for (int s = 0; s < seeds; ++s) {
+        std::mt19937 gen(0xC0FFEEu + cache_len * 7919u + s * 13u + roll_offset * 31u);
+        std::uniform_real_distribution<float> dist(-0.5f, 0.5f);
+
+        std::vector<float> Q_full(qh * hd);
+        for (auto& x : Q_full) x = dist(gen);
+
+        auto abs_pos_of_slot = [&](size_t slot) {
+            return slot < SINK_SIZE ? slot : cache_abs_offset + slot;
+        };
+
+        std::vector<float> K_slots(kvh * cache_len * hd), V_slots(kvh * cache_len * hd);
+        for (size_t slot = 0; slot < cache_len; ++slot) {
+            std::mt19937 g2(0xBEEF0u + abs_pos_of_slot(slot) * 9377u + s * 7u);
+            std::uniform_real_distribution<float> d(-0.5f, 0.5f);
+            for (size_t h = 0; h < kvh; ++h)
+                for (size_t i = 0; i < hd; ++i) {
+                    K_slots[h * cache_len * hd + slot * hd + i] = d(g2);
+                    V_slots[h * cache_len * hd + slot * hd + i] = d(g2);
+                }
+        }
+        std::vector<float> K_new(kvh * hd), V_new(kvh * hd);
+        for (auto& x : K_new) x = dist(gen);
+        for (auto& x : V_new) x = dist(gen);
+
+        std::vector<float> ref(qh * hd, 0.0f);
+        const size_t kv_total = cache_len + 1;
+        const size_t kv_start_abs = (window_size > 0 && position_offset > window_size)
+                                    ? position_offset - window_size : 0;
+        for (size_t qhi = 0; qhi < qh; ++qhi) {
+            const size_t kvhi = qhi * kvh / qh;
+            std::vector<double> scores(kv_total, -1e30);
+            double max_score = -1e30;
+            for (size_t slot = 0; slot < kv_total; ++slot) {
+                const size_t abs = (slot < cache_len) ? abs_pos_of_slot(slot) : position_offset;
+                bool window_masked = false;
+                if (window_size > 0 && kv_start_abs > 0 && slot >= SINK_SIZE) {
+                    window_masked = (abs < kv_start_abs);
+                }
+                if (window_masked) continue;
+                double dot = 0.0;
+                const float* k = (slot < cache_len)
+                                 ? &K_slots[kvhi * cache_len * hd + slot * hd]
+                                 : &K_new[kvhi * hd];
+                for (size_t i = 0; i < hd; ++i) dot += Q_full[qhi * hd + i] * k[i];
+                scores[slot] = dot * scale;
+                if (scores[slot] > max_score) max_score = scores[slot];
+            }
+            double sum_exp = 0.0;
+            for (size_t i = 0; i < kv_total; ++i) {
+                if (scores[i] > -1e29) { scores[i] = std::exp(scores[i] - max_score); sum_exp += scores[i]; }
+                else scores[i] = 0.0;
+            }
+            for (size_t i = 0; i < kv_total; ++i) scores[i] /= sum_exp;
+            for (size_t i = 0; i < hd; ++i) {
+                double v = 0.0;
+                for (size_t slot = 0; slot < kv_total; ++slot) {
+                    if (scores[slot] == 0.0) continue;
+                    const float* vptr = (slot < cache_len)
+                                        ? &V_slots[kvhi * cache_len * hd + slot * hd]
+                                        : &V_new[kvhi * hd];
+                    v += scores[slot] * vptr[i];
+                }
+                ref[qhi * hd + i] = static_cast<float>(v);
+            }
+        }
+
+        std::vector<__fp16> q_fp16(qh * hd);
+        for (size_t qhi = 0; qhi < qh; ++qhi)
+            for (size_t i = 0; i < hd; ++i) q_fp16[qhi * hd + i] = static_cast<__fp16>(Q_full[qhi * hd + i]);
+
+        const size_t groups_per_token = hd / kGroupSize;
+        std::vector<int8_t> k_cached(kvh * cache_len * hd), v_cached(kvh * cache_len * hd);
+        std::vector<float>  k_scales_q(kvh * cache_len * groups_per_token);
+        std::vector<float>  v_scales_q(kvh * cache_len * groups_per_token);
+        for (size_t slot = 0; slot < cache_len; ++slot) {
+            for (size_t h = 0; h < kvh; ++h) {
+                const float* kr = &K_slots[h * cache_len * hd + slot * hd];
+                const float* vr = &V_slots[h * cache_len * hd + slot * hd];
+                int8_t* kdst = &k_cached[(slot * kvh + h) * hd];
+                int8_t* vdst = &v_cached[(slot * kvh + h) * hd];
+                float* ksdst = &k_scales_q[(slot * kvh + h) * groups_per_token];
+                float* vsdst = &v_scales_q[(slot * kvh + h) * groups_per_token];
+                for (size_t g = 0; g < groups_per_token; ++g) {
+                    float kmax = 0.0f, vmax = 0.0f;
+                    for (size_t i = 0; i < kGroupSize; ++i) {
+                        kmax = std::max(kmax, std::abs(kr[g * kGroupSize + i]));
+                        vmax = std::max(vmax, std::abs(vr[g * kGroupSize + i]));
+                    }
+                    float ksc = kmax / 127.0f, vsc = vmax / 127.0f;
+                    ksdst[g] = ksc; vsdst[g] = vsc;
+                    float kinv = ksc > 0.0f ? 127.0f / kmax : 0.0f;
+                    float vinv = vsc > 0.0f ? 127.0f / vmax : 0.0f;
+                    for (size_t i = 0; i < kGroupSize; ++i) {
+                        kdst[g * kGroupSize + i] = static_cast<int8_t>(std::lrintf(
+                            std::max(-127.0f, std::min(127.0f, kr[g * kGroupSize + i] * kinv))));
+                        vdst[g * kGroupSize + i] = static_cast<int8_t>(std::lrintf(
+                            std::max(-127.0f, std::min(127.0f, vr[g * kGroupSize + i] * vinv))));
+                    }
+                }
+            }
+        }
+        std::vector<__fp16> k_new_fp16(kvh * hd), v_new_fp16(kvh * hd);
+        for (size_t h = 0; h < kvh; ++h)
+            for (size_t i = 0; i < hd; ++i) {
+                k_new_fp16[h * hd + i] = static_cast<__fp16>(K_new[h * hd + i]);
+                v_new_fp16[h * hd + i] = static_cast<__fp16>(V_new[h * hd + i]);
+            }
+
+        std::vector<__fp16> out_fp16(qh * hd);
+        cactus_attention_hybrid_int8_fp16(
+            q_fp16.data(),
+            k_cached.data(), v_cached.data(),
+            k_scales_q.data(), v_scales_q.data(),
+            k_new_fp16.data(), v_new_fp16.data(),
+            out_fp16.data(),
+            1, 1, cache_len, 1,
+            qh, kvh, hd,
+            scale, position_offset, true, window_size, kGroupSize);
+
+        std::vector<float> got(qh * hd);
+        for (size_t i = 0; i < got.size(); ++i) got[i] = static_cast<float>(out_fp16[i]);
 
         AccuracyResult ar = check_accuracy(ref.data(), got.data(), got.size(), 1.0f);
         out.max_nrmse = std::max(out.max_nrmse, ar.nrmse);
@@ -153,9 +299,33 @@ int main() {
     bool all_ok = true;
     constexpr float kNoiseFloor = 0.005f;  // Empirically int8 group=32 noise floor.
 
+    std::cout << "[no window]\n";
     for (size_t cl : cache_lens) {
-        AccuracyStats st = run_one(cl, seeds, dims);
+        AccuracyStats st = run_one(cl, seeds, dims, 0);
         std::cout << std::left << std::setw(12) << cl
+                  << std::fixed << std::setprecision(6)
+                  << std::setw(14) << st.max_nrmse
+                  << std::setw(14) << st.mean_nrmse
+                  << std::setw(14) << st.max_abs << "\n";
+        if (st.max_nrmse > kNoiseFloor) all_ok = false;
+    }
+
+    std::cout << "\n[sliding window=512, unrolled cache]\n";
+    for (size_t cl : cache_lens) {
+        AccuracyStats st = run_one(cl, seeds, dims, 512);
+        std::cout << std::left << std::setw(12) << cl
+                  << std::fixed << std::setprecision(6)
+                  << std::setw(14) << st.max_nrmse
+                  << std::setw(14) << st.mean_nrmse
+                  << std::setw(14) << st.max_abs << "\n";
+        if (st.max_nrmse > kNoiseFloor) all_ok = false;
+    }
+
+    // Rolled cache: verifies the dispatcher falls back to the general path.
+    std::cout << "\n[sliding window=512, rolled cache (cl=511, roll=128/512/2048)]\n";
+    for (size_t roll : {size_t(128), size_t(512), size_t(2048)}) {
+        AccuracyStats st = run_one_rolled(511, roll, seeds, dims, 512);
+        std::cout << "roll=" << std::left << std::setw(7) << roll
                   << std::fixed << std::setprecision(6)
                   << std::setw(14) << st.max_nrmse
                   << std::setw(14) << st.mean_nrmse

--- a/tests/bench/attn_bench.cpp
+++ b/tests/bench/attn_bench.cpp
@@ -1,0 +1,28 @@
+#include "bench_common.h"
+#include "bench_driver.h"
+
+#include <iostream>
+
+int main(int argc, char** argv) {
+    bench::AttnBenchOptions opt;
+    std::string err;
+    if (!bench::parse_attn_bench_args(argc, argv, opt, err)) {
+        std::cerr << "Error: " << err << "\n"
+                  << "Usage: " << argv[0]
+                  << " [--iterations N] [--warmup N]\n"
+                  << "       [--graphs attn_prefill_s,attn_decode_cache]\n"
+                  << "       [--dims 128,256,...] [--model_dim N] [--heads N]\n"
+                  << "       [--backends fw1,fw2] [--threads N|max] [--csv path]\n";
+        return 1;
+    }
+
+    const auto& backends = bench::get_attn_backends();
+    std::cout << "Registered attention backends: " << backends.size() << "\n";
+    for (const auto& b : backends) {
+        std::cout << "  " << b.name << " (" << b.framework << ", "
+                  << (b.mode == bench::AttnMode::PREFILL ? "prefill" : "decode") << ")\n";
+    }
+
+    if (!bench::run_attn_benchmark(opt)) return 1;
+    return 0;
+}

--- a/tests/bench/attn_bench.cpp
+++ b/tests/bench/attn_bench.cpp
@@ -11,7 +11,7 @@ int main(int argc, char** argv) {
                   << "Usage: " << argv[0]
                   << " [--iterations N] [--warmup N]\n"
                   << "       [--graphs attn_prefill_s,attn_decode_cache]\n"
-                  << "       [--dims 128,256,...] [--model_dim N] [--heads N]\n"
+                  << "       [--dims 128,256,...] [--model_dim N] [--heads N] [--kv_heads N] [--head_dim N]\n"
                   << "       [--backends fw1,fw2] [--threads N|max] [--csv path]\n";
         return 1;
     }

--- a/tests/bench/backend_cactus.cpp
+++ b/tests/bench/backend_cactus.cpp
@@ -1,0 +1,228 @@
+#include "bench_driver.h"
+
+#include "../../cactus-kernels/cactus_kernels.h"
+#include "../../cactus-kernels/src/threading.h"
+
+#include <arm_neon.h>
+#include <cmath>
+#include <cstring>
+
+namespace {
+
+// ── Matmul ──────────────────────────────────────────────────────────────────
+
+namespace matmul {
+
+struct Weights {
+    size_t K = 0, N = 0;
+    std::vector<int8_t> int8_weights;
+    std::vector<__fp16> scales;
+    std::vector<__fp16> output_buf;
+};
+
+void* prepare_int8(const float* fp32, size_t N, size_t K) {
+    auto* w = new Weights();
+    w->K = K;
+    w->N = N;
+
+    std::vector<float> src(fp32, fp32 + N * K);
+    std::vector<int8_t> rowmajor;
+    std::vector<float> raw_scales;
+
+    bench::quantize_int8_per_group(src, N, K, rowmajor, raw_scales);
+    w->int8_weights = bench::interleave_weights_nk4(rowmajor, N, K);
+    w->scales = bench::interleave_scales_n4(raw_scales, N, K / bench::kGroupSize);
+    return w;
+}
+
+void run_kernel(size_t M, size_t K, size_t N,
+                void* weights, void*,
+                const int8_t* act_int8, const float* act_scales,
+                float* output, float*) {
+    auto* w = static_cast<Weights*>(weights);
+    w->output_buf.assign(M * w->N, __fp16(0.0f));
+
+    int thr = bench::get_thread_override();
+    if (thr > 0) CactusThreading::set_gemm_threads(static_cast<size_t>(thr));
+
+    if (M == 1) {
+        cactus_gemv_int8(act_int8, act_scales[0],
+                         w->int8_weights.data(), w->scales.data(),
+                         w->output_buf.data(), K, N, bench::kGroupSize);
+    } else {
+        cactus_matmul_int8(act_int8, act_scales,
+                           w->int8_weights.data(), w->scales.data(),
+                           w->output_buf.data(), M, K, N, bench::kGroupSize);
+    }
+
+    if (thr > 0) CactusThreading::reset_gemm_threads();
+
+    if (output) {
+        size_t count = M * w->N;
+        bench::fp16_to_fp32(w->output_buf.data(), output, count);
+    }
+}
+
+void cleanup(void* weights, void*) {
+    delete static_cast<Weights*>(weights);
+}
+
+} // namespace matmul
+
+// ── Attention ───────────────────────────────────────────────────────────────
+
+namespace attn {
+
+struct State {
+    bench::AttnDims dims;
+    bench::AttnMode mode;
+    size_t seq_len = 0;
+    size_t cache_len = 0;
+    float scale = 0.0f;
+    std::vector<__fp16> q, k, v, output;
+    std::vector<__fp16> k_new, v_new;
+    std::vector<int8_t> k_cached, v_cached;
+    std::vector<float> k_scales, v_scales;
+};
+
+// Driver layout for Q/K/V is [head, seq, head_dim].
+// Cactus prefill expects [batch, seq, head, head_dim] (= [seq, head, head_dim] when batch=1).
+static void transpose_seq_head(const float* src, __fp16* dst,
+                                size_t heads, size_t seq, size_t head_dim) {
+    for (size_t s = 0; s < seq; ++s)
+        for (size_t h = 0; h < heads; ++h) {
+            const float* in = src + h * seq * head_dim + s * head_dim;
+            __fp16* out = dst + s * heads * head_dim + h * head_dim;
+            for (size_t d = 0; d < head_dim; ++d)
+                out[d] = static_cast<__fp16>(in[d]);
+        }
+}
+
+static void transpose_back(const __fp16* src, float* dst,
+                            size_t heads, size_t seq, size_t head_dim) {
+    for (size_t h = 0; h < heads; ++h)
+        for (size_t s = 0; s < seq; ++s) {
+            const __fp16* in = src + s * heads * head_dim + h * head_dim;
+            float* out = dst + h * seq * head_dim + s * head_dim;
+            for (size_t d = 0; d < head_dim; ++d)
+                out[d] = static_cast<float>(in[d]);
+        }
+}
+
+static void* prepare_impl(const bench::AttnDims& dims, size_t seq_len, size_t cache_len,
+                           const float* fp32_q, const float* fp32_k, const float* fp32_v,
+                           bench::AttnMode mode) {
+    auto* s = new State();
+    s->dims = dims;
+    s->mode = mode;
+    s->scale = 1.0f / std::sqrt(static_cast<float>(dims.head_dim));
+
+    if (mode == bench::AttnMode::PREFILL) {
+        s->seq_len = seq_len;
+        size_t q_count = dims.num_q_heads * seq_len * dims.head_dim;
+        size_t kv_count = dims.num_kv_heads * seq_len * dims.head_dim;
+
+        s->q.resize(q_count);
+        s->k.resize(kv_count);
+        s->v.resize(kv_count);
+        s->output.resize(q_count);
+
+        transpose_seq_head(fp32_q, s->q.data(), dims.num_q_heads,  seq_len, dims.head_dim);
+        transpose_seq_head(fp32_k, s->k.data(), dims.num_kv_heads, seq_len, dims.head_dim);
+        transpose_seq_head(fp32_v, s->v.data(), dims.num_kv_heads, seq_len, dims.head_dim);
+    } else {
+        s->seq_len = 1;
+        s->cache_len = cache_len;
+        size_t q_count = dims.num_q_heads * dims.head_dim;
+        size_t kv_per_token = dims.num_kv_heads * dims.head_dim;
+        size_t kv_seq_len = cache_len + 1;
+        size_t kv_total = dims.num_kv_heads * kv_seq_len * dims.head_dim;
+
+        s->q.resize(q_count);
+        bench::fp32_to_fp16(fp32_q, s->q.data(), q_count);
+
+        s->k_new.resize(kv_per_token);
+        s->v_new.resize(kv_per_token);
+        s->output.resize(q_count);
+
+        std::vector<__fp16> full_k(kv_total), full_v(kv_total);
+        transpose_seq_head(fp32_k, full_k.data(), dims.num_kv_heads, kv_seq_len, dims.head_dim);
+        transpose_seq_head(fp32_v, full_v.data(), dims.num_kv_heads, kv_seq_len, dims.head_dim);
+
+        size_t cached_elements = cache_len * kv_per_token;
+        s->k_cached.resize(cached_elements);
+        s->v_cached.resize(cached_elements);
+
+        size_t sc = kv_scales_count(cache_len, dims.num_kv_heads, dims.head_dim);
+        s->k_scales.resize(sc);
+        s->v_scales.resize(sc);
+
+        cactus_quantize_kv_fp16_to_int8(full_k.data(), s->k_cached.data(), s->k_scales.data(),
+                                         cache_len, dims.num_kv_heads, dims.head_dim);
+        cactus_quantize_kv_fp16_to_int8(full_v.data(), s->v_cached.data(), s->v_scales.data(),
+                                         cache_len, dims.num_kv_heads, dims.head_dim);
+
+        size_t new_offset = cached_elements;
+        std::memcpy(s->k_new.data(), full_k.data() + new_offset, kv_per_token * sizeof(__fp16));
+        std::memcpy(s->v_new.data(), full_v.data() + new_offset, kv_per_token * sizeof(__fp16));
+    }
+    return s;
+}
+
+void* prepare_prefill(const bench::AttnDims& d, size_t sl, size_t cl,
+                      const float* q, const float* k, const float* v) {
+    return prepare_impl(d, sl, cl, q, k, v, bench::AttnMode::PREFILL);
+}
+void* prepare_decode(const bench::AttnDims& d, size_t sl, size_t cl,
+                     const float* q, const float* k, const float* v) {
+    return prepare_impl(d, sl, cl, q, k, v, bench::AttnMode::DECODE);
+}
+
+void run(void* state, float* output) {
+    auto* s = static_cast<State*>(state);
+
+    if (s->mode == bench::AttnMode::PREFILL) {
+        cactus_attention_f16(s->q.data(), s->k.data(), s->v.data(), s->output.data(),
+                              1, s->seq_len, s->seq_len,
+                              s->dims.num_q_heads, s->dims.num_kv_heads,
+                              s->dims.head_dim, s->scale, nullptr, 0, 0, true);
+    } else {
+        cactus_attention_hybrid_int8_fp16(
+            s->q.data(),
+            s->k_cached.data(), s->v_cached.data(),
+            s->k_scales.data(), s->v_scales.data(),
+            s->k_new.data(), s->v_new.data(),
+            s->output.data(),
+            1, 1, s->cache_len, 1,
+            s->dims.num_q_heads, s->dims.num_kv_heads, s->dims.head_dim,
+            s->scale, s->cache_len, true, 0, bench::kGroupSize);
+    }
+
+    if (output)
+        transpose_back(s->output.data(), output,
+                       s->dims.num_q_heads, s->seq_len, s->dims.head_dim);
+}
+
+void cleanup(void* state) { delete static_cast<State*>(state); }
+
+} // namespace attn
+
+// ── Registration ────────────────────────────────────────────────────────────
+
+static int reg = []{
+    bench::register_matmul_backend({
+        "cactus_int8", "cactus",
+        matmul::prepare_int8, nullptr, matmul::run_kernel, matmul::cleanup
+    });
+    bench::register_attn_backend({
+        "cactus_prefill", "cactus", bench::AttnMode::PREFILL,
+        attn::prepare_prefill, attn::run, attn::cleanup
+    });
+    bench::register_attn_backend({
+        "cactus_decode", "cactus", bench::AttnMode::DECODE,
+        attn::prepare_decode, attn::run, attn::cleanup
+    });
+    return 0;
+}();
+
+} // namespace

--- a/tests/bench/backend_cactus.cpp
+++ b/tests/bench/backend_cactus.cpp
@@ -9,8 +9,6 @@
 
 namespace {
 
-// ── Matmul ──────────────────────────────────────────────────────────────────
-
 namespace matmul {
 
 struct Weights {
@@ -69,8 +67,6 @@ void cleanup(void* weights, void*) {
 
 } // namespace matmul
 
-// ── Attention ───────────────────────────────────────────────────────────────
-
 namespace attn {
 
 struct State {
@@ -85,8 +81,7 @@ struct State {
     std::vector<float> k_scales, v_scales;
 };
 
-// Driver layout for Q/K/V is [head, seq, head_dim].
-// Cactus prefill expects [batch, seq, head, head_dim] (= [seq, head, head_dim] when batch=1).
+// Driver layout [head, seq, head_dim] → cactus prefill layout [seq, head, head_dim] (batch=1).
 static void transpose_seq_head(const float* src, __fp16* dst,
                                 size_t heads, size_t seq, size_t head_dim) {
     for (size_t s = 0; s < seq; ++s)
@@ -206,8 +201,6 @@ void run(void* state, float* output) {
 void cleanup(void* state) { delete static_cast<State*>(state); }
 
 } // namespace attn
-
-// ── Registration ────────────────────────────────────────────────────────────
 
 static int reg = []{
     bench::register_matmul_backend({

--- a/tests/bench/backend_executorch.cpp
+++ b/tests/bench/backend_executorch.cpp
@@ -149,16 +149,11 @@ namespace { [[maybe_unused]] static int reg_xnn = []{ return 0; }(); }
 
 #endif // WITH_EXECUTORCH
 
-
-// ── ExecuTorch fused-attention backends (extension/llm/custom_ops) ──────────
-// Separate flag (WITH_EXECUTORCH_LLM) because this requires a built ExecuTorch
-// tree, not just XNNPACK. Uses torch::executor::native::custom_sdpa_out for
-// FP32 prefill (graph 4) and custom_quantized_sdpa_out for INT8 per-channel
-// decode (graph 5). Both paths are precision/scheme-asymmetric vs cactus:
-//   • cactus prefill is FP16; ET custom_sdpa is FP32-only.
-//   • cactus decode uses FP16 Q + INT8 KV with per-group(32) scales; ET
-//     custom_quantized_sdpa uses INT8 Q/K/V with per-channel scales.
-// Backend names include the precision/scheme tag so plot legends stay honest.
+// WITH_EXECUTORCH_LLM is separate from WITH_EXECUTORCH because the LLM custom
+// ops require a built ExecuTorch tree, not just XNNPACK. cactus prefill is
+// FP16 vs ET custom_sdpa FP32-only; cactus decode is FP16 Q + INT8 KV
+// per-group(32) vs ET custom_quantized_sdpa INT8 Q/K/V per-channel — the
+// asymmetry is reflected in the backend names.
 
 #ifdef WITH_EXECUTORCH_LLM
 
@@ -181,23 +176,18 @@ using et::runtime::KernelRuntimeContext;
 using etext::TensorPtr;
 using etext::make_tensor_ptr;
 
-// ── FP32 prefill (graph 4) ──────────────────────────────────────────────────
-// Driver supplies Q/K/V as FP32 in [head, seq, head_dim]. custom_sdpa_out
-// expects BSNH = [B, S, N, H] (no is_seq_at_dim_1 flag exists for the
-// non-quantized variant; default is BSNH per op_sdpa.cpp).
-//
-// We transpose driver buffers to BSNH at prepare-time.
+// custom_sdpa_out has no is_seq_at_dim_1 flag (the default BSNH is hard-coded
+// per op_sdpa.cpp), so we must transpose driver's BNSH buffers to BSNH.
 
 namespace et_attn_prefill {
 
 struct State {
     bench::AttnDims dims;
     size_t seq_len = 0;
-    std::vector<float> q, k, v;     // BSNH layout
-    std::vector<float> out;          // BSNH layout from kernel
+    std::vector<float> q, k, v;
+    std::vector<float> out;
 };
 
-// [head, seq, head_dim] (BNSH with B=1) → [seq, head, head_dim] (BSNH with B=1).
 static void transpose_bnsh_to_bsnh(const float* src, float* dst,
                                     size_t heads, size_t seq, size_t head_dim) {
     for (size_t s = 0; s < seq; ++s)
@@ -207,7 +197,6 @@ static void transpose_bnsh_to_bsnh(const float* src, float* dst,
             std::memcpy(out, in, head_dim * sizeof(float));
         }
 }
-// Inverse for output.
 static void transpose_bsnh_to_bnsh(const float* src, float* dst,
                                     size_t heads, size_t seq, size_t head_dim) {
     for (size_t h = 0; h < heads; ++h)
@@ -245,7 +234,6 @@ void run(void* state, float* output) {
     SZ S = static_cast<SZ>(s->seq_len);
     SZ D = static_cast<SZ>(d.head_dim);
 
-    // BSNH shape: [B, S, num_heads, head_dim]
     auto q_t = make_tensor_ptr({B, S, Hq,  D}, s->q.data(),  ScalarType::Float);
     auto k_t = make_tensor_ptr({B, S, Hkv, D}, s->k.data(),  ScalarType::Float);
     auto v_t = make_tensor_ptr({B, S, Hkv, D}, s->v.data(),  ScalarType::Float);
@@ -273,38 +261,30 @@ void cleanup(void* state) { delete static_cast<State*>(state); }
 
 } // namespace et_attn_prefill
 
-// ── INT8 per-channel decode (graph 5) ───────────────────────────────────────
-// Quantize Q (1 token), K and V (cache_len+1 tokens) per-row in BSNH layout.
-// Per-channel scale = one scale per [B, S, N] row (per head_dim vector).
-// Symmetric INT8 (zero_point=0). BSNH layout = is_seq_at_dim_1=true.
-
 namespace et_attn_decode_q8pc {
 
 struct State {
     bench::AttnDims dims;
     size_t kv_seq_len = 0;
-    // BNSH layout for data (matches driver's [head, seq, head_dim] directly).
-    // Scales/zp: 4D [B, N, S, 1].
-    //
-    // The header (op_sdpa.h) declares this last bool parameter as
+    // The header (op_sdpa.h) declares the last bool parameter as
     // `is_seq_at_dim_1`, but the implementation (op_sdpa.cpp) renames the
     // same parameter to `is_seq_at_dim_2` in its body. The body's name
     // describes the actual behavior: passing `true` selects `SeqDim::TWO`
     // (BNSH = seq at dim 2). We pass `true` to match our BNSH buffer.
+    // Scales/zp must be 4D matching the first N-1 dims of the data tensor
+    // ([B, N, S, 1]); zero-points must be Char (INT8).
     std::vector<int8_t> q_int8, k_int8, v_int8;
     std::vector<float>  q_scales, k_scales, v_scales;
     std::vector<int8_t> q_zp, k_zp, v_zp;
     std::vector<float>  out;
 };
 
-// Quantize per-row from driver layout [head, seq, head_dim] (= BNSH B=1)
-// directly — no transpose. Scales/zp produced in [N, S, 1] order to match.
 static void quantize_bnsh(const float* src, size_t heads, size_t seq, size_t head_dim,
                            int8_t* q_out, float* scales_out, int8_t* zp_out) {
     for (size_t h = 0; h < heads; ++h) {
         for (size_t s = 0; s < seq; ++s) {
             const float* in = src + (h * seq + s) * head_dim;
-            const size_t row_idx = h * seq + s;     // BNSH row index (B=1)
+            const size_t row_idx = h * seq + s;
             int8_t* qrow = q_out + row_idx * head_dim;
             float max_abs = 0.0f;
             for (size_t d = 0; d < head_dim; ++d) max_abs = std::max(max_abs, std::abs(in[d]));
@@ -356,11 +336,9 @@ void run(void* state, float* output) {
     SZ KVL = static_cast<SZ>(s->kv_seq_len);
     SZ D = static_cast<SZ>(d.head_dim);
 
-    // BNSH for data tensors (driver layout, no transpose).
     auto q_t  = make_tensor_ptr({B, Hq,  S,   D}, s->q_int8.data(), ScalarType::Char);
     auto k_t  = make_tensor_ptr({B, Hkv, KVL, D}, s->k_int8.data(), ScalarType::Char);
     auto v_t  = make_tensor_ptr({B, Hkv, KVL, D}, s->v_int8.data(), ScalarType::Char);
-    // Scales/zp same rank as data, BNSH-aligned: [B, N, S, 1].
     auto qs_t = make_tensor_ptr({B, Hq,  S,   1}, s->q_scales.data(), ScalarType::Float);
     auto ks_t = make_tensor_ptr({B, Hkv, KVL, 1}, s->k_scales.data(), ScalarType::Float);
     auto vs_t = make_tensor_ptr({B, Hkv, KVL, 1}, s->v_scales.data(), ScalarType::Float);
@@ -381,17 +359,15 @@ void run(void* state, float* output) {
         /*start_pos*/ static_cast<int64_t>(s->kv_seq_len - 1),
         no_mask,
         /*dropout_p*/ 0.0,
-        /*is_causal*/ true,          // shifted causal mask aligned to start_pos
+        /*is_causal*/ true,
         scale,
         qz, qs,
         kz, ks,
         vz, vs,
-        /*is_seq_at_dim_1*/ true,    // BNSH. Header param name vs impl body
+        /*is_seq_at_dim_1*/ true,    // BNSH; header param name vs impl body
                                      // disagree (see struct comment above).
         *o_t);
 
-    // Output is BSNH [1, 1, Hq, D]. With seq=1 it's the same memory layout
-    // as driver's [head, seq, head_dim]; just copy.
     if (output)
         std::memcpy(output, s->out.data(), s->out.size() * sizeof(float));
 }

--- a/tests/bench/backend_executorch.cpp
+++ b/tests/bench/backend_executorch.cpp
@@ -1,0 +1,421 @@
+#include "bench_driver.h"
+
+#ifdef WITH_EXECUTORCH
+
+#include <xnnpack.h>
+#include <pthreadpool.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <limits>
+#include <vector>
+
+namespace {
+
+static bool s_initialized = false;
+static pthreadpool_t s_threadpool = nullptr;
+static size_t s_threadpool_threads = 0;
+
+static bool ensure_init() {
+    if (!s_initialized) {
+        if (xnn_initialize(nullptr) != xnn_status_success) {
+            fprintf(stderr, "[executorch] xnn_initialize failed\n");
+            return false;
+        }
+        s_threadpool = pthreadpool_create(0);
+        s_threadpool_threads = 0;
+        s_initialized = true;
+    }
+    return true;
+}
+
+static void ensure_threadpool(int num_threads) {
+    size_t target = (num_threads > 0) ? static_cast<size_t>(num_threads) : 0;
+    if (target == s_threadpool_threads) return;
+    if (s_threadpool) pthreadpool_destroy(s_threadpool);
+    s_threadpool = pthreadpool_create(target);
+    s_threadpool_threads = target;
+}
+
+static void* aligned_alloc_workspace(size_t size) {
+    if (size == 0) return nullptr;
+    void* ptr = nullptr;
+    posix_memalign(&ptr, 64, size);
+    return ptr;
+}
+
+static void fill_qparams(struct xnn_quantization_params* qp, size_t M,
+                          const float* act_scales) {
+    for (size_t m = 0; m < M; ++m) {
+        qp[m].zero_point = 0;
+        qp[m].scale = act_scales[m];
+    }
+    for (size_t m = M; m < M + XNN_EXTRA_QUANTIZATION_PARAMS; ++m)
+        qp[m] = qp[M ? M - 1 : 0];
+}
+
+struct XnnWeights {
+    size_t K = 0, N = 0;
+    xnn_operator_t op = nullptr;
+    size_t current_M = 0;
+    size_t workspace_size = 0;
+    void* workspace = nullptr;
+    std::vector<struct xnn_quantization_params> qp_buf;
+    std::vector<float> output_buf;
+};
+
+static void reshape(XnnWeights* w, size_t M) {
+    size_t ws = 0;
+    xnn_reshape_fully_connected_nc_qd8_f32_qc8w(w->op, M, &ws, s_threadpool);
+    if (ws > w->workspace_size) {
+        free(w->workspace);
+        w->workspace = aligned_alloc_workspace(ws);
+        w->workspace_size = ws;
+    }
+    if (w->qp_buf.size() < M + XNN_EXTRA_QUANTIZATION_PARAMS)
+        w->qp_buf.resize(M + XNN_EXTRA_QUANTIZATION_PARAMS);
+    w->current_M = M;
+}
+
+void run_kernel(size_t M, size_t /*K*/, size_t /*N*/,
+                void* weights, void*,
+                const int8_t* act, const float* act_scales,
+                float* output, float*) {
+    auto* w = static_cast<XnnWeights*>(weights);
+    if (!w || !w->op) return;
+
+    int thr = bench::get_thread_override();
+    if (thr > 0) ensure_threadpool(thr);
+
+    w->output_buf.resize(M * w->N);
+    if (w->current_M != M) reshape(w, M);
+    fill_qparams(w->qp_buf.data(), M, act_scales);
+    xnn_setup_fully_connected_nc_qd8_f32_qc8w(
+        w->op, act, w->output_buf.data(), w->workspace, w->qp_buf.data());
+    xnn_run_operator(w->op, s_threadpool);
+    if (output)
+        std::memcpy(output, w->output_buf.data(), M * w->N * sizeof(float));
+}
+
+void cleanup(void* weights, void*) {
+    auto* w = static_cast<XnnWeights*>(weights);
+    if (w) {
+        if (w->op) xnn_delete_operator(w->op);
+        free(w->workspace);
+        delete w;
+    }
+}
+
+void* int8_prepare(const float* fp32, size_t N, size_t K) {
+    if (!ensure_init()) return nullptr;
+
+    std::vector<int8_t> qw(N * K);
+    std::vector<float> scales(N);
+    bench::quantize_rows_int8(fp32, qw.data(), scales.data(), N, K);
+
+    auto* w = new XnnWeights();
+    w->K = K;
+    w->N = N;
+    xnn_status st = xnn_create_fully_connected_nc_qd8_f32_qc8w(
+        K, N, K, N,
+        scales.data(), qw.data(), nullptr,
+        -std::numeric_limits<float>::infinity(),
+        std::numeric_limits<float>::infinity(),
+        0, nullptr, &w->op);
+    if (st != xnn_status_success) {
+        fprintf(stderr, "[executorch_int8] create failed (%d)\n", static_cast<int>(st));
+        delete w;
+        return nullptr;
+    }
+    return w;
+}
+
+static int reg = [] {
+    bench::register_matmul_backend({
+        "executorch_int8", "executorch",
+        int8_prepare, nullptr, run_kernel, cleanup
+    });
+    return 0;
+}();
+
+} // namespace
+
+#else  // !WITH_EXECUTORCH
+
+namespace { [[maybe_unused]] static int reg_xnn = []{ return 0; }(); }
+
+#endif // WITH_EXECUTORCH
+
+
+// ── ExecuTorch fused-attention backends (extension/llm/custom_ops) ──────────
+// Separate flag (WITH_EXECUTORCH_LLM) because this requires a built ExecuTorch
+// tree, not just XNNPACK. Uses torch::executor::native::custom_sdpa_out for
+// FP32 prefill (graph 4) and custom_quantized_sdpa_out for INT8 per-channel
+// decode (graph 5). Both paths are precision/scheme-asymmetric vs cactus:
+//   • cactus prefill is FP16; ET custom_sdpa is FP32-only.
+//   • cactus decode uses FP16 Q + INT8 KV with per-group(32) scales; ET
+//     custom_quantized_sdpa uses INT8 Q/K/V with per-channel scales.
+// Backend names include the precision/scheme tag so plot legends stay honest.
+
+#ifdef WITH_EXECUTORCH_LLM
+
+#include <executorch/runtime/core/exec_aten/exec_aten.h>
+#include <executorch/runtime/kernel/kernel_runtime_context.h>
+#include <executorch/extension/llm/custom_ops/op_sdpa.h>
+#include <executorch/extension/tensor/tensor.h>
+
+#include <cmath>
+#include <cstring>
+#include <vector>
+
+namespace {
+
+namespace et = ::executorch;
+namespace etext = ::executorch::extension;
+using et::aten::ScalarType;
+using et::aten::Tensor;
+using et::runtime::KernelRuntimeContext;
+using etext::TensorPtr;
+using etext::make_tensor_ptr;
+
+// ── FP32 prefill (graph 4) ──────────────────────────────────────────────────
+// Driver supplies Q/K/V as FP32 in [head, seq, head_dim]. custom_sdpa_out
+// expects BSNH = [B, S, N, H] (no is_seq_at_dim_1 flag exists for the
+// non-quantized variant; default is BSNH per op_sdpa.cpp).
+//
+// We transpose driver buffers to BSNH at prepare-time.
+
+namespace et_attn_prefill {
+
+struct State {
+    bench::AttnDims dims;
+    size_t seq_len = 0;
+    std::vector<float> q, k, v;     // BSNH layout
+    std::vector<float> out;          // BSNH layout from kernel
+};
+
+// [head, seq, head_dim] (BNSH with B=1) → [seq, head, head_dim] (BSNH with B=1).
+static void transpose_bnsh_to_bsnh(const float* src, float* dst,
+                                    size_t heads, size_t seq, size_t head_dim) {
+    for (size_t s = 0; s < seq; ++s)
+        for (size_t h = 0; h < heads; ++h) {
+            const float* in = src + h * seq * head_dim + s * head_dim;
+            float* out = dst + s * heads * head_dim + h * head_dim;
+            std::memcpy(out, in, head_dim * sizeof(float));
+        }
+}
+// Inverse for output.
+static void transpose_bsnh_to_bnsh(const float* src, float* dst,
+                                    size_t heads, size_t seq, size_t head_dim) {
+    for (size_t h = 0; h < heads; ++h)
+        for (size_t s = 0; s < seq; ++s) {
+            const float* in = src + s * heads * head_dim + h * head_dim;
+            float* out = dst + h * seq * head_dim + s * head_dim;
+            std::memcpy(out, in, head_dim * sizeof(float));
+        }
+}
+
+void* prepare(const bench::AttnDims& dims, size_t seq_len, size_t /*cache_len*/,
+              const float* fp32_q, const float* fp32_k, const float* fp32_v) {
+    auto* s = new State();
+    s->dims = dims;
+    s->seq_len = seq_len;
+    size_t q_count = dims.num_q_heads  * seq_len * dims.head_dim;
+    size_t k_count = dims.num_kv_heads * seq_len * dims.head_dim;
+    s->q.resize(q_count);
+    s->k.resize(k_count);
+    s->v.resize(k_count);
+    s->out.assign(q_count, 0.0f);
+    transpose_bnsh_to_bsnh(fp32_q, s->q.data(), dims.num_q_heads,  seq_len, dims.head_dim);
+    transpose_bnsh_to_bsnh(fp32_k, s->k.data(), dims.num_kv_heads, seq_len, dims.head_dim);
+    transpose_bnsh_to_bsnh(fp32_v, s->v.data(), dims.num_kv_heads, seq_len, dims.head_dim);
+    return s;
+}
+
+void run(void* state, float* output) {
+    auto* s = static_cast<State*>(state);
+    const auto& d = s->dims;
+    using SZ = ::executorch::aten::SizesType;
+    SZ B = 1;
+    SZ Hq = static_cast<SZ>(d.num_q_heads);
+    SZ Hkv = static_cast<SZ>(d.num_kv_heads);
+    SZ S = static_cast<SZ>(s->seq_len);
+    SZ D = static_cast<SZ>(d.head_dim);
+
+    // BSNH shape: [B, S, num_heads, head_dim]
+    auto q_t = make_tensor_ptr({B, S, Hq,  D}, s->q.data(),  ScalarType::Float);
+    auto k_t = make_tensor_ptr({B, S, Hkv, D}, s->k.data(),  ScalarType::Float);
+    auto v_t = make_tensor_ptr({B, S, Hkv, D}, s->v.data(),  ScalarType::Float);
+    auto o_t = make_tensor_ptr({B, S, Hq,  D}, s->out.data(), ScalarType::Float);
+
+    KernelRuntimeContext ctx;
+    et::aten::optional<Tensor> no_mask;
+    et::aten::optional<double> scale = static_cast<double>(1.0 / std::sqrt(static_cast<float>(d.head_dim)));
+
+    ::torch::executor::native::custom_sdpa_out(
+        ctx, *q_t, *k_t, *v_t,
+        /*start_pos*/ 0,
+        no_mask,
+        /*dropout_p*/ 0.0,
+        /*is_causal*/ true,
+        scale,
+        *o_t);
+
+    if (output)
+        transpose_bsnh_to_bnsh(s->out.data(), output,
+                                d.num_q_heads, s->seq_len, d.head_dim);
+}
+
+void cleanup(void* state) { delete static_cast<State*>(state); }
+
+} // namespace et_attn_prefill
+
+// ── INT8 per-channel decode (graph 5) ───────────────────────────────────────
+// Quantize Q (1 token), K and V (cache_len+1 tokens) per-row in BSNH layout.
+// Per-channel scale = one scale per [B, S, N] row (per head_dim vector).
+// Symmetric INT8 (zero_point=0). BSNH layout = is_seq_at_dim_1=true.
+
+namespace et_attn_decode_q8pc {
+
+struct State {
+    bench::AttnDims dims;
+    size_t kv_seq_len = 0;
+    // BNSH layout for data (matches driver's [head, seq, head_dim] directly).
+    // Scales/zp: 4D [B, N, S, 1].
+    //
+    // The header (op_sdpa.h) declares this last bool parameter as
+    // `is_seq_at_dim_1`, but the implementation (op_sdpa.cpp) renames the
+    // same parameter to `is_seq_at_dim_2` in its body. The body's name
+    // describes the actual behavior: passing `true` selects `SeqDim::TWO`
+    // (BNSH = seq at dim 2). We pass `true` to match our BNSH buffer.
+    std::vector<int8_t> q_int8, k_int8, v_int8;
+    std::vector<float>  q_scales, k_scales, v_scales;
+    std::vector<int8_t> q_zp, k_zp, v_zp;
+    std::vector<float>  out;
+};
+
+// Quantize per-row from driver layout [head, seq, head_dim] (= BNSH B=1)
+// directly — no transpose. Scales/zp produced in [N, S, 1] order to match.
+static void quantize_bnsh(const float* src, size_t heads, size_t seq, size_t head_dim,
+                           int8_t* q_out, float* scales_out, int8_t* zp_out) {
+    for (size_t h = 0; h < heads; ++h) {
+        for (size_t s = 0; s < seq; ++s) {
+            const float* in = src + (h * seq + s) * head_dim;
+            const size_t row_idx = h * seq + s;     // BNSH row index (B=1)
+            int8_t* qrow = q_out + row_idx * head_dim;
+            float max_abs = 0.0f;
+            for (size_t d = 0; d < head_dim; ++d) max_abs = std::max(max_abs, std::abs(in[d]));
+            float scale = std::max(max_abs / 127.0f, 1e-10f);
+            float inv = 1.0f / scale;
+            scales_out[row_idx] = scale;
+            zp_out[row_idx] = 0;
+            for (size_t d = 0; d < head_dim; ++d) {
+                int q = static_cast<int>(std::round(in[d] * inv));
+                qrow[d] = static_cast<int8_t>(std::max(-128, std::min(127, q)));
+            }
+        }
+    }
+}
+
+void* prepare(const bench::AttnDims& dims, size_t /*seq_len*/, size_t cache_len,
+              const float* fp32_q, const float* fp32_k, const float* fp32_v) {
+    auto* s = new State();
+    s->dims = dims;
+    s->kv_seq_len = cache_len + 1;
+
+    const size_t hd = dims.head_dim;
+    const size_t q_rows  = 1 * dims.num_q_heads;
+    const size_t kv_rows = s->kv_seq_len * dims.num_kv_heads;
+
+    s->q_int8.resize(q_rows  * hd);   s->q_scales.resize(q_rows);   s->q_zp.assign(q_rows, 0);
+    s->k_int8.resize(kv_rows * hd);   s->k_scales.resize(kv_rows);  s->k_zp.assign(kv_rows, 0);
+    s->v_int8.resize(kv_rows * hd);   s->v_scales.resize(kv_rows);  s->v_zp.assign(kv_rows, 0);
+
+    quantize_bnsh(fp32_q, dims.num_q_heads,  1,            hd,
+                   s->q_int8.data(), s->q_scales.data(), s->q_zp.data());
+    quantize_bnsh(fp32_k, dims.num_kv_heads, s->kv_seq_len, hd,
+                   s->k_int8.data(), s->k_scales.data(), s->k_zp.data());
+    quantize_bnsh(fp32_v, dims.num_kv_heads, s->kv_seq_len, hd,
+                   s->v_int8.data(), s->v_scales.data(), s->v_zp.data());
+
+    s->out.assign(dims.num_q_heads * hd, 0.0f);
+    return s;
+}
+
+void run(void* state, float* output) {
+    auto* s = static_cast<State*>(state);
+    const auto& d = s->dims;
+    using SZ = ::executorch::aten::SizesType;
+    SZ B = 1;
+    SZ Hq = static_cast<SZ>(d.num_q_heads);
+    SZ Hkv = static_cast<SZ>(d.num_kv_heads);
+    SZ S = 1;
+    SZ KVL = static_cast<SZ>(s->kv_seq_len);
+    SZ D = static_cast<SZ>(d.head_dim);
+
+    // BNSH for data tensors (driver layout, no transpose).
+    auto q_t  = make_tensor_ptr({B, Hq,  S,   D}, s->q_int8.data(), ScalarType::Char);
+    auto k_t  = make_tensor_ptr({B, Hkv, KVL, D}, s->k_int8.data(), ScalarType::Char);
+    auto v_t  = make_tensor_ptr({B, Hkv, KVL, D}, s->v_int8.data(), ScalarType::Char);
+    // Scales/zp same rank as data, BNSH-aligned: [B, N, S, 1].
+    auto qs_t = make_tensor_ptr({B, Hq,  S,   1}, s->q_scales.data(), ScalarType::Float);
+    auto ks_t = make_tensor_ptr({B, Hkv, KVL, 1}, s->k_scales.data(), ScalarType::Float);
+    auto vs_t = make_tensor_ptr({B, Hkv, KVL, 1}, s->v_scales.data(), ScalarType::Float);
+    auto qz_t = make_tensor_ptr({B, Hq,  S,   1}, s->q_zp.data(),     ScalarType::Char);
+    auto kz_t = make_tensor_ptr({B, Hkv, KVL, 1}, s->k_zp.data(),     ScalarType::Char);
+    auto vz_t = make_tensor_ptr({B, Hkv, KVL, 1}, s->v_zp.data(),     ScalarType::Char);
+    auto o_t  = make_tensor_ptr({B, Hq,  S,   D}, s->out.data(), ScalarType::Float);
+
+    KernelRuntimeContext ctx;
+    et::aten::optional<Tensor> no_mask;
+    et::aten::optional<double> scale = static_cast<double>(1.0 / std::sqrt(static_cast<float>(d.head_dim)));
+    et::aten::optional<Tensor> qz(*qz_t), qs(*qs_t);
+    et::aten::optional<Tensor> kz(*kz_t), ks(*ks_t);
+    et::aten::optional<Tensor> vz(*vz_t), vs(*vs_t);
+
+    ::torch::executor::native::custom_quantized_sdpa_out(
+        ctx, *q_t, *k_t, *v_t,
+        /*start_pos*/ static_cast<int64_t>(s->kv_seq_len - 1),
+        no_mask,
+        /*dropout_p*/ 0.0,
+        /*is_causal*/ true,          // shifted causal mask aligned to start_pos
+        scale,
+        qz, qs,
+        kz, ks,
+        vz, vs,
+        /*is_seq_at_dim_1*/ true,    // BNSH. Header param name vs impl body
+                                     // disagree (see struct comment above).
+        *o_t);
+
+    // Output is BSNH [1, 1, Hq, D]. With seq=1 it's the same memory layout
+    // as driver's [head, seq, head_dim]; just copy.
+    if (output)
+        std::memcpy(output, s->out.data(), s->out.size() * sizeof(float));
+}
+
+void cleanup(void* state) { delete static_cast<State*>(state); }
+
+} // namespace et_attn_decode_q8pc
+
+static int reg_attn = [] {
+    bench::register_attn_backend({
+        "executorch_sdpa_prefill_fp32", "executorch", bench::AttnMode::PREFILL,
+        et_attn_prefill::prepare, et_attn_prefill::run, et_attn_prefill::cleanup
+    });
+    bench::register_attn_backend({
+        "executorch_qsdpa_decode_int8pc", "executorch", bench::AttnMode::DECODE,
+        et_attn_decode_q8pc::prepare, et_attn_decode_q8pc::run, et_attn_decode_q8pc::cleanup
+    });
+    return 0;
+}();
+
+} // namespace
+
+#else  // !WITH_EXECUTORCH_LLM
+
+namespace { [[maybe_unused]] static int reg_attn = []{ return 0; }(); }
+
+#endif // WITH_EXECUTORCH_LLM

--- a/tests/bench/backend_ggml.cpp
+++ b/tests/bench/backend_ggml.cpp
@@ -14,8 +14,6 @@
 
 namespace {
 
-// ── Matmul (Q8_0 — group size 32 INT8) ─────────────────────────────────────
-
 namespace matmul {
 
 struct Weights {
@@ -106,13 +104,11 @@ void run_kernel(size_t M, size_t K, size_t N,
     w->output.resize(M * w->N);
 
     const auto* cpu_traits = ggml_get_type_traits_cpu(w->type);
-    // Honor the bench's --threads override (default: hardware_concurrency).
     size_t target_threads = static_cast<size_t>(
         bench::get_effective_threads(static_cast<int>(std::thread::hardware_concurrency())));
     target_threads = std::max<size_t>(1, target_threads);
 
-    // Serial path for small N: skip threadpool wakeup entirely (eliminates
-    // ~tens-of-μs per call for tiny matmul).
+    // Serial path skips threadpool wakeup (saves tens of μs per call at tiny N).
     if (target_threads == 1 || w->N < 64) {
         gemv_slice(cpu_traits->vec_dot, cpu_traits->nrows,
                    w->quantized.data(), w->row_stride,
@@ -139,8 +135,6 @@ void cleanup(void* weights, void* activations) {
 }
 
 } // namespace matmul
-
-// ── Attention (flash + matmul-composed, INT8 KV) ────────────────────────────
 
 namespace attn {
 
@@ -218,12 +212,9 @@ static SetupResult setup_common(const bench::AttnDims& dims, size_t seq_len, siz
     return r;
 }
 
-// Shared ggml threadpool — single pool reused across all states.
-// Without this, each state creates its own pool with `hardware_concurrency`
-// threads. With NS=64 states at small cache, that means 64 × 14 ≈ 900
-// threads sitting on condition variables, fighting the OS scheduler. That
-// causes the per-call cost to balloon at small cache_len (where NS is large)
-// and produce the non-monotonic ggml decode curve.
+// Shared ggml threadpool — without this, each state creates its own pool with
+// `hardware_concurrency` threads, so at small cache (large NS) hundreds of
+// threads sit on condition variables and the per-call cost balloons.
 static ggml_threadpool* get_ggml_threadpool() {
     static ggml_threadpool* tp = nullptr;
     static int last_threads = -1;
@@ -340,9 +331,6 @@ static int reg = [] {
         "ggml_q8_0", "ggml",
         matmul::prepare_q8, matmul::prepare_act, matmul::run_kernel, matmul::cleanup
     });
-    // Prefill: keep just the fused flash_attn path (canonical llama.cpp
-    // when --flash-attn is on). The matmul-composed prefill path was
-    // removed — it produced a parallel curve that just cluttered the chart.
     bench::register_attn_backend({
         "ggml_fa_q8_prefill", "ggml", bench::AttnMode::PREFILL,
         attn::fa_q8_prefill, attn::run, attn::cleanup
@@ -351,9 +339,6 @@ static int reg = [] {
         "ggml_fa_q8_decode", "ggml", bench::AttnMode::DECODE,
         attn::fa_q8_decode, attn::run, attn::cleanup
     });
-    // ggml_mm_q8_decode (matmul-composed) was dropped — it produces wrong
-    // output (nrmse=1.24). The flash-attention path (ggml_fa_q8_decode) is
-    // ggml's real fused attention kernel and is what we compare against.
     return 0;
 }();
 

--- a/tests/bench/backend_ggml.cpp
+++ b/tests/bench/backend_ggml.cpp
@@ -1,0 +1,364 @@
+#include "bench_driver.h"
+
+#ifdef WITH_GGML
+
+#include "ggml.h"
+#include "ggml-cpu.h"
+
+#include "../../cactus-kernels/src/threading.h"
+
+#include <cstring>
+#include <cmath>
+#include <thread>
+#include <vector>
+
+namespace {
+
+// ── Matmul (Q8_0 — group size 32 INT8) ─────────────────────────────────────
+
+namespace matmul {
+
+struct Weights {
+    size_t K = 0, N = 0;
+    ggml_type type = GGML_TYPE_Q8_0;
+    std::vector<uint8_t> quantized;
+    size_t row_stride = 0;
+    std::vector<float> output;
+};
+
+void* prepare_q8(const float* fp32, size_t N, size_t K) {
+    auto* w = new Weights();
+    w->K = K; w->N = N; w->type = GGML_TYPE_Q8_0;
+    w->row_stride = ggml_row_size(w->type, K);
+    w->quantized.resize(w->row_stride * N);
+
+    const auto* cpu_traits = ggml_get_type_traits_cpu(w->type);
+    auto from_float = cpu_traits->from_float;
+    if (!from_float) from_float = ggml_get_type_traits(w->type)->from_float_ref;
+
+    for (size_t n = 0; n < N; n++)
+        from_float(fp32 + n * K, w->quantized.data() + n * w->row_stride, static_cast<int64_t>(K));
+    return w;
+}
+
+struct Activations {
+    std::vector<uint8_t> q8_input;
+    size_t q8_row_stride = 0;
+};
+
+void* prepare_act(const float* fp32, size_t M, size_t K, void*) {
+    auto* a = new Activations();
+    a->q8_row_stride = ggml_row_size(GGML_TYPE_Q8_0, K);
+    a->q8_input.resize(a->q8_row_stride * M);
+    auto quantize = ggml_get_type_traits_cpu(GGML_TYPE_Q8_0)->from_float;
+    for (size_t m = 0; m < M; m++)
+        quantize(fp32 + m * K, a->q8_input.data() + m * a->q8_row_stride, static_cast<int64_t>(K));
+    return a;
+}
+
+static void gemv_slice(ggml_vec_dot_t vec_dot, int64_t nrows,
+                        const uint8_t* wdata, size_t w_stride,
+                        const uint8_t* q8_input, size_t q8_row_stride,
+                        float* output, size_t M, size_t K, size_t N,
+                        size_t n_begin, size_t n_end) {
+    const int Kint = static_cast<int>(K);
+    (void)N;
+    for (size_t m = 0; m < M; m++) {
+        const uint8_t* act_row = q8_input + m * q8_row_stride;
+        float* out_row = output + m * N;
+        bool can_pair_m = (nrows >= 2 && m + 1 < M);
+
+        size_t n = n_begin;
+        if (can_pair_m) {
+            float* out_row_next = output + (m + 1) * N;
+            for (; n + 1 < n_end; n += 2) {
+                float tmp[4];
+                vec_dot(Kint, tmp, 2,
+                        wdata + n * w_stride, w_stride,
+                        act_row, q8_row_stride, 2);
+                out_row[n]          = tmp[0];
+                out_row[n + 1]      = tmp[1];
+                out_row_next[n]     = tmp[2];
+                out_row_next[n + 1] = tmp[3];
+            }
+            for (; n < n_end; n++) {
+                vec_dot(Kint, out_row + n, 0,
+                        wdata + n * w_stride, 0, act_row, 0, 1);
+                vec_dot(Kint, out_row_next + n, 0,
+                        wdata + n * w_stride, 0, act_row + q8_row_stride, 0, 1);
+            }
+            m++;
+        } else {
+            for (; n < n_end; n++)
+                vec_dot(Kint, out_row + n, 0,
+                        wdata + n * w_stride, 0, act_row, 0, 1);
+        }
+    }
+}
+
+void run_kernel(size_t M, size_t K, size_t N,
+                void* weights, void* activations,
+                const int8_t*, const float*,
+                float* output, float*) {
+    (void)K; (void)N;
+    auto* w = static_cast<Weights*>(weights);
+    auto* a = static_cast<Activations*>(activations);
+    w->output.resize(M * w->N);
+
+    const auto* cpu_traits = ggml_get_type_traits_cpu(w->type);
+    // Honor the bench's --threads override (default: hardware_concurrency).
+    size_t target_threads = static_cast<size_t>(
+        bench::get_effective_threads(static_cast<int>(std::thread::hardware_concurrency())));
+    target_threads = std::max<size_t>(1, target_threads);
+
+    // Serial path for small N: skip threadpool wakeup entirely (eliminates
+    // ~tens-of-μs per call for tiny matmul).
+    if (target_threads == 1 || w->N < 64) {
+        gemv_slice(cpu_traits->vec_dot, cpu_traits->nrows,
+                   w->quantized.data(), w->row_stride,
+                   a->q8_input.data(), a->q8_row_stride,
+                   w->output.data(), M, w->K, w->N, 0, w->N);
+    } else {
+        size_t chunk = std::max<size_t>(16, w->N / target_threads);
+        CactusThreading::ParallelConfig par_cfg{chunk, 16};
+        CactusThreading::parallel_for(w->N, par_cfg,
+            [&](size_t n_begin, size_t n_end) {
+                gemv_slice(cpu_traits->vec_dot, cpu_traits->nrows,
+                           w->quantized.data(), w->row_stride,
+                           a->q8_input.data(), a->q8_row_stride,
+                           w->output.data(), M, w->K, w->N, n_begin, n_end);
+            });
+    }
+
+    if (output) std::memcpy(output, w->output.data(), M * w->N * sizeof(float));
+}
+
+void cleanup(void* weights, void* activations) {
+    delete static_cast<Weights*>(weights);
+    if (activations) delete static_cast<Activations*>(activations);
+}
+
+} // namespace matmul
+
+// ── Attention (flash + matmul-composed, INT8 KV) ────────────────────────────
+
+namespace attn {
+
+struct State {
+    bench::AttnDims dims;
+    size_t seq_len;
+    size_t output_count;
+    bool permuted_output;
+    ggml_context* ctx;
+    ggml_cgraph*  graph;
+    ggml_threadpool* threadpool;
+    ggml_cplan plan;
+    std::vector<uint8_t> work_buf;
+    ggml_tensor* result;
+};
+
+static void fill_causal_mask(ggml_fp16_t* data, size_t kv_len, size_t seq_len) {
+    size_t offset = kv_len - seq_len;
+    for (size_t sq = 0; sq < seq_len; ++sq)
+        for (size_t kv = 0; kv < kv_len; ++kv)
+            data[sq * kv_len + kv] = (kv <= sq + offset)
+                ? ggml_fp32_to_fp16(0.0f)
+                : ggml_fp32_to_fp16(-INFINITY);
+}
+
+static void quantize_tensor(const float* fp32, void* dst, ggml_type type, size_t n) {
+    if (type == GGML_TYPE_F32) { std::memcpy(dst, fp32, n * sizeof(float)); return; }
+    auto from_float = ggml_get_type_traits_cpu(type)->from_float;
+    if (!from_float) from_float = ggml_get_type_traits(type)->from_float_ref;
+    from_float(fp32, (uint8_t*)dst, static_cast<int64_t>(n));
+}
+
+struct SetupResult {
+    ggml_context* ctx;
+    ggml_tensor* q_t;
+    ggml_tensor* k_t;
+    ggml_tensor* mask_t;
+    size_t sl, kvl, hd, qh, kvh, kv_rows;
+    float scale;
+};
+
+static SetupResult setup_common(const bench::AttnDims& dims, size_t seq_len, size_t cache_len,
+                                 const float* fp32_q, const float* fp32_k,
+                                 bench::AttnMode mode, ggml_type kv_type, size_t extra_bytes) {
+    SetupResult r;
+    r.sl  = (mode == bench::AttnMode::PREFILL) ? seq_len : 1;
+    r.kvl = (mode == bench::AttnMode::PREFILL) ? seq_len : cache_len + 1;
+    r.hd  = dims.head_dim;
+    r.qh  = dims.num_q_heads;
+    r.kvh = dims.num_kv_heads;
+    r.kv_rows = r.kvh * r.kvl;
+    r.scale = 1.0f / std::sqrt(static_cast<float>(r.hd));
+
+    size_t kv_row_bytes = ggml_row_size(kv_type, r.hd);
+    size_t data_bytes = r.qh * r.sl * r.hd * sizeof(float)
+                      + 2 * r.kv_rows * kv_row_bytes
+                      + r.kvl * r.sl * sizeof(ggml_fp16_t)
+                      + r.qh * r.sl * r.hd * sizeof(float)
+                      + extra_bytes;
+    size_t ctx_size = data_bytes + ggml_tensor_overhead() * 16 + ggml_graph_overhead() + 64 * 1024 * 1024;
+
+    r.ctx = ggml_init({ ctx_size, nullptr, false });
+
+    r.q_t = ggml_new_tensor_3d(r.ctx, GGML_TYPE_F32, (int64_t)r.hd, (int64_t)r.sl, (int64_t)r.qh);
+    r.k_t = ggml_new_tensor_3d(r.ctx, kv_type, (int64_t)r.hd, (int64_t)r.kvl, (int64_t)r.kvh);
+    ggml_set_name(r.q_t, "Q"); ggml_set_input(r.q_t);
+    ggml_set_name(r.k_t, "K"); ggml_set_input(r.k_t);
+
+    std::memcpy(r.q_t->data, fp32_q, r.qh * r.sl * r.hd * sizeof(float));
+    quantize_tensor(fp32_k, r.k_t->data, kv_type, r.kv_rows * r.hd);
+
+    r.mask_t = ggml_new_tensor_2d(r.ctx, GGML_TYPE_F16, (int64_t)r.kvl, (int64_t)r.sl);
+    ggml_set_name(r.mask_t, "mask"); ggml_set_input(r.mask_t);
+    fill_causal_mask((ggml_fp16_t*)r.mask_t->data, r.kvl, r.sl);
+    return r;
+}
+
+// Shared ggml threadpool — single pool reused across all states.
+// Without this, each state creates its own pool with `hardware_concurrency`
+// threads. With NS=64 states at small cache, that means 64 × 14 ≈ 900
+// threads sitting on condition variables, fighting the OS scheduler. That
+// causes the per-call cost to balloon at small cache_len (where NS is large)
+// and produce the non-monotonic ggml decode curve.
+static ggml_threadpool* get_ggml_threadpool() {
+    static ggml_threadpool* tp = nullptr;
+    static int last_threads = -1;
+    int target = bench::get_effective_threads(
+        static_cast<int>(std::thread::hardware_concurrency()));
+    if (target < 1) target = 1;
+    if (tp == nullptr || target != last_threads) {
+        if (tp) ggml_threadpool_free(tp);
+        auto params = ggml_threadpool_params_default(target);
+        tp = ggml_threadpool_new(&params);
+        last_threads = target;
+    }
+    return tp;
+}
+static int get_ggml_threads() {
+    return std::max(1, bench::get_effective_threads(
+        static_cast<int>(std::thread::hardware_concurrency())));
+}
+
+static State* finalize(const bench::AttnDims& dims, SetupResult& r,
+                        ggml_tensor* result, bool permuted) {
+    auto* gf = ggml_new_graph_custom(r.ctx, 4096, false);
+    ggml_build_forward_expand(gf, result);
+
+    int n_threads = get_ggml_threads();
+    auto* tp = get_ggml_threadpool();
+    auto cplan = ggml_graph_plan(gf, n_threads, tp);
+    std::vector<uint8_t> work_buf(cplan.work_size);
+    cplan.work_data = work_buf.data();
+
+    auto* s = new State{ dims, r.sl, r.qh * r.sl * r.hd, permuted,
+                          r.ctx, gf, tp, cplan, std::move(work_buf), result };
+    s->plan.work_data = s->work_buf.data();
+    return s;
+}
+
+void* prepare_flash(const bench::AttnDims& dims, size_t seq_len, size_t cache_len,
+                    const float* fp32_q, const float* fp32_k, const float* fp32_v,
+                    bench::AttnMode mode, ggml_type kv_type) {
+    auto r = setup_common(dims, seq_len, cache_len, fp32_q, fp32_k, mode, kv_type, 0);
+
+    auto* v_t = ggml_new_tensor_3d(r.ctx, kv_type, (int64_t)r.hd, (int64_t)r.kvl, (int64_t)r.kvh);
+    ggml_set_name(v_t, "V"); ggml_set_input(v_t);
+    quantize_tensor(fp32_v, v_t->data, kv_type, r.kv_rows * r.hd);
+
+    auto* result = ggml_flash_attn_ext(r.ctx, r.q_t, r.k_t, v_t, r.mask_t, r.scale, 0.0f, 0.0f);
+    ggml_set_output(result);
+    return finalize(dims, r, result, true);
+}
+
+void* prepare_matmul(const bench::AttnDims& dims, size_t seq_len, size_t cache_len,
+                     const float* fp32_q, const float* fp32_k, const float* fp32_v,
+                     bench::AttnMode mode, ggml_type kv_type) {
+    size_t sl  = (mode == bench::AttnMode::PREFILL) ? seq_len : 1;
+    size_t kvl = (mode == bench::AttnMode::PREFILL) ? seq_len : cache_len + 1;
+    size_t extra = dims.num_q_heads * sl * kvl * sizeof(float) * 2;
+    auto r = setup_common(dims, seq_len, cache_len, fp32_q, fp32_k, mode, kv_type, extra);
+
+    auto* v_t = ggml_new_tensor_3d(r.ctx, kv_type, (int64_t)r.kvl, (int64_t)r.hd, (int64_t)r.kvh);
+    ggml_set_name(v_t, "V"); ggml_set_input(v_t);
+    std::vector<float> v_transposed(r.kvh * r.kvl * r.hd);
+    for (size_t h = 0; h < r.kvh; ++h)
+        bench::transpose_2d(fp32_v + h * r.kvl * r.hd,
+                             v_transposed.data() + h * r.hd * r.kvl,
+                             r.kvl, r.hd);
+    quantize_tensor(v_transposed.data(), v_t->data, kv_type, r.kv_rows * r.hd);
+
+    auto* kq = ggml_mul_mat(r.ctx, r.k_t, r.q_t);
+    kq = ggml_soft_max_ext(r.ctx, kq, r.mask_t, r.scale, 0.0f);
+    auto* kqv = ggml_mul_mat(r.ctx, v_t, kq);
+    ggml_set_output(kqv);
+    return finalize(dims, r, kqv, false);
+}
+
+#define GGML_ATTN_VARIANT(name, prep_fn, mode, type) \
+    void* name(const bench::AttnDims& d, size_t sl, size_t cl, const float* q, const float* k, const float* v) { \
+        return prep_fn(d, sl, cl, q, k, v, bench::AttnMode::mode, type); \
+    }
+GGML_ATTN_VARIANT(fa_q8_prefill, prepare_flash,  PREFILL, GGML_TYPE_Q8_0)
+GGML_ATTN_VARIANT(fa_q8_decode,  prepare_flash,  DECODE,  GGML_TYPE_Q8_0)
+GGML_ATTN_VARIANT(mm_q8_prefill, prepare_matmul, PREFILL, GGML_TYPE_Q8_0)
+GGML_ATTN_VARIANT(mm_q8_decode,  prepare_matmul, DECODE,  GGML_TYPE_Q8_0)
+#undef GGML_ATTN_VARIANT
+
+void run(void* state, float* output) {
+    auto* s = static_cast<State*>(state);
+    ggml_graph_compute(s->graph, &s->plan);
+
+    if (output) {
+        const float* src = (const float*)s->result->data;
+        size_t hd = s->dims.head_dim, qh = s->dims.num_q_heads, sl = s->seq_len;
+        if (s->permuted_output) {
+            for (size_t sq = 0; sq < sl; ++sq)
+                for (size_t h = 0; h < qh; ++h)
+                    std::memcpy(output + h * sl * hd + sq * hd,
+                                src + (sq * qh + h) * hd, hd * sizeof(float));
+        } else {
+            std::memcpy(output, src, s->output_count * sizeof(float));
+        }
+    }
+}
+
+void cleanup(void* state) {
+    auto* s = static_cast<State*>(state);
+    // Threadpool is shared (see get_ggml_threadpool); do NOT free here.
+    ggml_free(s->ctx);
+    delete s;
+}
+
+} // namespace attn
+
+static int reg = [] {
+    bench::register_matmul_backend({
+        "ggml_q8_0", "ggml",
+        matmul::prepare_q8, matmul::prepare_act, matmul::run_kernel, matmul::cleanup
+    });
+    // Prefill: keep just the fused flash_attn path (canonical llama.cpp
+    // when --flash-attn is on). The matmul-composed prefill path was
+    // removed — it produced a parallel curve that just cluttered the chart.
+    bench::register_attn_backend({
+        "ggml_fa_q8_prefill", "ggml", bench::AttnMode::PREFILL,
+        attn::fa_q8_prefill, attn::run, attn::cleanup
+    });
+    bench::register_attn_backend({
+        "ggml_fa_q8_decode", "ggml", bench::AttnMode::DECODE,
+        attn::fa_q8_decode, attn::run, attn::cleanup
+    });
+    // ggml_mm_q8_decode (matmul-composed) was dropped — it produces wrong
+    // output (nrmse=1.24). The flash-attention path (ggml_fa_q8_decode) is
+    // ggml's real fused attention kernel and is what we compare against.
+    return 0;
+}();
+
+} // namespace
+
+#else
+namespace { [[maybe_unused]] static int reg = []{ return 0; }(); }
+#endif

--- a/tests/bench/backend_litert.cpp
+++ b/tests/bench/backend_litert.cpp
@@ -1,0 +1,404 @@
+#include "bench_driver.h"
+
+#ifdef WITH_LITERT
+
+#include <arm_neon.h>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <vector>
+
+#include "tflite/kernels/internal/optimized/neon_tensor_utils.h"
+#include "ruy/ruy.h"
+
+namespace {
+
+static constexpr int kRuyGemvThreads = 1;
+static constexpr int kRuyGemmThreads = 4;
+
+// ── Matmul (INT8 only) ──────────────────────────────────────────────────────
+
+struct Int8Weights {
+    size_t K = 0, N = 0;
+    std::vector<int8_t> int8_rowmajor;
+    std::vector<float> weight_scales;
+    std::vector<float> neon_output;
+    std::vector<int32_t> ruy_output;
+};
+
+// Shared ruy::Context across all matrices — without this, NM matrices each
+// create their own Context with thread pool, leading to 4k+ worker threads
+// at small dims. Single shared Context with the bench's thread budget.
+static ruy::Context* get_ruy_context(int max_threads) {
+    static std::unique_ptr<ruy::Context> ctx;
+    static int last_threads = -1;
+    if (!ctx || max_threads != last_threads) {
+        ctx = std::make_unique<ruy::Context>();
+        ctx->set_max_num_threads(max_threads);
+        last_threads = max_threads;
+    }
+    return ctx.get();
+}
+
+void* int8_prepare(const float* fp32, size_t N, size_t K) {
+    auto* w = new Int8Weights();
+    w->K = K;
+    w->N = N;
+    w->int8_rowmajor.resize(N * K);
+    w->weight_scales.resize(N);
+    bench::quantize_rows_int8(fp32, w->int8_rowmajor.data(), w->weight_scales.data(), N, K);
+    return w;
+}
+
+void int8_cleanup(void* weights, void*) {
+    delete static_cast<Int8Weights*>(weights);
+}
+
+void neon_run_kernel(size_t M, size_t /*K*/, size_t /*N*/,
+                     void* weights, void*,
+                     const int8_t* act_int8, const float* act_scales,
+                     float* output, float*) {
+    auto* w = static_cast<Int8Weights*>(weights);
+    w->neon_output.resize(M * w->N);
+    std::memset(w->neon_output.data(), 0, M * w->N * sizeof(float));
+    tflite::tensor_utils::MatrixBatchVectorMultiplyAccumulate(
+        w->int8_rowmajor.data(), static_cast<int>(w->N), static_cast<int>(w->K),
+        act_int8, act_scales, static_cast<int>(M), w->neon_output.data());
+
+    const float* ws = w->weight_scales.data();
+    for (size_t m = 0; m < M; m++) {
+        float* row = w->neon_output.data() + m * w->N;
+        size_t n = 0;
+        for (; n + 4 <= w->N; n += 4) {
+            float32x4_t v = vld1q_f32(row + n);
+            float32x4_t s = vld1q_f32(ws + n);
+            vst1q_f32(row + n, vmulq_f32(v, s));
+        }
+        for (; n < w->N; n++) row[n] *= ws[n];
+    }
+
+    if (output) std::memcpy(output, w->neon_output.data(), M * w->N * sizeof(float));
+}
+
+static void ruy_run_kernel_impl(size_t M, Int8Weights* w,
+                                const int8_t* act_int8, ruy::Context* ctx) {
+    w->ruy_output.resize(M * w->N);
+
+    ruy::Matrix<int8_t> lhs;
+    ruy::MakeSimpleLayout(static_cast<int>(M), static_cast<int>(w->K),
+                          ruy::Order::kRowMajor, lhs.mutable_layout());
+    lhs.set_data(act_int8); lhs.set_zero_point(0);
+
+    ruy::Matrix<int8_t> rhs;
+    ruy::MakeSimpleLayout(static_cast<int>(w->K), static_cast<int>(w->N),
+                          ruy::Order::kColMajor, rhs.mutable_layout());
+    rhs.set_data(w->int8_rowmajor.data()); rhs.set_zero_point(0);
+    rhs.set_cache_policy(ruy::CachePolicy::kAlwaysCache);
+
+    ruy::Matrix<int32_t> dst;
+    ruy::MakeSimpleLayout(static_cast<int>(M), static_cast<int>(w->N),
+                          ruy::Order::kRowMajor, dst.mutable_layout());
+    dst.set_data(w->ruy_output.data());
+
+    ruy::MulParams<int32_t, int32_t> mul_params;
+    ruy::Mul(lhs, rhs, mul_params, ctx, &dst);
+}
+
+void ruy_run_kernel(size_t M, size_t /*K*/, size_t /*N*/,
+                    void* weights, void*,
+                    const int8_t* act_int8, const float* act_scales,
+                    float* output, float*) {
+    auto* w = static_cast<Int8Weights*>(weights);
+    int default_threads = (M <= 1) ? kRuyGemvThreads : kRuyGemmThreads;
+    int threads = bench::get_effective_threads(default_threads);
+    ruy_run_kernel_impl(M, w, act_int8, get_ruy_context(threads));
+
+    w->neon_output.resize(M * w->N);
+    const float* ws = w->weight_scales.data();
+    for (size_t m = 0; m < M; m++) {
+        float32x4_t as = vdupq_n_f32(act_scales[m]);
+        const int32_t* src = w->ruy_output.data() + m * w->N;
+        float* dst = w->neon_output.data() + m * w->N;
+        size_t n = 0;
+        for (; n + 4 <= w->N; n += 4) {
+            float32x4_t v = vcvtq_f32_s32(vld1q_s32(src + n));
+            float32x4_t s = vld1q_f32(ws + n);
+            vst1q_f32(dst + n, vmulq_f32(vmulq_f32(v, as), s));
+        }
+        for (; n < w->N; n++)
+            dst[n] = static_cast<float>(src[n]) * act_scales[m] * ws[n];
+    }
+
+    if (output) std::memcpy(output, w->neon_output.data(), M * w->N * sizeof(float));
+}
+
+// ── Attention via LiteRT primitives (matmul-composed) ──────────────────────
+//
+// LiteRT/TFLite has no fused attention op, so we hand-compose Q·Kᵀ →
+// softmax → @V using its INT8 matmul kernels. Same semantic as ggml's
+// `mm_q8_*` matmul-composed paths. The cactus and onnxrt comparisons remain
+// against fused attention kernels; this gives a fair "best you can do with
+// LiteRT primitives" comparison point.
+
+namespace attn {
+
+static void ruy_matmul_int32(const int8_t* A, size_t M, size_t K,
+                              const int8_t* B_rowmajor, size_t N,
+                              int32_t* dst, ruy::Context* ctx,
+                              bool cache_rhs = false) {
+    ruy::Matrix<int8_t> lhs;
+    ruy::MakeSimpleLayout(static_cast<int>(M), static_cast<int>(K),
+                          ruy::Order::kRowMajor, lhs.mutable_layout());
+    lhs.set_data(A); lhs.set_zero_point(0);
+
+    ruy::Matrix<int8_t> rhs;
+    ruy::MakeSimpleLayout(static_cast<int>(K), static_cast<int>(N),
+                          ruy::Order::kColMajor, rhs.mutable_layout());
+    rhs.set_data(B_rowmajor); rhs.set_zero_point(0);
+    if (cache_rhs) rhs.set_cache_policy(ruy::CachePolicy::kAlwaysCache);
+
+    ruy::Matrix<int32_t> out;
+    ruy::MakeSimpleLayout(static_cast<int>(M), static_cast<int>(N),
+                          ruy::Order::kRowMajor, out.mutable_layout());
+    out.set_data(dst);
+
+    ruy::MulParams<int32_t, int32_t> mul_params;
+    ruy::Mul(lhs, rhs, mul_params, ctx, &out);
+}
+
+static void dequant_and_scale(const int32_t* int32_out,
+                               const float* row_scales, const float* col_scales,
+                               float extra_scale, float* dst,
+                               size_t M, size_t N) {
+    for (size_t m = 0; m < M; ++m) {
+        float rs = row_scales[m] * extra_scale;
+        float32x4_t rs_v = vdupq_n_f32(rs);
+        const int32_t* src = int32_out + m * N;
+        float* out = dst + m * N;
+        size_t n = 0;
+        for (; n + 4 <= N; n += 4) {
+            float32x4_t v = vcvtq_f32_s32(vld1q_s32(src + n));
+            float32x4_t cs = vld1q_f32(col_scales + n);
+            vst1q_f32(out + n, vmulq_f32(vmulq_f32(v, rs_v), cs));
+        }
+        for (; n < N; n++)
+            out[n] = static_cast<float>(src[n]) * rs * col_scales[n];
+    }
+}
+
+static void neon_mbvma_dequant(const int8_t* weight, size_t N, size_t K,
+                                const float* weight_scales,
+                                const int8_t* act_int8, const float* act_scales,
+                                float* dst) {
+    std::memset(dst, 0, N * sizeof(float));
+    tflite::tensor_utils::MatrixBatchVectorMultiplyAccumulate(
+        weight, static_cast<int>(N), static_cast<int>(K),
+        act_int8, act_scales, 1, dst);
+    size_t n = 0;
+    for (; n + 4 <= N; n += 4) {
+        float32x4_t v = vld1q_f32(dst + n);
+        float32x4_t s = vld1q_f32(weight_scales + n);
+        vst1q_f32(dst + n, vmulq_f32(v, s));
+    }
+    for (; n < N; n++) dst[n] *= weight_scales[n];
+}
+
+static void softmax_causal(float* scores, size_t seq_len, size_t kv_seq_len) {
+    size_t offset = kv_seq_len - seq_len;
+    for (size_t sq = 0; sq < seq_len; ++sq) {
+        float* row = scores + sq * kv_seq_len;
+        if (seq_len > 1)
+            for (size_t sk = sq + offset + 1; sk < kv_seq_len; ++sk)
+                row[sk] = -1e30f;
+
+        float max_val = row[0];
+        for (size_t sk = 1; sk < kv_seq_len; ++sk)
+            if (row[sk] > max_val) max_val = row[sk];
+
+        float sum = 0.0f;
+        for (size_t sk = 0; sk < kv_seq_len; ++sk) {
+            row[sk] = std::exp(row[sk] - max_val);
+            sum += row[sk];
+        }
+        float inv_sum = 1.0f / sum;
+        for (size_t sk = 0; sk < kv_seq_len; ++sk) row[sk] *= inv_sum;
+    }
+}
+
+struct KVHead {
+    std::vector<int8_t> k_int8;          // [kv_seq_len, head_dim] row-major
+    std::vector<float>  k_scales;        // [kv_seq_len] per row
+    std::vector<int8_t> vt_int8;         // [head_dim, kv_seq_len] V transposed
+    std::vector<float>  vt_scales;       // [head_dim] per row
+};
+
+struct AttnState {
+    bench::AttnDims dims;
+    size_t seq_len = 0, kv_seq_len = 0;
+    float scale = 0.0f;
+    std::vector<KVHead> kv_heads;
+    std::vector<float> fp32_q;
+    int ruy_threads = 1;     // resolved from --threads at prepare time
+    std::vector<int8_t>  q_int8_buf;
+    std::vector<float>   q_scales_buf;
+    std::vector<int32_t> int32_buf;
+    std::vector<float>   scores_buf;
+    std::vector<int8_t>  scores_int8_buf;
+    std::vector<float>   scores_scales_buf;
+    std::vector<float>   sv_buf;
+};
+
+static void* attn_prepare(const bench::AttnDims& dims, size_t seq_len, size_t cache_len,
+                           const float* fp32_q, const float* fp32_k, const float* fp32_v,
+                           bench::AttnMode mode) {
+    auto* s = new AttnState();
+    s->dims = dims;
+    s->seq_len = (mode == bench::AttnMode::PREFILL) ? seq_len : 1;
+    s->kv_seq_len = (mode == bench::AttnMode::PREFILL) ? seq_len : cache_len + 1;
+    s->scale = 1.0f / std::sqrt(static_cast<float>(dims.head_dim));
+
+    size_t sl = s->seq_len, kvl = s->kv_seq_len, hd = dims.head_dim;
+    s->fp32_q.assign(fp32_q, fp32_q + dims.num_q_heads * sl * hd);
+
+    s->kv_heads.resize(dims.num_kv_heads);
+    for (size_t h = 0; h < dims.num_kv_heads; ++h) {
+        auto& head = s->kv_heads[h];
+        const float* k_head = fp32_k + h * kvl * hd;
+        const float* v_head = fp32_v + h * kvl * hd;
+
+        head.k_int8.resize(kvl * hd);
+        head.k_scales.resize(kvl);
+        bench::quantize_rows_int8(k_head, head.k_int8.data(), head.k_scales.data(), kvl, hd);
+
+        std::vector<float> vt(hd * kvl);
+        bench::transpose_2d(v_head, vt.data(), kvl, hd);
+        head.vt_int8.resize(hd * kvl);
+        head.vt_scales.resize(hd);
+        bench::quantize_rows_int8(vt.data(), head.vt_int8.data(), head.vt_scales.data(), hd, kvl);
+    }
+
+    s->q_int8_buf.resize(sl * hd);
+    s->q_scales_buf.resize(sl);
+    s->int32_buf.resize(std::max(sl * kvl, sl * hd));
+    s->scores_buf.resize(sl * kvl);
+    s->scores_int8_buf.resize(sl * kvl);
+    s->scores_scales_buf.resize(sl);
+    s->sv_buf.resize(sl * hd);
+
+    s->ruy_threads = bench::get_effective_threads(sl > 1 ? kRuyGemmThreads : kRuyGemvThreads);
+    return s;
+}
+
+static void run_ruy(void* state, float* output) {
+    auto* s = static_cast<AttnState*>(state);
+    size_t sl = s->seq_len, kvl = s->kv_seq_len, hd = s->dims.head_dim;
+    size_t gqa_ratio = s->dims.num_q_heads / s->dims.num_kv_heads;
+    ruy::Context* ctx = get_ruy_context(s->ruy_threads);
+
+    for (size_t qh = 0; qh < s->dims.num_q_heads; ++qh) {
+        size_t kvh = qh / gqa_ratio;
+        const float* q_head = s->fp32_q.data() + qh * sl * hd;
+        auto& kv = s->kv_heads[kvh];
+
+        bench::quantize_rows_int8(q_head, s->q_int8_buf.data(), s->q_scales_buf.data(), sl, hd);
+
+        ruy_matmul_int32(s->q_int8_buf.data(), sl, hd, kv.k_int8.data(), kvl,
+                         s->int32_buf.data(), ctx, true);
+        dequant_and_scale(s->int32_buf.data(), s->q_scales_buf.data(), kv.k_scales.data(),
+                          s->scale, s->scores_buf.data(), sl, kvl);
+
+        softmax_causal(s->scores_buf.data(), sl, kvl);
+
+        bench::quantize_rows_int8(s->scores_buf.data(), s->scores_int8_buf.data(),
+                                   s->scores_scales_buf.data(), sl, kvl);
+
+        ruy_matmul_int32(s->scores_int8_buf.data(), sl, kvl, kv.vt_int8.data(), hd,
+                         s->int32_buf.data(), ctx, true);
+        dequant_and_scale(s->int32_buf.data(), s->scores_scales_buf.data(), kv.vt_scales.data(),
+                          1.0f, s->sv_buf.data(), sl, hd);
+
+        if (output)
+            std::memcpy(output + qh * sl * hd, s->sv_buf.data(), sl * hd * sizeof(float));
+    }
+}
+
+// Decode-only NEON path (TFLite MatrixBatchVectorMultiplyAccumulate is a
+// vector-matrix kernel; only useful when query has 1 row).
+static void run_neon(void* state, float* output) {
+    auto* s = static_cast<AttnState*>(state);
+    size_t kvl = s->kv_seq_len, hd = s->dims.head_dim;
+    size_t gqa_ratio = s->dims.num_q_heads / s->dims.num_kv_heads;
+
+    for (size_t qh = 0; qh < s->dims.num_q_heads; ++qh) {
+        size_t kvh = qh / gqa_ratio;
+        const float* q_head = s->fp32_q.data() + qh * hd;
+        auto& kv = s->kv_heads[kvh];
+
+        bench::quantize_rows_int8(q_head, s->q_int8_buf.data(), s->q_scales_buf.data(), 1, hd);
+        s->q_scales_buf[0] *= s->scale;
+
+        neon_mbvma_dequant(kv.k_int8.data(), kvl, hd, kv.k_scales.data(),
+                           s->q_int8_buf.data(), s->q_scales_buf.data(),
+                           s->scores_buf.data());
+
+        softmax_causal(s->scores_buf.data(), 1, kvl);
+
+        bench::quantize_rows_int8(s->scores_buf.data(), s->scores_int8_buf.data(),
+                                   s->scores_scales_buf.data(), 1, kvl);
+
+        neon_mbvma_dequant(kv.vt_int8.data(), hd, kvl, kv.vt_scales.data(),
+                           s->scores_int8_buf.data(), s->scores_scales_buf.data(),
+                           s->sv_buf.data());
+
+        if (output)
+            std::memcpy(output + qh * hd, s->sv_buf.data(), hd * sizeof(float));
+    }
+}
+
+static void cleanup(void* state) { delete static_cast<AttnState*>(state); }
+
+void* prefill(const bench::AttnDims& d, size_t sl, size_t cl,
+              const float* q, const float* k, const float* v) {
+    return attn_prepare(d, sl, cl, q, k, v, bench::AttnMode::PREFILL);
+}
+void* decode(const bench::AttnDims& d, size_t sl, size_t cl,
+             const float* q, const float* k, const float* v) {
+    return attn_prepare(d, sl, cl, q, k, v, bench::AttnMode::DECODE);
+}
+
+} // namespace attn
+
+static int reg = [] {
+    bench::register_matmul_backend({
+        "litert_neon", "litert",
+        int8_prepare, nullptr, neon_run_kernel, int8_cleanup
+    });
+    bench::register_matmul_backend({
+        "litert_ruy", "litert",
+        int8_prepare, nullptr, ruy_run_kernel, int8_cleanup
+    });
+
+    using P = bench::AttnMode;
+    // Matmul-composed attention via Ruy GEMM (covers prefill and decode).
+    bench::register_attn_backend({
+        "litert_ruy_prefill", "litert", P::PREFILL,
+        attn::prefill, attn::run_ruy, attn::cleanup
+    });
+    bench::register_attn_backend({
+        "litert_ruy_decode", "litert", P::DECODE,
+        attn::decode,  attn::run_ruy, attn::cleanup
+    });
+    // Decode-only path via TFLite NEON MBVMA (vector-matrix kernel).
+    bench::register_attn_backend({
+        "litert_neon_decode", "litert", P::DECODE,
+        attn::decode,  attn::run_neon, attn::cleanup
+    });
+    return 0;
+}();
+
+} // namespace
+
+#else  // !WITH_LITERT
+namespace { [[maybe_unused]] static int reg = []{ return 0; }(); }
+#endif

--- a/tests/bench/backend_litert.cpp
+++ b/tests/bench/backend_litert.cpp
@@ -17,8 +17,6 @@ namespace {
 static constexpr int kRuyGemvThreads = 1;
 static constexpr int kRuyGemmThreads = 4;
 
-// ── Matmul (INT8 only) ──────────────────────────────────────────────────────
-
 struct Int8Weights {
     size_t K = 0, N = 0;
     std::vector<int8_t> int8_rowmajor;
@@ -27,9 +25,8 @@ struct Int8Weights {
     std::vector<int32_t> ruy_output;
 };
 
-// Shared ruy::Context across all matrices — without this, NM matrices each
-// create their own Context with thread pool, leading to 4k+ worker threads
-// at small dims. Single shared Context with the bench's thread budget.
+// Shared ruy::Context — without this, each matrix creates its own Context
+// with thread pool, leading to 4k+ worker threads at small dims.
 static ruy::Context* get_ruy_context(int max_threads) {
     static std::unique_ptr<ruy::Context> ctx;
     static int last_threads = -1;
@@ -133,13 +130,9 @@ void ruy_run_kernel(size_t M, size_t /*K*/, size_t /*N*/,
     if (output) std::memcpy(output, w->neon_output.data(), M * w->N * sizeof(float));
 }
 
-// ── Attention via LiteRT primitives (matmul-composed) ──────────────────────
-//
-// LiteRT/TFLite has no fused attention op, so we hand-compose Q·Kᵀ →
-// softmax → @V using its INT8 matmul kernels. Same semantic as ggml's
-// `mm_q8_*` matmul-composed paths. The cactus and onnxrt comparisons remain
-// against fused attention kernels; this gives a fair "best you can do with
-// LiteRT primitives" comparison point.
+// LiteRT/TFLite has no fused attention op, so attention here is hand-composed
+// from its INT8 matmul kernels (Q·Kᵀ → softmax → @V). Cactus and onnxrt are
+// compared against fused kernels; this is the best LiteRT-primitive baseline.
 
 namespace attn {
 
@@ -227,10 +220,10 @@ static void softmax_causal(float* scores, size_t seq_len, size_t kv_seq_len) {
 }
 
 struct KVHead {
-    std::vector<int8_t> k_int8;          // [kv_seq_len, head_dim] row-major
-    std::vector<float>  k_scales;        // [kv_seq_len] per row
-    std::vector<int8_t> vt_int8;         // [head_dim, kv_seq_len] V transposed
-    std::vector<float>  vt_scales;       // [head_dim] per row
+    std::vector<int8_t> k_int8;
+    std::vector<float>  k_scales;
+    std::vector<int8_t> vt_int8;
+    std::vector<float>  vt_scales;
 };
 
 struct AttnState {
@@ -239,7 +232,7 @@ struct AttnState {
     float scale = 0.0f;
     std::vector<KVHead> kv_heads;
     std::vector<float> fp32_q;
-    int ruy_threads = 1;     // resolved from --threads at prepare time
+    int ruy_threads = 1;
     std::vector<int8_t>  q_int8_buf;
     std::vector<float>   q_scales_buf;
     std::vector<int32_t> int32_buf;
@@ -323,8 +316,8 @@ static void run_ruy(void* state, float* output) {
     }
 }
 
-// Decode-only NEON path (TFLite MatrixBatchVectorMultiplyAccumulate is a
-// vector-matrix kernel; only useful when query has 1 row).
+// TFLite's MatrixBatchVectorMultiplyAccumulate is vector-matrix only, so the
+// NEON path is decode-only (query must have 1 row).
 static void run_neon(void* state, float* output) {
     auto* s = static_cast<AttnState*>(state);
     size_t kvl = s->kv_seq_len, hd = s->dims.head_dim;
@@ -380,7 +373,6 @@ static int reg = [] {
     });
 
     using P = bench::AttnMode;
-    // Matmul-composed attention via Ruy GEMM (covers prefill and decode).
     bench::register_attn_backend({
         "litert_ruy_prefill", "litert", P::PREFILL,
         attn::prefill, attn::run_ruy, attn::cleanup
@@ -389,7 +381,6 @@ static int reg = [] {
         "litert_ruy_decode", "litert", P::DECODE,
         attn::decode,  attn::run_ruy, attn::cleanup
     });
-    // Decode-only path via TFLite NEON MBVMA (vector-matrix kernel).
     bench::register_attn_backend({
         "litert_neon_decode", "litert", P::DECODE,
         attn::decode,  attn::run_neon, attn::cleanup

--- a/tests/bench/backend_onnxrt.cpp
+++ b/tests/bench/backend_onnxrt.cpp
@@ -1,0 +1,676 @@
+#include "bench_driver.h"
+
+#ifdef WITH_ONNXRT
+
+#include <onnxruntime_cxx_api.h>
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <memory>
+#include <thread>
+#include <unordered_map>
+
+namespace {
+
+struct PBuf {
+    std::vector<uint8_t> d;
+    void varint(uint64_t v) {
+        while (v > 0x7F) { d.push_back(static_cast<uint8_t>((v & 0x7F) | 0x80)); v >>= 7; }
+        d.push_back(static_cast<uint8_t>(v));
+    }
+    void fld_vi(int f, uint64_t v) {
+        varint(static_cast<uint64_t>(f) << 3); varint(v);
+    }
+    void fld_ld(int f, const PBuf& sub) {
+        varint(static_cast<uint64_t>(f) << 3 | 2);
+        varint(sub.d.size());
+        d.insert(d.end(), sub.d.begin(), sub.d.end());
+    }
+    void fld_str(int f, const char* s) {
+        size_t n = std::strlen(s);
+        varint(static_cast<uint64_t>(f) << 3 | 2);
+        varint(n);
+        d.insert(d.end(), s, s + n);
+    }
+};
+
+static PBuf make_dim_param(const char* name) { PBuf d; d.fld_str(2, name); return d; }
+static PBuf make_dim_value(size_t v) { PBuf d; d.fld_vi(1, v); return d; }
+
+template<typename... Dims>
+static PBuf make_value_info(const char* name, int elem_type, const Dims&... dims) {
+    PBuf shape; (shape.fld_ld(1, dims), ...);
+    PBuf tensor; tensor.fld_vi(1, elem_type); tensor.fld_ld(2, shape);
+    PBuf type; type.fld_ld(1, tensor);
+    PBuf vi; vi.fld_str(1, name); vi.fld_ld(2, type);
+    return vi;
+}
+
+static PBuf make_attr_int(const char* name, int64_t val) {
+    PBuf a;
+    a.fld_str(1, name);
+    a.fld_vi(3, static_cast<uint64_t>(val));
+    a.fld_vi(20, 2);
+    return a;
+}
+
+static Ort::Env& get_env() {
+    static Ort::Env env(ORT_LOGGING_LEVEL_ERROR, "bench");
+    return env;
+}
+
+static Ort::MemoryInfo& get_cpu_mem() {
+    static Ort::MemoryInfo mem = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
+    return mem;
+}
+
+static std::vector<uint8_t> build_model(size_t K, size_t N) {
+    const size_t n_blocks = K / bench::kGroupSize;
+    const size_t b_last_dim = bench::kGroupSize;
+    const size_t zp_last_dim = n_blocks;
+
+    PBuf node;
+    node.fld_str(1, "A");
+    node.fld_str(1, "B");
+    node.fld_str(1, "scales");
+    node.fld_str(1, "zero_points");
+    node.fld_str(2, "Y");
+    node.fld_str(4, "MatMulNBits");
+    node.fld_str(7, "com.microsoft");
+    node.fld_ld(5, make_attr_int("K", static_cast<int64_t>(K)));
+    node.fld_ld(5, make_attr_int("N", static_cast<int64_t>(N)));
+    node.fld_ld(5, make_attr_int("bits", 8));
+    node.fld_ld(5, make_attr_int("block_size", static_cast<int64_t>(bench::kGroupSize)));
+    node.fld_ld(5, make_attr_int("accuracy_level", 4));
+
+    auto a_vi  = make_value_info("A", 1, make_dim_param("M"), make_dim_value(K));
+    auto b_vi  = make_value_info("B", 2, make_dim_value(N), make_dim_value(n_blocks),
+                                 make_dim_value(b_last_dim));
+    auto s_vi  = make_value_info("scales", 1, make_dim_value(N), make_dim_value(n_blocks));
+    auto zp_vi = make_value_info("zero_points", 2,
+                                 make_dim_value(N), make_dim_value(zp_last_dim));
+    auto y_vi  = make_value_info("Y", 1, make_dim_param("M"), make_dim_value(N));
+
+    PBuf graph;
+    graph.fld_ld(1, node);
+    graph.fld_str(2, "bench_int8");
+    graph.fld_ld(11, a_vi);
+    graph.fld_ld(11, b_vi);
+    graph.fld_ld(11, s_vi);
+    graph.fld_ld(11, zp_vi);
+    graph.fld_ld(12, y_vi);
+
+    PBuf opset1; opset1.fld_str(1, ""); opset1.fld_vi(2, 13);
+    PBuf opset2; opset2.fld_str(1, "com.microsoft"); opset2.fld_vi(2, 1);
+
+    PBuf model;
+    model.fld_vi(1, 7);
+    model.fld_ld(8, opset1);
+    model.fld_ld(8, opset2);
+    model.fld_ld(7, graph);
+    return model.d;
+}
+
+static constexpr int kGemvThreads = 2;
+static constexpr int kGemmThreads = 3;
+
+struct OrtWeights {
+    size_t K = 0, N = 0;
+    std::vector<uint8_t> B_packed;
+    std::vector<float> scales;
+    std::vector<uint8_t> zero_points;
+};
+
+struct OrtActivations {
+    std::vector<float> fp32;
+};
+
+// Cache ORT sessions by (M, K, N). Session creation costs ~tens of ms each
+// (model parse + graph optimization); without caching, NM matrices ⇒ NM
+// sessions per config — quickly dominates wall time at small dims.
+struct SessionKey { size_t M, K, N; };
+struct SessionKeyHash {
+    size_t operator()(const SessionKey& k) const noexcept {
+        // Pack the three small ints into a single 64-bit value before hashing.
+        // This avoids the high collision rate that XOR-with-shift produces
+        // when M, K, N are powers of two.
+        uint64_t packed = (static_cast<uint64_t>(k.M) * 0x9e3779b97f4a7c15ull)
+                        ^ (static_cast<uint64_t>(k.K) * 0xbf58476d1ce4e5b9ull)
+                        ^ (static_cast<uint64_t>(k.N) * 0x94d049bb133111ebull);
+        return std::hash<uint64_t>{}(packed);
+    }
+};
+struct SessionKeyEq {
+    bool operator()(const SessionKey& a, const SessionKey& b) const noexcept {
+        return a.M == b.M && a.K == b.K && a.N == b.N;
+    }
+};
+
+// Function-local static so its destruction is sequenced AFTER any
+// function-local Ort::Env (constructed in get_env()). Reverse order of
+// construction → reverse order of destruction; Env outlives sessions.
+static auto& matmul_sessions() {
+    static std::unordered_map<SessionKey, std::shared_ptr<Ort::Session>,
+                               SessionKeyHash, SessionKeyEq> m;
+    return m;
+}
+
+static std::shared_ptr<Ort::Session> get_matmul_session(size_t M, size_t K, size_t N) {
+    auto& cache = matmul_sessions();
+    SessionKey key{M, K, N};
+    auto it = cache.find(key);
+    if (it != cache.end()) return it->second;
+
+    try {
+        auto bytes = build_model(K, N);
+        int threads = bench::get_effective_threads((M == 1) ? kGemvThreads : kGemmThreads);
+        Ort::SessionOptions opts;
+        opts.SetIntraOpNumThreads(threads);
+        opts.SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_ENABLE_ALL);
+        auto session = std::make_shared<Ort::Session>(get_env(), bytes.data(), bytes.size(), opts);
+        cache.emplace(key, session);
+        return session;
+    } catch (const Ort::Exception& e) {
+        fprintf(stderr, "[onnxrt matmul] session creation failed (M=%zu K=%zu N=%zu): %s\n",
+                M, K, N, e.what());
+        return nullptr;
+    }
+}
+
+void* prepare_act(const float* fp32, size_t M, size_t K, void* /*raw_weights*/) {
+    auto* a = new OrtActivations();
+    a->fp32.assign(fp32, fp32 + M * K);
+    return a;
+}
+
+void run_kernel(size_t M, size_t K, size_t N,
+                void* weights, void* activations,
+                const int8_t*, const float*,
+                float* output, float*) {
+    auto* w = static_cast<OrtWeights*>(weights);
+    auto* a = static_cast<OrtActivations*>(activations);
+    if (!w || !a) return;
+
+    auto session = get_matmul_session(M, K, N);
+    if (!session) return;     // session creation failed; error already logged
+    auto& mem = get_cpu_mem();
+    const size_t n_blocks = K / bench::kGroupSize;
+    const size_t b_last_dim = bench::kGroupSize;
+    const size_t b_total = N * K;
+    const size_t zp_cols = n_blocks;
+
+    int64_t a_shape[]  = {(int64_t)M, (int64_t)K};
+    int64_t b_shape[]  = {(int64_t)N, (int64_t)n_blocks, (int64_t)b_last_dim};
+    int64_t s_shape[]  = {(int64_t)N, (int64_t)n_blocks};
+    int64_t zp_shape[] = {(int64_t)N, (int64_t)zp_cols};
+
+    Ort::Value inputs[4] = {
+        Ort::Value::CreateTensor<float>(mem, a->fp32.data(), M * K, a_shape, 2),
+        Ort::Value::CreateTensor<uint8_t>(mem, w->B_packed.data(), b_total, b_shape, 3),
+        Ort::Value::CreateTensor<float>(mem, w->scales.data(), N * n_blocks, s_shape, 2),
+        Ort::Value::CreateTensor<uint8_t>(mem, w->zero_points.data(), N * zp_cols, zp_shape, 2),
+    };
+
+    static const char* in_names[]  = {"A", "B", "scales", "zero_points"};
+    static const char* out_names[] = {"Y"};
+
+    Ort::RunOptions run_opts;
+    auto out = session->Run(run_opts, in_names, inputs, 4, out_names, 1);
+    if (output) {
+        const float* y = out[0].GetTensorData<float>();
+        std::memcpy(output, y, M * w->N * sizeof(float));
+    }
+}
+
+void cleanup(void* weights, void* activations) {
+    delete static_cast<OrtWeights*>(weights);
+    if (activations) delete static_cast<OrtActivations*>(activations);
+}
+
+static void pack_int8(OrtWeights* w, const float* fp32) {
+    size_t N = w->N, K = w->K;
+    std::vector<float> src(fp32, fp32 + N * K);
+    std::vector<int8_t> int8_vals;
+    std::vector<float> raw_scales;
+    bench::quantize_int8_per_group(src, N, K, int8_vals, raw_scales);
+
+    w->B_packed.resize(N * K);
+    for (size_t i = 0; i < N * K; i++)
+        w->B_packed[i] = static_cast<uint8_t>(static_cast<int>(int8_vals[i]) + 128);
+
+    w->scales = raw_scales;
+    const size_t n_blocks = K / bench::kGroupSize;
+    w->zero_points.resize(N * n_blocks, 128);
+}
+
+void* i8_prepare(const float* fp32, size_t N, size_t K) {
+    auto* w = new OrtWeights();
+    w->K = K; w->N = N;
+    pack_int8(w, fp32);
+    return w;
+}
+
+// ── Attention via com.microsoft.GroupQueryAttention (FP16) ──────────────────
+//
+// GQA is the only ORT contrib attention op with FP16 support on CPU EP.
+// MultiHeadAttention's CPU registration is FP32-only; same for
+// DecoderMaskedMultiHeadAttention. We use GQA with num_heads==kv_num_heads
+// for graphs 4 & 5.
+//
+//   onnxrt_gqa_prefill         — FP16 Q/K/V, empty past KV (graph 4)
+//   onnxrt_gqa_decode_fp16kv   — FP16 query (M=1), FP16 past KV of length
+//                                cache_len, plus 1 new K/V token (graph 5;
+//                                NOT INT8 KV — ORT has no quantized-KV op)
+//
+// GQA layout:
+//   query / key / value  : [batch, seq, heads*head_dim]      (BSH)
+//   past_key / past_value: [batch, kv_heads, past_seq, head_dim]  (BNSH)
+//   seqlens_k            : int32[batch], = past_sequence_length
+//   total_sequence_length: int32 scalar, = past + new
+//   present_key / present_value (outputs we ignore): BNSH
+
+namespace gqa {
+
+constexpr int kElemFloat16 = 10;  // ONNX TensorProto DataType FP16
+constexpr int kElemInt32   = 6;   // INT32
+constexpr int kAttrTypeInt   = 2;
+constexpr int kAttrTypeFloat = 1;
+
+static PBuf attr_int(const char* name, int64_t val) {
+    PBuf a;
+    a.fld_str(1, name);
+    a.fld_vi(3, static_cast<uint64_t>(val));
+    a.fld_vi(20, kAttrTypeInt);
+    return a;
+}
+
+static PBuf attr_float(const char* name, float val) {
+    PBuf a;
+    a.fld_str(1, name);
+    uint32_t bits;
+    std::memcpy(&bits, &val, 4);
+    a.varint(static_cast<uint64_t>(2) << 3 | 5);  // field 2, fixed32
+    a.d.push_back(static_cast<uint8_t>(bits & 0xFF));
+    a.d.push_back(static_cast<uint8_t>((bits >> 8) & 0xFF));
+    a.d.push_back(static_cast<uint8_t>((bits >> 16) & 0xFF));
+    a.d.push_back(static_cast<uint8_t>((bits >> 24) & 0xFF));
+    a.fld_vi(20, kAttrTypeFloat);
+    return a;
+}
+
+// 0-dim (scalar) value-info: tensor type with empty shape.
+static PBuf make_scalar_value_info(const char* name, int elem_type) {
+    PBuf shape;  // intentionally empty
+    PBuf tensor; tensor.fld_vi(1, elem_type); tensor.fld_ld(2, shape);
+    PBuf type;   type.fld_ld(1, tensor);
+    PBuf vi;     vi.fld_str(1, name); vi.fld_ld(2, type);
+    return vi;
+}
+
+static std::vector<uint8_t> build_gqa_model(size_t q_seq, size_t past_seq, size_t total_seq,
+                                             size_t num_heads, size_t head_dim) {
+    const size_t hidden = num_heads * head_dim;
+    const size_t new_kv_seq = total_seq - past_seq;
+    const bool with_past = (past_seq > 0);
+    // Spec is permissive about layout, but the CPU compute path expects K/V
+    // in 4D BNSH (gqa_attention_base.h:341 — k = K + kv_input_chunk_length *
+    // (i / kv_num_heads_factor)). Q stays 3D BSH; output stays 3D BSH.
+
+    // GQA's past_key/past_value/present_key/present_value are optional. For
+    // the prompt (prefill) phase we skip them entirely — empty strings in the
+    // node's input/output lists, and no matching value_info on the graph. If
+    // we instead pass shape-[1,h,0,d] tensors, the CPU GQA kernel's prompt
+    // path produces wrong results (validated empirically: nrmse=0.87).
+    PBuf node;
+    node.fld_str(1, "Q");
+    node.fld_str(1, "K");
+    node.fld_str(1, "V");
+    node.fld_str(1, with_past ? "past_key"   : "");
+    node.fld_str(1, with_past ? "past_value" : "");
+    node.fld_str(1, "seqlens_k");
+    node.fld_str(1, "total_seq_len");
+    node.fld_str(2, "Y");
+    // GQA op schema requires 3+ outputs. Empty-string outputs aren't allowed,
+    // so always declare present_key/present_value — even for prefill they're
+    // valid: they end up containing K and V written into a freshly-grown
+    // cache buffer.
+    node.fld_str(2, "present_key");
+    node.fld_str(2, "present_value");
+    node.fld_str(4, "GroupQueryAttention");
+    node.fld_str(7, "com.microsoft");
+    node.fld_ld(5, attr_int  ("num_heads",         static_cast<int64_t>(num_heads)));
+    node.fld_ld(5, attr_int  ("kv_num_heads",      static_cast<int64_t>(num_heads)));
+    node.fld_ld(5, attr_int  ("do_rotary",         0));
+    node.fld_ld(5, attr_int  ("rotary_interleaved",0));
+    node.fld_ld(5, attr_int  ("local_window_size", -1));
+    node.fld_ld(5, attr_float("scale",             1.0f / std::sqrt(static_cast<float>(head_dim))));
+    node.fld_ld(5, attr_float("softcap",           0.0f));
+
+    auto q_vi  = make_value_info("Q", kElemFloat16,
+                                  make_dim_value(1), make_dim_value(q_seq), make_dim_value(hidden));
+    auto k_vi  = make_value_info("K", kElemFloat16,
+                                  make_dim_value(1), make_dim_value(new_kv_seq), make_dim_value(hidden));
+    auto v_vi  = make_value_info("V", kElemFloat16,
+                                  make_dim_value(1), make_dim_value(new_kv_seq), make_dim_value(hidden));
+    auto sk_vi = make_value_info("seqlens_k", kElemInt32, make_dim_value(1));
+    auto ts_vi = make_scalar_value_info("total_seq_len", kElemInt32);
+    auto y_vi  = make_value_info("Y", kElemFloat16,
+                                  make_dim_value(1), make_dim_value(q_seq), make_dim_value(hidden));
+
+    PBuf graph;
+    graph.fld_ld(1, node);
+    graph.fld_str(2, "bench_gqa");
+    graph.fld_ld(11, q_vi);
+    graph.fld_ld(11, k_vi);
+    graph.fld_ld(11, v_vi);
+    if (with_past) {
+        auto pk_vi = make_value_info("past_key", kElemFloat16,
+                                      make_dim_value(1), make_dim_value(num_heads),
+                                      make_dim_value(past_seq), make_dim_value(head_dim));
+        auto pv_vi = make_value_info("past_value", kElemFloat16,
+                                      make_dim_value(1), make_dim_value(num_heads),
+                                      make_dim_value(past_seq), make_dim_value(head_dim));
+        graph.fld_ld(11, pk_vi);
+        graph.fld_ld(11, pv_vi);
+    }
+    graph.fld_ld(11, sk_vi);
+    graph.fld_ld(11, ts_vi);
+    graph.fld_ld(12, y_vi);
+    // present_key/present_value always declared (GQA schema requires them).
+    {
+        auto presk_vi = make_value_info("present_key", kElemFloat16,
+                                         make_dim_value(1), make_dim_value(num_heads),
+                                         make_dim_value(total_seq), make_dim_value(head_dim));
+        auto presv_vi = make_value_info("present_value", kElemFloat16,
+                                         make_dim_value(1), make_dim_value(num_heads),
+                                         make_dim_value(total_seq), make_dim_value(head_dim));
+        graph.fld_ld(12, presk_vi);
+        graph.fld_ld(12, presv_vi);
+    }
+
+    PBuf opset1; opset1.fld_str(1, ""); opset1.fld_vi(2, 17);
+    PBuf opset2; opset2.fld_str(1, "com.microsoft"); opset2.fld_vi(2, 1);
+
+    PBuf model;
+    model.fld_vi(1, 7);
+    model.fld_ld(8, opset1);
+    model.fld_ld(8, opset2);
+    model.fld_ld(7, graph);
+    return model.d;
+}
+
+// FP16 conversions (manual, to avoid leaning on __fp16 in this header-public code).
+static uint16_t fp32_to_fp16_bits(float f) {
+    uint32_t x; std::memcpy(&x, &f, 4);
+    uint32_t sign = (x >> 16) & 0x8000;
+    int32_t  exp  = static_cast<int32_t>((x >> 23) & 0xFF) - 127 + 15;
+    uint32_t mant = (x >> 13) & 0x3FF;
+    if (exp <= 0) {
+        if (exp < -10) return static_cast<uint16_t>(sign);
+        mant = ((x & 0x7FFFFF) | 0x800000) >> (1 - exp + 13);
+        return static_cast<uint16_t>(sign | (mant & 0x3FF));
+    }
+    if (exp >= 31) return static_cast<uint16_t>(sign | 0x7C00);
+    return static_cast<uint16_t>(sign | (static_cast<uint32_t>(exp) << 10) | mant);
+}
+static float fp16_bits_to_fp32(uint16_t h) {
+    uint32_t sign = (h & 0x8000) << 16;
+    uint32_t exp  = (h >> 10) & 0x1F;
+    uint32_t mant = h & 0x3FF;
+    uint32_t out;
+    if (exp == 0) {
+        if (mant == 0) { out = sign; }
+        else {
+            while ((mant & 0x400) == 0) { mant <<= 1; exp--; }
+            exp++; mant &= 0x3FF;
+            out = sign | ((exp + 112) << 23) | (mant << 13);
+        }
+    } else if (exp == 31) {
+        out = sign | 0x7F800000 | (mant << 13);
+    } else {
+        out = sign | ((exp + 112) << 23) | (mant << 13);
+    }
+    float f; std::memcpy(&f, &out, 4); return f;
+}
+
+// Driver Q layout [head, seq, head_dim] → ORT BSH layout [1, seq, head*head_dim] FP16.
+static void pack_bsh(const float* src, uint16_t* dst,
+                      size_t num_heads, size_t seq, size_t head_dim) {
+    for (size_t s = 0; s < seq; ++s)
+        for (size_t h = 0; h < num_heads; ++h) {
+            const float* in = src + h * seq * head_dim + s * head_dim;
+            uint16_t* out = dst + s * num_heads * head_dim + h * head_dim;
+            for (size_t d = 0; d < head_dim; ++d)
+                out[d] = fp32_to_fp16_bits(in[d]);
+        }
+}
+
+// Driver K/V layout [head, seq, head_dim] → ORT BNSH layout [1, head, seq, head_dim] FP16.
+// Physical buffer order is identical (head outermost) — just FP32→FP16 cast.
+static void pack_bnsh(const float* src, uint16_t* dst,
+                       size_t num_heads, size_t seq, size_t head_dim) {
+    const size_t total = num_heads * seq * head_dim;
+    for (size_t i = 0; i < total; ++i)
+        dst[i] = fp32_to_fp16_bits(src[i]);
+}
+
+// ORT BSH FP16 → driver [head, seq, head_dim] FP32.
+static void unpack_bsh(const uint16_t* src, float* dst,
+                        size_t num_heads, size_t seq, size_t head_dim) {
+    for (size_t h = 0; h < num_heads; ++h)
+        for (size_t s = 0; s < seq; ++s) {
+            const uint16_t* in = src + s * num_heads * head_dim + h * head_dim;
+            float* out = dst + h * seq * head_dim + s * head_dim;
+            for (size_t d = 0; d < head_dim; ++d)
+                out[d] = fp16_bits_to_fp32(in[d]);
+        }
+}
+
+struct GqaState {
+    bench::AttnDims dims;
+    size_t q_seq;
+    size_t past_seq;
+    size_t new_kv_seq;
+    size_t total_seq;
+    size_t hidden;
+
+    std::vector<uint16_t> q_fp16;             // BSH [1, q_seq, hidden]
+    std::vector<uint16_t> k_new_fp16;         // BSH [1, new_kv_seq, hidden]
+    std::vector<uint16_t> v_new_fp16;         // BSH [1, new_kv_seq, hidden]
+    std::vector<uint16_t> past_key_fp16;      // BNSH [1, h, past_seq, d]
+    std::vector<uint16_t> past_value_fp16;    // BNSH [1, h, past_seq, d]
+    std::vector<uint16_t> present_key_buf;    // BNSH [1, h, total_seq, d] (output, ignored)
+    std::vector<uint16_t> present_value_buf;
+    int32_t seqlens_k_val = 0;
+    int32_t total_seq_val = 0;
+
+    std::unique_ptr<Ort::Session> session;
+    Ort::RunOptions run_opts;
+};
+
+static void* gqa_prepare_impl(const bench::AttnDims& dims, size_t seq_len, size_t cache_len,
+                               const float* fp32_q, const float* fp32_k, const float* fp32_v,
+                               bench::AttnMode mode) {
+    if (dims.num_q_heads != dims.num_kv_heads) {
+        fprintf(stderr, "[onnxrt gqa] this bench wires GQA with h_q==h_kv only\n");
+        return nullptr;
+    }
+
+    auto* s = new GqaState();
+    s->dims = dims;
+    s->hidden = dims.num_q_heads * dims.head_dim;
+
+    // GQA's `seqlens_k` semantic: "index of the last valid token in the
+    // K cache AFTER processing" — i.e., total_sequence_length - 1.
+    // Confirmed against the python prefill test: `seqlens_k = cache_seqlens
+    // - 1` where `cache_seqlens = total_sequence_length`. (The past_seq
+    // interpretation happens to match for decode but is wrong for prefill.)
+    if (mode == bench::AttnMode::PREFILL) {
+        s->q_seq      = seq_len;
+        s->past_seq   = 0;
+        s->new_kv_seq = seq_len;
+        s->total_seq  = seq_len;
+        s->seqlens_k_val = static_cast<int32_t>(seq_len - 1);
+        s->total_seq_val = static_cast<int32_t>(seq_len);
+    } else {
+        s->q_seq      = 1;
+        s->past_seq   = cache_len;
+        s->new_kv_seq = 1;
+        s->total_seq  = cache_len + 1;
+        s->seqlens_k_val = static_cast<int32_t>(cache_len);   // = total_seq - 1
+        s->total_seq_val = static_cast<int32_t>(cache_len + 1);
+    }
+
+    // Q
+    s->q_fp16.resize(s->q_seq * s->hidden);
+    pack_bsh(fp32_q, s->q_fp16.data(), dims.num_q_heads, s->q_seq, dims.head_dim);
+
+    // Split K/V: first past_seq tokens go to past_*, last new_kv_seq tokens go to K/V.
+    // Driver passes K/V in [head, total_kv_seq, head_dim] layout.
+    s->past_key_fp16.resize(dims.num_kv_heads * s->past_seq * dims.head_dim);
+    s->past_value_fp16.resize(dims.num_kv_heads * s->past_seq * dims.head_dim);
+    s->k_new_fp16.resize(s->new_kv_seq * s->hidden);
+    s->v_new_fp16.resize(s->new_kv_seq * s->hidden);
+
+    if (mode == bench::AttnMode::PREFILL) {
+        // No past — whole K/V is "new", BSH layout (3D).
+        pack_bsh(fp32_k, s->k_new_fp16.data(), dims.num_kv_heads, s->new_kv_seq, dims.head_dim);
+        pack_bsh(fp32_v, s->v_new_fp16.data(), dims.num_kv_heads, s->new_kv_seq, dims.head_dim);
+    } else {
+        // Decode: split driver K/V into past (BNSH) + new (BSH).
+        auto split_pack = [&](const float* src, uint16_t* past_dst, uint16_t* new_dst) {
+            std::vector<float> past_only(dims.num_kv_heads * s->past_seq * dims.head_dim);
+            std::vector<float> new_only(dims.num_kv_heads * s->new_kv_seq * dims.head_dim);
+            for (size_t h = 0; h < dims.num_kv_heads; ++h) {
+                const float* head_base = src + h * s->total_seq * dims.head_dim;
+                std::memcpy(past_only.data() + h * s->past_seq * dims.head_dim,
+                            head_base, s->past_seq * dims.head_dim * sizeof(float));
+                std::memcpy(new_only.data() + h * s->new_kv_seq * dims.head_dim,
+                            head_base + s->past_seq * dims.head_dim,
+                            s->new_kv_seq * dims.head_dim * sizeof(float));
+            }
+            pack_bnsh(past_only.data(), past_dst, dims.num_kv_heads, s->past_seq, dims.head_dim);
+            pack_bsh(new_only.data(),   new_dst,  dims.num_kv_heads, s->new_kv_seq, dims.head_dim);
+        };
+        split_pack(fp32_k, s->past_key_fp16.data(),   s->k_new_fp16.data());
+        split_pack(fp32_v, s->past_value_fp16.data(), s->v_new_fp16.data());
+    }
+
+    s->present_key_buf.resize(dims.num_kv_heads * s->total_seq * dims.head_dim);
+    s->present_value_buf.resize(dims.num_kv_heads * s->total_seq * dims.head_dim);
+
+    auto bytes = build_gqa_model(s->q_seq, s->past_seq, s->total_seq,
+                                  dims.num_q_heads, dims.head_dim);
+
+    int threads = bench::get_effective_threads(static_cast<int>(std::thread::hardware_concurrency()));
+    Ort::SessionOptions opts;
+    opts.SetIntraOpNumThreads(threads);
+    opts.SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_ENABLE_ALL);
+    try {
+        s->session = std::make_unique<Ort::Session>(get_env(), bytes.data(), bytes.size(), opts);
+    } catch (const Ort::Exception& e) {
+        fprintf(stderr, "[onnxrt gqa] session creation failed: %s\n", e.what());
+        delete s;
+        return nullptr;
+    }
+    return s;
+}
+
+void* gqa_prefill(const bench::AttnDims& d, size_t sl, size_t cl,
+                  const float* q, const float* k, const float* v) {
+    return gqa_prepare_impl(d, sl, cl, q, k, v, bench::AttnMode::PREFILL);
+}
+void* gqa_decode_fp16kv(const bench::AttnDims& d, size_t sl, size_t cl,
+                         const float* q, const float* k, const float* v) {
+    return gqa_prepare_impl(d, sl, cl, q, k, v, bench::AttnMode::DECODE);
+}
+
+void gqa_run(void* state, float* output) {
+    auto* s = static_cast<GqaState*>(state);
+    if (!s || !s->session) return;
+
+    auto& mem = get_cpu_mem();
+    const bool with_past = (s->past_seq > 0);
+
+    int64_t q_shape[]  = {1, (int64_t)s->q_seq, (int64_t)s->hidden};
+    int64_t kv_shape[] = {1, (int64_t)s->new_kv_seq, (int64_t)s->hidden};
+    int64_t pkv_shape[] = {1, (int64_t)s->dims.num_kv_heads,
+                            (int64_t)s->past_seq, (int64_t)s->dims.head_dim};
+    int64_t sk_shape[] = {1};
+    // 0-dim (scalar) tensor: pass nullptr shape with dim_count=0. A
+    // zero-sized array is non-portable (gcc/clang extension).
+    const int64_t* ts_shape = nullptr;
+
+    if (with_past) {
+        Ort::Value inputs[7] = {
+            Ort::Value::CreateTensor(mem, s->q_fp16.data(), s->q_fp16.size() * sizeof(uint16_t),
+                                      q_shape, 3, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16),
+            Ort::Value::CreateTensor(mem, s->k_new_fp16.data(), s->k_new_fp16.size() * sizeof(uint16_t),
+                                      kv_shape, 3, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16),
+            Ort::Value::CreateTensor(mem, s->v_new_fp16.data(), s->v_new_fp16.size() * sizeof(uint16_t),
+                                      kv_shape, 3, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16),
+            Ort::Value::CreateTensor(mem, s->past_key_fp16.data(), s->past_key_fp16.size() * sizeof(uint16_t),
+                                      pkv_shape, 4, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16),
+            Ort::Value::CreateTensor(mem, s->past_value_fp16.data(), s->past_value_fp16.size() * sizeof(uint16_t),
+                                      pkv_shape, 4, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16),
+            Ort::Value::CreateTensor<int32_t>(mem, &s->seqlens_k_val, 1, sk_shape, 1),
+            Ort::Value::CreateTensor<int32_t>(mem, &s->total_seq_val, 1, ts_shape, 0),
+        };
+        static const char* in_names[]  = {"Q","K","V","past_key","past_value","seqlens_k","total_seq_len"};
+        static const char* out_names[] = {"Y","present_key","present_value"};
+        auto out = s->session->Run(s->run_opts, in_names, inputs, 7, out_names, 3);
+        if (output) {
+            const uint16_t* y = out[0].GetTensorData<uint16_t>();
+            unpack_bsh(y, output, s->dims.num_q_heads, s->q_seq, s->dims.head_dim);
+        }
+    } else {
+        // Prefill: Q/K/V + seqlens_k + total_seq_len. Past inputs are skipped
+        // via empty-string node-input names in the model. We still bind 3
+        // outputs because GQA's schema requires them; we only read Y.
+        Ort::Value inputs[5] = {
+            Ort::Value::CreateTensor(mem, s->q_fp16.data(), s->q_fp16.size() * sizeof(uint16_t),
+                                      q_shape, 3, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16),
+            Ort::Value::CreateTensor(mem, s->k_new_fp16.data(), s->k_new_fp16.size() * sizeof(uint16_t),
+                                      kv_shape, 3, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16),
+            Ort::Value::CreateTensor(mem, s->v_new_fp16.data(), s->v_new_fp16.size() * sizeof(uint16_t),
+                                      kv_shape, 3, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16),
+            Ort::Value::CreateTensor<int32_t>(mem, &s->seqlens_k_val, 1, sk_shape, 1),
+            Ort::Value::CreateTensor<int32_t>(mem, &s->total_seq_val, 1, ts_shape, 0),
+        };
+        static const char* in_names[]  = {"Q","K","V","seqlens_k","total_seq_len"};
+        static const char* out_names[] = {"Y","present_key","present_value"};
+        auto out = s->session->Run(s->run_opts, in_names, inputs, 5, out_names, 3);
+        if (output) {
+            const uint16_t* y = out[0].GetTensorData<uint16_t>();
+            unpack_bsh(y, output, s->dims.num_q_heads, s->q_seq, s->dims.head_dim);
+        }
+    }
+}
+
+void gqa_cleanup(void* state) { delete static_cast<GqaState*>(state); }
+
+} // namespace gqa
+
+static int reg = [] {
+    bench::register_matmul_backend({
+        "onnxrt_int8", "onnxrt",
+        i8_prepare, prepare_act, run_kernel, cleanup
+    });
+    bench::register_attn_backend({
+        "onnxrt_gqa_prefill", "onnxrt", bench::AttnMode::PREFILL,
+        gqa::gqa_prefill, gqa::gqa_run, gqa::gqa_cleanup
+    });
+    // FP16 KV — NOT INT8 KV. Plot with a precision tag: comparison vs cactus's
+    // hybrid_int8 is precision-asymmetric. ORT has no INT8-KV-cache attention op.
+    bench::register_attn_backend({
+        "onnxrt_gqa_decode_fp16kv", "onnxrt", bench::AttnMode::DECODE,
+        gqa::gqa_decode_fp16kv, gqa::gqa_run, gqa::gqa_cleanup
+    });
+    return 0;
+}();
+
+} // namespace
+
+#else
+namespace { [[maybe_unused]] static int reg = []{ return 0; }(); }
+#endif

--- a/tests/bench/backend_onnxrt.cpp
+++ b/tests/bench/backend_onnxrt.cpp
@@ -131,9 +131,7 @@ struct OrtActivations {
 struct SessionKey { size_t M, K, N; };
 struct SessionKeyHash {
     size_t operator()(const SessionKey& k) const noexcept {
-        // Pack the three small ints into a single 64-bit value before hashing.
-        // This avoids the high collision rate that XOR-with-shift produces
-        // when M, K, N are powers of two.
+        // Avoid XOR-with-shift's high collision rate on power-of-two M, K, N.
         uint64_t packed = (static_cast<uint64_t>(k.M) * 0x9e3779b97f4a7c15ull)
                         ^ (static_cast<uint64_t>(k.K) * 0xbf58476d1ce4e5b9ull)
                         ^ (static_cast<uint64_t>(k.N) * 0x94d049bb133111ebull);
@@ -192,7 +190,7 @@ void run_kernel(size_t M, size_t K, size_t N,
     if (!w || !a) return;
 
     auto session = get_matmul_session(M, K, N);
-    if (!session) return;     // session creation failed; error already logged
+    if (!session) return;
     auto& mem = get_cpu_mem();
     const size_t n_blocks = K / bench::kGroupSize;
     const size_t b_last_dim = bench::kGroupSize;
@@ -250,29 +248,15 @@ void* i8_prepare(const float* fp32, size_t N, size_t K) {
     return w;
 }
 
-// ── Attention via com.microsoft.GroupQueryAttention (FP16) ──────────────────
-//
-// GQA is the only ORT contrib attention op with FP16 support on CPU EP.
-// MultiHeadAttention's CPU registration is FP32-only; same for
-// DecoderMaskedMultiHeadAttention. We use GQA with num_heads==kv_num_heads
-// for graphs 4 & 5.
-//
-//   onnxrt_gqa_prefill         — FP16 Q/K/V, empty past KV (graph 4)
-//   onnxrt_gqa_decode_fp16kv   — FP16 query (M=1), FP16 past KV of length
-//                                cache_len, plus 1 new K/V token (graph 5;
-//                                NOT INT8 KV — ORT has no quantized-KV op)
-//
-// GQA layout:
-//   query / key / value  : [batch, seq, heads*head_dim]      (BSH)
-//   past_key / past_value: [batch, kv_heads, past_seq, head_dim]  (BNSH)
-//   seqlens_k            : int32[batch], = past_sequence_length
-//   total_sequence_length: int32 scalar, = past + new
-//   present_key / present_value (outputs we ignore): BNSH
+// GQA is the only ORT contrib attention op with FP16 support on CPU EP
+// (MultiHeadAttention and DecoderMaskedMultiHeadAttention CPU registrations
+// are FP32-only). We use GQA with num_heads==kv_num_heads. Decode runs FP16
+// KV, not INT8 — ORT has no quantized-KV attention op.
 
 namespace gqa {
 
-constexpr int kElemFloat16 = 10;  // ONNX TensorProto DataType FP16
-constexpr int kElemInt32   = 6;   // INT32
+constexpr int kElemFloat16 = 10;
+constexpr int kElemInt32   = 6;
 constexpr int kAttrTypeInt   = 2;
 constexpr int kAttrTypeFloat = 1;
 
@@ -289,7 +273,7 @@ static PBuf attr_float(const char* name, float val) {
     a.fld_str(1, name);
     uint32_t bits;
     std::memcpy(&bits, &val, 4);
-    a.varint(static_cast<uint64_t>(2) << 3 | 5);  // field 2, fixed32
+    a.varint(static_cast<uint64_t>(2) << 3 | 5);
     a.d.push_back(static_cast<uint8_t>(bits & 0xFF));
     a.d.push_back(static_cast<uint8_t>((bits >> 8) & 0xFF));
     a.d.push_back(static_cast<uint8_t>((bits >> 16) & 0xFF));
@@ -298,9 +282,8 @@ static PBuf attr_float(const char* name, float val) {
     return a;
 }
 
-// 0-dim (scalar) value-info: tensor type with empty shape.
 static PBuf make_scalar_value_info(const char* name, int elem_type) {
-    PBuf shape;  // intentionally empty
+    PBuf shape;
     PBuf tensor; tensor.fld_vi(1, elem_type); tensor.fld_ld(2, shape);
     PBuf type;   type.fld_ld(1, tensor);
     PBuf vi;     vi.fld_str(1, name); vi.fld_ld(2, type);
@@ -312,15 +295,11 @@ static std::vector<uint8_t> build_gqa_model(size_t q_seq, size_t past_seq, size_
     const size_t hidden = num_heads * head_dim;
     const size_t new_kv_seq = total_seq - past_seq;
     const bool with_past = (past_seq > 0);
-    // Spec is permissive about layout, but the CPU compute path expects K/V
-    // in 4D BNSH (gqa_attention_base.h:341 — k = K + kv_input_chunk_length *
-    // (i / kv_num_heads_factor)). Q stays 3D BSH; output stays 3D BSH.
-
-    // GQA's past_key/past_value/present_key/present_value are optional. For
-    // the prompt (prefill) phase we skip them entirely — empty strings in the
-    // node's input/output lists, and no matching value_info on the graph. If
-    // we instead pass shape-[1,h,0,d] tensors, the CPU GQA kernel's prompt
-    // path produces wrong results (validated empirically: nrmse=0.87).
+    // The CPU compute path expects K/V as 4D BNSH (gqa_attention_base.h:341).
+    // For prefill (no past), we omit past_key/past_value entirely — empty
+    // strings in the node's input list and no matching value_info. Passing
+    // shape-[1,h,0,d] tensors instead silently corrupts output on the prompt
+    // path (nrmse=0.87).
     PBuf node;
     node.fld_str(1, "Q");
     node.fld_str(1, "K");
@@ -330,10 +309,8 @@ static std::vector<uint8_t> build_gqa_model(size_t q_seq, size_t past_seq, size_
     node.fld_str(1, "seqlens_k");
     node.fld_str(1, "total_seq_len");
     node.fld_str(2, "Y");
-    // GQA op schema requires 3+ outputs. Empty-string outputs aren't allowed,
-    // so always declare present_key/present_value — even for prefill they're
-    // valid: they end up containing K and V written into a freshly-grown
-    // cache buffer.
+    // GQA schema requires 3+ outputs and disallows empty-string outputs, so
+    // present_key/present_value are always declared (even for prefill).
     node.fld_str(2, "present_key");
     node.fld_str(2, "present_value");
     node.fld_str(4, "GroupQueryAttention");
@@ -376,7 +353,6 @@ static std::vector<uint8_t> build_gqa_model(size_t q_seq, size_t past_seq, size_
     graph.fld_ld(11, sk_vi);
     graph.fld_ld(11, ts_vi);
     graph.fld_ld(12, y_vi);
-    // present_key/present_value always declared (GQA schema requires them).
     {
         auto presk_vi = make_value_info("present_key", kElemFloat16,
                                          make_dim_value(1), make_dim_value(num_heads),
@@ -399,7 +375,6 @@ static std::vector<uint8_t> build_gqa_model(size_t q_seq, size_t past_seq, size_
     return model.d;
 }
 
-// FP16 conversions (manual, to avoid leaning on __fp16 in this header-public code).
 static uint16_t fp32_to_fp16_bits(float f) {
     uint32_t x; std::memcpy(&x, &f, 4);
     uint32_t sign = (x >> 16) & 0x8000;
@@ -433,7 +408,7 @@ static float fp16_bits_to_fp32(uint16_t h) {
     float f; std::memcpy(&f, &out, 4); return f;
 }
 
-// Driver Q layout [head, seq, head_dim] → ORT BSH layout [1, seq, head*head_dim] FP16.
+// Driver [head, seq, head_dim] → ORT BSH [1, seq, head*head_dim] FP16.
 static void pack_bsh(const float* src, uint16_t* dst,
                       size_t num_heads, size_t seq, size_t head_dim) {
     for (size_t s = 0; s < seq; ++s)
@@ -445,8 +420,8 @@ static void pack_bsh(const float* src, uint16_t* dst,
         }
 }
 
-// Driver K/V layout [head, seq, head_dim] → ORT BNSH layout [1, head, seq, head_dim] FP16.
-// Physical buffer order is identical (head outermost) — just FP32→FP16 cast.
+// Driver [head, seq, head_dim] and ORT BNSH [1, head, seq, head_dim] share
+// the same physical buffer order, so this is just FP32 → FP16.
 static void pack_bnsh(const float* src, uint16_t* dst,
                        size_t num_heads, size_t seq, size_t head_dim) {
     const size_t total = num_heads * seq * head_dim;
@@ -454,7 +429,6 @@ static void pack_bnsh(const float* src, uint16_t* dst,
         dst[i] = fp32_to_fp16_bits(src[i]);
 }
 
-// ORT BSH FP16 → driver [head, seq, head_dim] FP32.
 static void unpack_bsh(const uint16_t* src, float* dst,
                         size_t num_heads, size_t seq, size_t head_dim) {
     for (size_t h = 0; h < num_heads; ++h)
@@ -474,12 +448,12 @@ struct GqaState {
     size_t total_seq;
     size_t hidden;
 
-    std::vector<uint16_t> q_fp16;             // BSH [1, q_seq, hidden]
-    std::vector<uint16_t> k_new_fp16;         // BSH [1, new_kv_seq, hidden]
-    std::vector<uint16_t> v_new_fp16;         // BSH [1, new_kv_seq, hidden]
-    std::vector<uint16_t> past_key_fp16;      // BNSH [1, h, past_seq, d]
-    std::vector<uint16_t> past_value_fp16;    // BNSH [1, h, past_seq, d]
-    std::vector<uint16_t> present_key_buf;    // BNSH [1, h, total_seq, d] (output, ignored)
+    std::vector<uint16_t> q_fp16;
+    std::vector<uint16_t> k_new_fp16;
+    std::vector<uint16_t> v_new_fp16;
+    std::vector<uint16_t> past_key_fp16;
+    std::vector<uint16_t> past_value_fp16;
+    std::vector<uint16_t> present_key_buf;
     std::vector<uint16_t> present_value_buf;
     int32_t seqlens_k_val = 0;
     int32_t total_seq_val = 0;
@@ -500,11 +474,9 @@ static void* gqa_prepare_impl(const bench::AttnDims& dims, size_t seq_len, size_
     s->dims = dims;
     s->hidden = dims.num_q_heads * dims.head_dim;
 
-    // GQA's `seqlens_k` semantic: "index of the last valid token in the
-    // K cache AFTER processing" — i.e., total_sequence_length - 1.
-    // Confirmed against the python prefill test: `seqlens_k = cache_seqlens
-    // - 1` where `cache_seqlens = total_sequence_length`. (The past_seq
-    // interpretation happens to match for decode but is wrong for prefill.)
+    // GQA's `seqlens_k` is "index of the last valid token in the K cache
+    // AFTER processing", i.e., total_sequence_length - 1. The past_seq
+    // interpretation happens to match for decode but is wrong for prefill.
     if (mode == bench::AttnMode::PREFILL) {
         s->q_seq      = seq_len;
         s->past_seq   = 0;
@@ -517,27 +489,22 @@ static void* gqa_prepare_impl(const bench::AttnDims& dims, size_t seq_len, size_
         s->past_seq   = cache_len;
         s->new_kv_seq = 1;
         s->total_seq  = cache_len + 1;
-        s->seqlens_k_val = static_cast<int32_t>(cache_len);   // = total_seq - 1
+        s->seqlens_k_val = static_cast<int32_t>(cache_len);
         s->total_seq_val = static_cast<int32_t>(cache_len + 1);
     }
 
-    // Q
     s->q_fp16.resize(s->q_seq * s->hidden);
     pack_bsh(fp32_q, s->q_fp16.data(), dims.num_q_heads, s->q_seq, dims.head_dim);
 
-    // Split K/V: first past_seq tokens go to past_*, last new_kv_seq tokens go to K/V.
-    // Driver passes K/V in [head, total_kv_seq, head_dim] layout.
     s->past_key_fp16.resize(dims.num_kv_heads * s->past_seq * dims.head_dim);
     s->past_value_fp16.resize(dims.num_kv_heads * s->past_seq * dims.head_dim);
     s->k_new_fp16.resize(s->new_kv_seq * s->hidden);
     s->v_new_fp16.resize(s->new_kv_seq * s->hidden);
 
     if (mode == bench::AttnMode::PREFILL) {
-        // No past — whole K/V is "new", BSH layout (3D).
         pack_bsh(fp32_k, s->k_new_fp16.data(), dims.num_kv_heads, s->new_kv_seq, dims.head_dim);
         pack_bsh(fp32_v, s->v_new_fp16.data(), dims.num_kv_heads, s->new_kv_seq, dims.head_dim);
     } else {
-        // Decode: split driver K/V into past (BNSH) + new (BSH).
         auto split_pack = [&](const float* src, uint16_t* past_dst, uint16_t* new_dst) {
             std::vector<float> past_only(dims.num_kv_heads * s->past_seq * dims.head_dim);
             std::vector<float> new_only(dims.num_kv_heads * s->new_kv_seq * dims.head_dim);
@@ -597,8 +564,8 @@ void gqa_run(void* state, float* output) {
     int64_t pkv_shape[] = {1, (int64_t)s->dims.num_kv_heads,
                             (int64_t)s->past_seq, (int64_t)s->dims.head_dim};
     int64_t sk_shape[] = {1};
-    // 0-dim (scalar) tensor: pass nullptr shape with dim_count=0. A
-    // zero-sized array is non-portable (gcc/clang extension).
+    // 0-dim scalar tensor: pass nullptr shape with dim_count=0 (a zero-sized
+    // array is a gcc/clang extension, not portable).
     const int64_t* ts_shape = nullptr;
 
     if (with_past) {
@@ -624,9 +591,6 @@ void gqa_run(void* state, float* output) {
             unpack_bsh(y, output, s->dims.num_q_heads, s->q_seq, s->dims.head_dim);
         }
     } else {
-        // Prefill: Q/K/V + seqlens_k + total_seq_len. Past inputs are skipped
-        // via empty-string node-input names in the model. We still bind 3
-        // outputs because GQA's schema requires them; we only read Y.
         Ort::Value inputs[5] = {
             Ort::Value::CreateTensor(mem, s->q_fp16.data(), s->q_fp16.size() * sizeof(uint16_t),
                                       q_shape, 3, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16),
@@ -660,8 +624,8 @@ static int reg = [] {
         "onnxrt_gqa_prefill", "onnxrt", bench::AttnMode::PREFILL,
         gqa::gqa_prefill, gqa::gqa_run, gqa::gqa_cleanup
     });
-    // FP16 KV — NOT INT8 KV. Plot with a precision tag: comparison vs cactus's
-    // hybrid_int8 is precision-asymmetric. ORT has no INT8-KV-cache attention op.
+    // FP16 KV (not INT8) — comparison vs cactus's hybrid_int8 is
+    // precision-asymmetric; ORT has no INT8-KV-cache attention op.
     bench::register_attn_backend({
         "onnxrt_gqa_decode_fp16kv", "onnxrt", bench::AttnMode::DECODE,
         gqa::gqa_decode_fp16kv, gqa::gqa_run, gqa::gqa_cleanup

--- a/tests/bench/bench_common.cpp
+++ b/tests/bench/bench_common.cpp
@@ -61,9 +61,11 @@ std::vector<AttnConfig> build_attn_configs(const AttnBenchOptions& opt) {
     if (dims.empty()) dims = default_dim_sweep();
 
     AttnDims base{};
-    base.head_dim = opt.model_dim / opt.num_heads;
+    base.head_dim = opt.head_dim_override > 0
+                    ? opt.head_dim_override
+                    : opt.model_dim / opt.num_heads;
     base.num_q_heads = opt.num_heads;
-    base.num_kv_heads = opt.num_heads;
+    base.num_kv_heads = opt.num_kv_heads > 0 ? opt.num_kv_heads : opt.num_heads;
 
     std::vector<AttnConfig> out;
     for (auto g : opt.graphs) {
@@ -208,7 +210,8 @@ void reference_attention_fp32(const float* Q, const float* K, const float* V,
                                float* output,
                                size_t num_q_heads, size_t num_kv_heads,
                                size_t seq_len, size_t kv_seq_len,
-                               size_t head_dim, float scale) {
+                               size_t head_dim, float scale,
+                               size_t window_size) {
     size_t gqa_ratio = num_q_heads / num_kv_heads;
 
     for (size_t qh = 0; qh < num_q_heads; ++qh) {
@@ -218,9 +221,11 @@ void reference_attention_fp32(const float* Q, const float* K, const float* V,
             std::vector<double> scores(kv_seq_len);
             double max_score = -1e30;
 
+            const size_t abs_q = sq + (kv_seq_len - seq_len);
             for (size_t sk = 0; sk < kv_seq_len; ++sk) {
-                bool is_masked = sk > sq + (kv_seq_len - seq_len);
-                if (is_masked) { scores[sk] = -1e30; continue; }
+                bool causal_masked = sk > abs_q;
+                bool window_masked = (window_size > 0 && abs_q > window_size && sk < abs_q - window_size);
+                if (causal_masked || window_masked) { scores[sk] = -1e30; continue; }
                 double dot = 0.0;
                 for (size_t d = 0; d < head_dim; ++d)
                     dot += static_cast<double>(Q[qh * seq_len * head_dim + sq * head_dim + d]) *
@@ -429,6 +434,12 @@ bool parse_attn_bench_args(int argc, char** argv, AttnBenchOptions& opt, std::st
         } else if (a == "--heads") {
             if (++i >= argc) { err = "Missing --heads value"; return false; }
             opt.num_heads = static_cast<size_t>(std::max(1, std::stoi(argv[i])));
+        } else if (a == "--kv_heads") {
+            if (++i >= argc) { err = "Missing --kv_heads value"; return false; }
+            opt.num_kv_heads = static_cast<size_t>(std::max(1, std::stoi(argv[i])));
+        } else if (a == "--head_dim") {
+            if (++i >= argc) { err = "Missing --head_dim value"; return false; }
+            opt.head_dim_override = static_cast<size_t>(std::max(1, std::stoi(argv[i])));
         } else if (a == "--csv") {
             if (++i >= argc) { err = "Missing --csv value"; return false; }
             opt.csv_path = argv[i];

--- a/tests/bench/bench_common.cpp
+++ b/tests/bench/bench_common.cpp
@@ -1,0 +1,450 @@
+#include "bench_common.h"
+
+#include <algorithm>
+#include <arm_neon.h>
+#include <cmath>
+#include <thread>
+
+namespace bench {
+
+static int s_thread_override = 0;
+
+void set_thread_override(int n) { s_thread_override = n; }
+int get_thread_override() { return s_thread_override; }
+int get_effective_threads(int backend_default) {
+    return s_thread_override > 0 ? s_thread_override : backend_default;
+}
+
+const char* matmul_graph_name(MatmulGraph g) {
+    switch (g) {
+        case MatmulGraph::GEMV_D:  return "gemv_d";
+        case MatmulGraph::GEMM_D:  return "gemm_d";
+        case MatmulGraph::GEMM_MN: return "gemm_mn";
+    }
+    return "unknown";
+}
+
+const char* attn_graph_name(AttnGraph g) {
+    switch (g) {
+        case AttnGraph::PREFILL_S:    return "attn_prefill_s";
+        case AttnGraph::DECODE_CACHE: return "attn_decode_cache";
+    }
+    return "unknown";
+}
+
+std::vector<MatmulConfig> build_matmul_configs(const MatmulBenchOptions& opt) {
+    std::vector<size_t> dims = opt.dims;
+    if (dims.empty()) dims = default_dim_sweep();
+
+    std::vector<MatmulConfig> out;
+    for (auto g : opt.graphs) {
+        for (size_t d : dims) {
+            MatmulConfig c{};
+            c.graph = g;
+            c.sweep_dim = d;
+            switch (g) {
+                case MatmulGraph::GEMV_D:
+                    c.M = 1; c.K = d; c.N = d; break;
+                case MatmulGraph::GEMM_D:
+                    c.M = 512; c.K = d; c.N = 512; break;
+                case MatmulGraph::GEMM_MN:
+                    c.M = d; c.K = 512; c.N = d; break;
+            }
+            out.push_back(c);
+        }
+    }
+    return out;
+}
+
+std::vector<AttnConfig> build_attn_configs(const AttnBenchOptions& opt) {
+    std::vector<size_t> dims = opt.dims;
+    if (dims.empty()) dims = default_dim_sweep();
+
+    AttnDims base{};
+    base.head_dim = opt.model_dim / opt.num_heads;
+    base.num_q_heads = opt.num_heads;
+    base.num_kv_heads = opt.num_heads;
+
+    std::vector<AttnConfig> out;
+    for (auto g : opt.graphs) {
+        for (size_t d : dims) {
+            AttnConfig c{};
+            c.graph = g;
+            c.dims = base;
+            c.sweep_dim = d;
+            if (g == AttnGraph::PREFILL_S) {
+                c.mode = AttnMode::PREFILL;
+                c.seq_len = d;
+                c.cache_len = 0;
+            } else {
+                c.mode = AttnMode::DECODE;
+                c.seq_len = 1;
+                c.cache_len = d;
+            }
+            out.push_back(c);
+        }
+    }
+    return out;
+}
+
+static void quantize_per_group(const std::vector<float>& src, size_t N, size_t K,
+                                std::vector<int8_t>& dst, std::vector<float>& scales,
+                                int qmax, int qmin) {
+    const size_t num_groups = K / kGroupSize;
+    dst.resize(N * K);
+    scales.resize(N * num_groups);
+    for (size_t n = 0; n < N; ++n) {
+        for (size_t g = 0; g < num_groups; ++g) {
+            float max_abs = 0.0f;
+            const size_t base = n * K + g * kGroupSize;
+            for (size_t k = 0; k < kGroupSize; ++k)
+                max_abs = std::max(max_abs, std::abs(src[base + k]));
+            float scale = std::max(max_abs / static_cast<float>(qmax), 1e-10f);
+            scales[n * num_groups + g] = scale;
+            for (size_t k = 0; k < kGroupSize; ++k) {
+                int q = static_cast<int>(std::round(src[base + k] / scale));
+                dst[base + k] = static_cast<int8_t>(std::max(qmin, std::min(qmax, q)));
+            }
+        }
+    }
+}
+
+void quantize_int8_per_group(const std::vector<float>& src, size_t N, size_t K,
+                              std::vector<int8_t>& dst, std::vector<float>& scales) {
+    quantize_per_group(src, N, K, dst, scales, 127, -128);
+}
+
+std::vector<int8_t> interleave_weights_nk4(const std::vector<int8_t>& rowmajor, size_t N, size_t K) {
+    const size_t N_blocks = N / kBlockSize;
+    const size_t K_blocks = K / kBlockSize;
+    std::vector<int8_t> out(N * K);
+    for (size_t nb = 0; nb < N_blocks; ++nb)
+        for (size_t kb = 0; kb < K_blocks; ++kb)
+            for (size_t ni = 0; ni < kBlockSize; ++ni)
+                for (size_t ki = 0; ki < kBlockSize; ++ki)
+                    out[(nb * K_blocks + kb) * kBlockSize * kBlockSize + ni * kBlockSize + ki] =
+                        rowmajor[(nb * kBlockSize + ni) * K + kb * kBlockSize + ki];
+    return out;
+}
+
+std::vector<__fp16> interleave_scales_n4(const std::vector<float>& scales, size_t N, size_t num_groups) {
+    const size_t N_blocks = N / kBlockSize;
+    std::vector<__fp16> out(N * num_groups);
+    for (size_t nb = 0; nb < N_blocks; ++nb)
+        for (size_t g = 0; g < num_groups; ++g)
+            for (size_t ni = 0; ni < kBlockSize; ++ni)
+                out[(nb * num_groups + g) * kBlockSize + ni] =
+                    static_cast<__fp16>(scales[(nb * kBlockSize + ni) * num_groups + g]);
+    return out;
+}
+
+CactusActivations prepare_cactus_activations(size_t M, size_t K, std::mt19937& gen) {
+    std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+    CactusActivations a;
+
+    a.fp32.resize(M * K);
+    for (auto& v : a.fp32) v = dist(gen);
+
+    a.fp16.resize(M * K);
+    for (size_t i = 0; i < M * K; ++i)
+        a.fp16[i] = static_cast<__fp16>(a.fp32[i]);
+
+    a.int8.resize(M * K);
+    a.scales.resize(M);
+    for (size_t m = 0; m < M; ++m) {
+        float max_abs = cactus_fp16_max_abs(a.fp16.data() + m * K, K);
+        float scale = std::max(max_abs / 127.0f, 1e-10f);
+        a.scales[m] = scale;
+        cactus_fp16_to_int8(a.fp16.data() + m * K, a.int8.data() + m * K, K, scale);
+    }
+    return a;
+}
+
+void reference_matmul_fp32(const float* A, const float* B_rowmajor_NK,
+                            float* C, size_t M, size_t K, size_t N) {
+    for (size_t m = 0; m < M; m++)
+        for (size_t n = 0; n < N; n++) {
+            double sum = 0.0;
+            for (size_t k = 0; k < K; k++)
+                sum += static_cast<double>(A[m * K + k]) *
+                       static_cast<double>(B_rowmajor_NK[n * K + k]);
+            C[m * N + n] = static_cast<float>(sum);
+        }
+}
+
+AccuracyResult check_accuracy(const float* reference, const float* actual,
+                               size_t count, float nrmse_tolerance) {
+    AccuracyResult r;
+    double sum_sq_err = 0.0;
+    double sum_sq_ref = 0.0;
+    for (size_t i = 0; i < count; i++) {
+        float err = std::abs(reference[i] - actual[i]);
+        if (err > r.max_abs_error) r.max_abs_error = err;
+        sum_sq_err += static_cast<double>(err) * err;
+        sum_sq_ref += static_cast<double>(reference[i]) * reference[i];
+    }
+    float rms_ref = static_cast<float>(std::sqrt(sum_sq_ref / std::max(count, size_t(1))));
+    float rms_err = static_cast<float>(std::sqrt(sum_sq_err / std::max(count, size_t(1))));
+    r.nrmse = (rms_ref > 1e-6f) ? rms_err / rms_ref : rms_err;
+    r.passed = r.nrmse <= nrmse_tolerance;
+    return r;
+}
+
+bool framework_matches_filter(const char* framework, const std::string& filter) {
+    if (filter.empty()) return true;
+    std::string fw(framework);
+    size_t pos = 0;
+    while (pos < filter.size()) {
+        size_t comma = filter.find(',', pos);
+        if (comma == std::string::npos) comma = filter.size();
+        std::string token = filter.substr(pos, comma - pos);
+        if (token == fw) return true;
+        pos = comma + 1;
+    }
+    return false;
+}
+
+void reference_attention_fp32(const float* Q, const float* K, const float* V,
+                               float* output,
+                               size_t num_q_heads, size_t num_kv_heads,
+                               size_t seq_len, size_t kv_seq_len,
+                               size_t head_dim, float scale) {
+    size_t gqa_ratio = num_q_heads / num_kv_heads;
+
+    for (size_t qh = 0; qh < num_q_heads; ++qh) {
+        size_t kvh = qh / gqa_ratio;
+
+        for (size_t sq = 0; sq < seq_len; ++sq) {
+            std::vector<double> scores(kv_seq_len);
+            double max_score = -1e30;
+
+            for (size_t sk = 0; sk < kv_seq_len; ++sk) {
+                bool is_masked = sk > sq + (kv_seq_len - seq_len);
+                if (is_masked) { scores[sk] = -1e30; continue; }
+                double dot = 0.0;
+                for (size_t d = 0; d < head_dim; ++d)
+                    dot += static_cast<double>(Q[qh * seq_len * head_dim + sq * head_dim + d]) *
+                           static_cast<double>(K[kvh * kv_seq_len * head_dim + sk * head_dim + d]);
+                scores[sk] = dot * scale;
+                if (scores[sk] > max_score) max_score = scores[sk];
+            }
+
+            double sum_exp = 0.0;
+            for (size_t sk = 0; sk < kv_seq_len; ++sk) {
+                scores[sk] = std::exp(scores[sk] - max_score);
+                sum_exp += scores[sk];
+            }
+            for (size_t sk = 0; sk < kv_seq_len; ++sk) scores[sk] /= sum_exp;
+
+            for (size_t d = 0; d < head_dim; ++d) {
+                double val = 0.0;
+                for (size_t sk = 0; sk < kv_seq_len; ++sk)
+                    val += scores[sk] *
+                           static_cast<double>(V[kvh * kv_seq_len * head_dim + sk * head_dim + d]);
+                output[qh * seq_len * head_dim + sq * head_dim + d] = static_cast<float>(val);
+            }
+        }
+    }
+}
+
+void fp32_to_fp16(const float* src, __fp16* dst, size_t count) {
+    size_t i = 0;
+    for (; i + 8 <= count; i += 8) {
+        float32x4_t lo = vld1q_f32(src + i);
+        float32x4_t hi = vld1q_f32(src + i + 4);
+        vst1_f16(reinterpret_cast<float16_t*>(dst + i), vcvt_f16_f32(lo));
+        vst1_f16(reinterpret_cast<float16_t*>(dst + i + 4), vcvt_f16_f32(hi));
+    }
+    for (; i < count; ++i) dst[i] = static_cast<__fp16>(src[i]);
+}
+
+void fp16_to_fp32(const __fp16* src, float* dst, size_t count) {
+    size_t i = 0;
+    for (; i + 8 <= count; i += 8) {
+        float16x8_t v = vld1q_f16(reinterpret_cast<const float16_t*>(src + i));
+        vst1q_f32(dst + i, vcvt_f32_f16(vget_low_f16(v)));
+        vst1q_f32(dst + i + 4, vcvt_f32_f16(vget_high_f16(v)));
+    }
+    for (; i < count; ++i) dst[i] = static_cast<float>(src[i]);
+}
+
+void quantize_rows_int8(const float* src, int8_t* dst, float* scales,
+                         size_t rows, size_t cols) {
+    for (size_t r = 0; r < rows; ++r) {
+        const float* row = src + r * cols;
+        int8_t* out = dst + r * cols;
+
+        float32x4_t vmax = vdupq_n_f32(0.0f);
+        size_t c = 0;
+        for (; c + 4 <= cols; c += 4)
+            vmax = vmaxq_f32(vmax, vabsq_f32(vld1q_f32(row + c)));
+        float max_abs = vmaxvq_f32(vmax);
+        for (; c < cols; ++c)
+            max_abs = std::max(max_abs, std::abs(row[c]));
+
+        float scale = std::max(max_abs / 127.0f, 1e-10f);
+        scales[r] = scale;
+        float inv_scale = 1.0f / scale;
+        float32x4_t vinv = vdupq_n_f32(inv_scale);
+
+        c = 0;
+        for (; c + 8 <= cols; c += 8) {
+            float32x4_t f0 = vmulq_f32(vld1q_f32(row + c), vinv);
+            float32x4_t f1 = vmulq_f32(vld1q_f32(row + c + 4), vinv);
+            int32x4_t i0 = vcvtnq_s32_f32(f0);
+            int32x4_t i1 = vcvtnq_s32_f32(f1);
+            int16x4_t s0 = vqmovn_s32(i0);
+            int16x4_t s1 = vqmovn_s32(i1);
+            int8x8_t b = vqmovn_s16(vcombine_s16(s0, s1));
+            vst1_s8(out + c, b);
+        }
+        for (; c < cols; ++c) {
+            int q = static_cast<int>(std::round(row[c] * inv_scale));
+            out[c] = static_cast<int8_t>(std::max(-128, std::min(127, q)));
+        }
+    }
+}
+
+void transpose_2d(const float* src, float* dst, size_t rows, size_t cols) {
+    for (size_t r = 0; r < rows; ++r)
+        for (size_t c = 0; c < cols; ++c)
+            dst[c * rows + r] = src[r * cols + c];
+}
+
+static bool parse_dim_list(const std::string& csv, std::vector<size_t>& out) {
+    out.clear();
+    size_t pos = 0;
+    while (pos < csv.size()) {
+        size_t comma = csv.find(',', pos);
+        if (comma == std::string::npos) comma = csv.size();
+        std::string tok = csv.substr(pos, comma - pos);
+        if (tok.empty()) return false;
+        try { out.push_back(static_cast<size_t>(std::stoull(tok))); }
+        catch (...) { return false; }
+        pos = comma + 1;
+    }
+    return !out.empty();
+}
+
+static bool parse_matmul_graphs(const std::string& csv, std::vector<MatmulGraph>& out) {
+    out.clear();
+    size_t pos = 0;
+    while (pos < csv.size()) {
+        size_t comma = csv.find(',', pos);
+        if (comma == std::string::npos) comma = csv.size();
+        std::string tok = csv.substr(pos, comma - pos);
+        if      (tok == "gemv_d")  out.push_back(MatmulGraph::GEMV_D);
+        else if (tok == "gemm_d")  out.push_back(MatmulGraph::GEMM_D);
+        else if (tok == "gemm_mn") out.push_back(MatmulGraph::GEMM_MN);
+        else return false;
+        pos = comma + 1;
+    }
+    return !out.empty();
+}
+
+static bool parse_attn_graphs(const std::string& csv, std::vector<AttnGraph>& out) {
+    out.clear();
+    size_t pos = 0;
+    while (pos < csv.size()) {
+        size_t comma = csv.find(',', pos);
+        if (comma == std::string::npos) comma = csv.size();
+        std::string tok = csv.substr(pos, comma - pos);
+        if      (tok == "attn_prefill_s")    out.push_back(AttnGraph::PREFILL_S);
+        else if (tok == "attn_decode_cache") out.push_back(AttnGraph::DECODE_CACHE);
+        else return false;
+        pos = comma + 1;
+    }
+    return !out.empty();
+}
+
+bool parse_matmul_bench_args(int argc, char** argv, MatmulBenchOptions& opt, std::string& err) {
+    for (int i = 1; i < argc; ++i) {
+        std::string a(argv[i]);
+        if (a == "--iterations") {
+            if (++i >= argc) { err = "Missing --iterations value"; return false; }
+            opt.iterations = std::max(1, std::stoi(argv[i]));
+        } else if (a == "--warmup") {
+            if (++i >= argc) { err = "Missing --warmup value"; return false; }
+            opt.warmup = std::max(0, std::stoi(argv[i]));
+        } else if (a == "--backends") {
+            if (++i >= argc) { err = "Missing --backends value"; return false; }
+            opt.backends_filter = argv[i];
+        } else if (a == "--graphs") {
+            if (++i >= argc) { err = "Missing --graphs value"; return false; }
+            if (!parse_matmul_graphs(argv[i], opt.graphs)) {
+                err = "Invalid --graphs value (use gemv_d,gemm_d,gemm_mn)";
+                return false;
+            }
+        } else if (a == "--dims") {
+            if (++i >= argc) { err = "Missing --dims value"; return false; }
+            if (!parse_dim_list(argv[i], opt.dims)) {
+                err = "Invalid --dims value";
+                return false;
+            }
+        } else if (a == "--csv") {
+            if (++i >= argc) { err = "Missing --csv value"; return false; }
+            opt.csv_path = argv[i];
+        } else if (a == "--threads") {
+            if (++i >= argc) { err = "Missing --threads value"; return false; }
+            std::string val(argv[i]);
+            if (val == "max")
+                opt.num_threads = static_cast<int>(std::thread::hardware_concurrency());
+            else
+                opt.num_threads = std::max(1, std::stoi(val));
+        } else {
+            err = "Unknown argument: " + a;
+            return false;
+        }
+    }
+    return true;
+}
+
+bool parse_attn_bench_args(int argc, char** argv, AttnBenchOptions& opt, std::string& err) {
+    for (int i = 1; i < argc; ++i) {
+        std::string a(argv[i]);
+        if (a == "--iterations") {
+            if (++i >= argc) { err = "Missing --iterations value"; return false; }
+            opt.iterations = std::max(1, std::stoi(argv[i]));
+        } else if (a == "--warmup") {
+            if (++i >= argc) { err = "Missing --warmup value"; return false; }
+            opt.warmup = std::max(0, std::stoi(argv[i]));
+        } else if (a == "--backends") {
+            if (++i >= argc) { err = "Missing --backends value"; return false; }
+            opt.backends_filter = argv[i];
+        } else if (a == "--graphs") {
+            if (++i >= argc) { err = "Missing --graphs value"; return false; }
+            if (!parse_attn_graphs(argv[i], opt.graphs)) {
+                err = "Invalid --graphs value (use attn_prefill_s,attn_decode_cache)";
+                return false;
+            }
+        } else if (a == "--dims") {
+            if (++i >= argc) { err = "Missing --dims value"; return false; }
+            if (!parse_dim_list(argv[i], opt.dims)) {
+                err = "Invalid --dims value";
+                return false;
+            }
+        } else if (a == "--model_dim") {
+            if (++i >= argc) { err = "Missing --model_dim value"; return false; }
+            opt.model_dim = static_cast<size_t>(std::max(1, std::stoi(argv[i])));
+        } else if (a == "--heads") {
+            if (++i >= argc) { err = "Missing --heads value"; return false; }
+            opt.num_heads = static_cast<size_t>(std::max(1, std::stoi(argv[i])));
+        } else if (a == "--csv") {
+            if (++i >= argc) { err = "Missing --csv value"; return false; }
+            opt.csv_path = argv[i];
+        } else if (a == "--threads") {
+            if (++i >= argc) { err = "Missing --threads value"; return false; }
+            std::string val(argv[i]);
+            if (val == "max")
+                opt.num_threads = static_cast<int>(std::thread::hardware_concurrency());
+            else
+                opt.num_threads = std::max(1, std::stoi(val));
+        } else {
+            err = "Unknown argument: " + a;
+            return false;
+        }
+    }
+    return true;
+}
+
+} // namespace bench

--- a/tests/bench/bench_common.h
+++ b/tests/bench/bench_common.h
@@ -75,6 +75,8 @@ struct AttnBenchOptions {
     std::vector<size_t> dims;
     size_t model_dim = 1024;
     size_t num_heads = 8;
+    size_t num_kv_heads = 0;  // 0 = use num_heads (MHA); >0 enables GQA/MQA
+    size_t head_dim_override = 0;  // 0 = derive from model_dim/num_heads
     std::string backends_filter;
     std::string csv_path;
 };
@@ -120,7 +122,8 @@ void reference_attention_fp32(const float* Q, const float* K, const float* V,
                                float* output,
                                size_t num_q_heads, size_t num_kv_heads,
                                size_t seq_len, size_t kv_seq_len,
-                               size_t head_dim, float scale);
+                               size_t head_dim, float scale,
+                               size_t window_size = 0);
 
 struct AccuracyResult {
     float max_abs_error = 0.0f;

--- a/tests/bench/bench_common.h
+++ b/tests/bench/bench_common.h
@@ -1,0 +1,166 @@
+#ifndef BENCH_COMMON_H
+#define BENCH_COMMON_H
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "../../cactus-kernels/cactus_kernels.h"
+
+namespace bench {
+
+constexpr size_t kGroupSize = 32;
+constexpr size_t kBlockSize = 4;
+
+// Default sweep dimensions used by the 5 benchmark graphs.
+inline const std::vector<size_t>& default_dim_sweep() {
+    static const std::vector<size_t> dims = {128, 256, 512, 1024, 2048, 4096};
+    return dims;
+}
+
+// ── Matmul benchmark configuration ──────────────────────────────────────────
+
+enum class MatmulGraph {
+    GEMV_D,    // (1 x d) @ (d x N), with N=d swept
+    GEMM_D,    // (M x d) @ (d x N), M=N=512, d swept
+    GEMM_MN,   // (M x d) @ (d x N), M=N swept, d=512
+};
+
+struct MatmulConfig {
+    MatmulGraph graph;
+    size_t M;
+    size_t K;
+    size_t N;
+    size_t sweep_dim;  // The varying dim that this config represents
+};
+
+struct MatmulBenchOptions {
+    int warmup = 50;
+    int iterations = 200;
+    int num_threads = 0;
+    std::vector<MatmulGraph> graphs = {MatmulGraph::GEMV_D, MatmulGraph::GEMM_D, MatmulGraph::GEMM_MN};
+    std::vector<size_t> dims;
+    std::string backends_filter;
+    std::string csv_path;
+};
+
+// ── Attention benchmark configuration ───────────────────────────────────────
+
+enum class AttnMode { PREFILL, DECODE };
+
+enum class AttnGraph {
+    PREFILL_S,        // Attention prefill, S swept, d=1024, h=8
+    DECODE_CACHE,     // Hybrid decode, cache_len swept, d=1024, h=8
+};
+
+struct AttnDims {
+    size_t head_dim = 128;
+    size_t num_q_heads = 8;
+    size_t num_kv_heads = 8;
+};
+
+struct AttnConfig {
+    AttnGraph graph;
+    AttnMode mode;
+    AttnDims dims;
+    size_t seq_len;
+    size_t cache_len;
+    size_t sweep_dim;
+};
+
+struct AttnBenchOptions {
+    int warmup = 50;
+    int iterations = 200;
+    int num_threads = 0;
+    std::vector<AttnGraph> graphs = {AttnGraph::PREFILL_S, AttnGraph::DECODE_CACHE};
+    std::vector<size_t> dims;       // Values of S / cache_len to sweep
+    size_t model_dim = 1024;
+    size_t num_heads = 8;
+    std::string backends_filter;
+    std::string csv_path;
+};
+
+// ── Misc helpers ────────────────────────────────────────────────────────────
+
+inline double now_ms() {
+    return std::chrono::duration<double, std::milli>(
+        std::chrono::steady_clock::now().time_since_epoch()).count();
+}
+
+inline double compute_matmul_gops(size_t M, size_t K, size_t N, int iters, double total_ms) {
+    if (total_ms <= 0.0) return 0.0;
+    return (2.0 * M * K * N * iters) / (total_ms * 1e6);
+}
+
+inline double compute_attention_gflops(size_t num_q_heads, size_t seq_len,
+                                        size_t kv_seq_len, size_t head_dim,
+                                        int iterations, double total_ms) {
+    if (total_ms <= 0.0) return 0.0;
+    double flops_per_call = static_cast<double>(num_q_heads) *
+        (4.0 * seq_len * kv_seq_len * head_dim + 5.0 * seq_len * kv_seq_len);
+    return (flops_per_call * iterations) / (total_ms * 1e6);
+}
+
+void quantize_int8_per_group(const std::vector<float>& src, size_t N, size_t K,
+                              std::vector<int8_t>& dst, std::vector<float>& scales);
+
+std::vector<int8_t> interleave_weights_nk4(const std::vector<int8_t>& rowmajor, size_t N, size_t K);
+std::vector<__fp16> interleave_scales_n4(const std::vector<float>& scales, size_t N, size_t num_groups);
+
+struct CactusActivations {
+    std::vector<int8_t> int8;
+    std::vector<float> scales;
+    std::vector<__fp16> fp16;
+    std::vector<float> fp32;
+};
+
+CactusActivations prepare_cactus_activations(size_t M, size_t K, std::mt19937& gen);
+
+void reference_matmul_fp32(const float* A, const float* B_rowmajor_NK,
+                            float* C, size_t M, size_t K, size_t N);
+
+void reference_attention_fp32(const float* Q, const float* K, const float* V,
+                               float* output,
+                               size_t num_q_heads, size_t num_kv_heads,
+                               size_t seq_len, size_t kv_seq_len,
+                               size_t head_dim, float scale);
+
+struct AccuracyResult {
+    float max_abs_error = 0.0f;
+    float nrmse = 0.0f;
+    bool passed = false;
+};
+
+AccuracyResult check_accuracy(const float* reference, const float* actual,
+                               size_t count, float nrmse_tolerance);
+
+bool framework_matches_filter(const char* framework, const std::string& filter);
+
+void fp32_to_fp16(const float* src, __fp16* dst, size_t count);
+void fp16_to_fp32(const __fp16* src, float* dst, size_t count);
+
+void quantize_rows_int8(const float* src, int8_t* dst, float* scales,
+                         size_t rows, size_t cols);
+
+void transpose_2d(const float* src, float* dst, size_t rows, size_t cols);
+
+void set_thread_override(int n);
+int  get_thread_override();
+int  get_effective_threads(int backend_default);
+
+bool parse_matmul_bench_args(int argc, char** argv, MatmulBenchOptions& opt, std::string& err);
+bool parse_attn_bench_args(int argc, char** argv, AttnBenchOptions& opt, std::string& err);
+
+const char* matmul_graph_name(MatmulGraph g);
+const char* attn_graph_name(AttnGraph g);
+
+std::vector<MatmulConfig> build_matmul_configs(const MatmulBenchOptions& opt);
+std::vector<AttnConfig>   build_attn_configs(const AttnBenchOptions& opt);
+
+} // namespace bench
+
+#endif

--- a/tests/bench/bench_common.h
+++ b/tests/bench/bench_common.h
@@ -16,13 +16,10 @@ namespace bench {
 constexpr size_t kGroupSize = 32;
 constexpr size_t kBlockSize = 4;
 
-// Default sweep dimensions used by the 5 benchmark graphs.
 inline const std::vector<size_t>& default_dim_sweep() {
     static const std::vector<size_t> dims = {128, 256, 512, 1024, 2048, 4096};
     return dims;
 }
-
-// ── Matmul benchmark configuration ──────────────────────────────────────────
 
 enum class MatmulGraph {
     GEMV_D,    // (1 x d) @ (d x N), with N=d swept
@@ -35,7 +32,7 @@ struct MatmulConfig {
     size_t M;
     size_t K;
     size_t N;
-    size_t sweep_dim;  // The varying dim that this config represents
+    size_t sweep_dim;
 };
 
 struct MatmulBenchOptions {
@@ -48,13 +45,11 @@ struct MatmulBenchOptions {
     std::string csv_path;
 };
 
-// ── Attention benchmark configuration ───────────────────────────────────────
-
 enum class AttnMode { PREFILL, DECODE };
 
 enum class AttnGraph {
-    PREFILL_S,        // Attention prefill, S swept, d=1024, h=8
-    DECODE_CACHE,     // Hybrid decode, cache_len swept, d=1024, h=8
+    PREFILL_S,
+    DECODE_CACHE,
 };
 
 struct AttnDims {
@@ -77,14 +72,12 @@ struct AttnBenchOptions {
     int iterations = 200;
     int num_threads = 0;
     std::vector<AttnGraph> graphs = {AttnGraph::PREFILL_S, AttnGraph::DECODE_CACHE};
-    std::vector<size_t> dims;       // Values of S / cache_len to sweep
+    std::vector<size_t> dims;
     size_t model_dim = 1024;
     size_t num_heads = 8;
     std::string backends_filter;
     std::string csv_path;
 };
-
-// ── Misc helpers ────────────────────────────────────────────────────────────
 
 inline double now_ms() {
     return std::chrono::duration<double, std::milli>(

--- a/tests/bench/bench_driver.cpp
+++ b/tests/bench/bench_driver.cpp
@@ -1,0 +1,576 @@
+#include "bench_driver.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <thread>
+
+namespace bench {
+
+// Target weight-pool size we want to exceed so each iteration's working set
+// can't fit in L2/SLC (Apple Silicon SLC tops out around 32–48 MB on M-series).
+// 64 MB is a comfortable upper bound that still keeps total memory in check
+// across backends.
+static constexpr size_t kCacheBypassBytes = 64u * 1024u * 1024u;
+
+// Sanity caps. With ORT session caching done in backend_onnxrt.cpp, raising
+// NM is cheap. NM=4096 at d=128 is 64MB pool — exceeds Apple Silicon SLC
+// (~32-48MB) so weight reads genuinely miss to RAM, matching real-inference
+// access patterns where every layer has unique weights.
+static constexpr size_t kMaxMatrixCount = 4096;
+static constexpr size_t kMaxAttnStateCount = 512;
+
+// Per-config: probe each backend solo, then skip from the interleaved loop
+// any backend that's >25× slower than cactus. Slow ones drag the round-robin
+// (the loop is bounded by the slowest backend per iteration). Skipped
+// backends still get a separate solo timed pass — with warmup — so their
+// reported number reflects sustained performance, not first-call setup
+// overhead.
+static constexpr int    kProbeIters     = 3;
+static constexpr double kSlowMultiplier = 25.0;
+static constexpr int    kSoloWarmup     = 5;
+static constexpr int    kSoloIters      = 10;
+
+static std::vector<MatmulBackendVariant>& matmul_registry() {
+    static std::vector<MatmulBackendVariant> r;
+    return r;
+}
+void register_matmul_backend(MatmulBackendVariant v) { matmul_registry().push_back(v); }
+const std::vector<MatmulBackendVariant>& get_matmul_backends() { return matmul_registry(); }
+
+static std::vector<AttnBackendVariant>& attn_registry() {
+    static std::vector<AttnBackendVariant> r;
+    return r;
+}
+void register_attn_backend(AttnBackendVariant v) { attn_registry().push_back(v); }
+const std::vector<AttnBackendVariant>& get_attn_backends() { return attn_registry(); }
+
+static std::string thread_label(int n) {
+    if (n == 0) return "default";
+    if (n == static_cast<int>(std::thread::hardware_concurrency())) {
+        std::ostringstream os; os << "max(" << n << ")"; return os.str();
+    }
+    std::ostringstream os; os << n; return os.str();
+}
+
+bool run_matmul_benchmark(const MatmulBenchOptions& opt) {
+    const auto& all = get_matmul_backends();
+
+    std::vector<const MatmulBackendVariant*> active;
+    for (const auto& b : all) {
+        if (!b.run_kernel) continue;
+        if (framework_matches_filter(b.framework, opt.backends_filter))
+            active.push_back(&b);
+    }
+    if (active.empty()) {
+        std::cerr << "[matmul] no backends matched filter\n";
+        return false;
+    }
+
+    set_thread_override(opt.num_threads);
+
+    std::cout << "# matmul-bench: warmup=" << opt.warmup
+              << " iter=" << opt.iterations
+              << " cache_target=" << (kCacheBypassBytes >> 20) << "MB"
+              << " threads=" << thread_label(opt.num_threads)
+              << " backends=";
+    for (size_t i = 0; i < active.size(); ++i) {
+        if (i) std::cout << ",";
+        std::cout << active[i]->name;
+    }
+    std::cout << "\n";
+
+    std::ofstream csv;
+    if (!opt.csv_path.empty()) {
+        csv.open(opt.csv_path);
+        csv << "graph,sweep_dim,M,K,N,backend,framework,time_us,gops,nrmse,max_err\n";
+    }
+
+    auto configs = build_matmul_configs(opt);
+    std::mt19937 gen(270270u);
+    std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+
+    // Per-config interleaving: for each (M,K,N) shape we prep ALL backends'
+    // weights & activations up front, then drive them round-robin so each
+    // iteration is "one call to every backend, in order." This averages
+    // thermal/frequency state across backends instead of letting whichever
+    // backend runs first cool the CPU for whichever runs second.
+    //
+    // A probe phase ahead of the main loop excludes any backend >25× slower
+    // than cactus from the round-robin (otherwise the slowest backend gates
+    // the entire loop's wall time). Skipped backends still report a
+    // probe-derived time for visibility.
+    struct Entry { void* w = nullptr; void* a = nullptr; };
+    struct BackendSlot {
+        const MatmulBackendVariant* backend = nullptr;
+        std::vector<Entry> entries;
+        AccuracyResult acc;
+        bool prepared = false;
+        bool skipped_slow = false;
+        double probe_avg_ms = 0.0;     // measured solo
+        double total_ms = 0.0;          // interleaved (200 iters) for normal backends; solo (kSoloIters, warmed) for skipped
+        int effective_iters = 0;        // how many iterations contributed to total_ms
+    };
+
+    for (const auto& cfg : configs) {
+        const size_t M = cfg.M, K = cfg.K, N = cfg.N;
+
+        // Dynamic weight-pool size: cycle through enough distinct matrices
+        // that the per-backend quantized weight set exceeds L2/SLC cache, so
+        // each iteration's weight load actually misses to RAM (matches real
+        // inference where every layer has unique weights). Floor=2 (always
+        // cycle something so we don't get register-level reuse on a single
+        // matrix); cap=kMaxMatrixCount so small dims don't blow up memory.
+        const size_t weight_bytes = N * K;  // INT8 quantized footprint
+        const size_t NM_for_bypass = (kCacheBypassBytes + weight_bytes - 1)
+                                      / std::max(weight_bytes, size_t(1));
+        const size_t NM = std::min(kMaxMatrixCount, std::max(size_t(2), NM_for_bypass));
+
+        std::cout << "\n── " << matmul_graph_name(cfg.graph)
+                  << " sweep=" << cfg.sweep_dim
+                  << " (" << M << "x" << K << "x" << N << ")"
+                  << " NM=" << NM << "\n";
+
+        std::vector<std::vector<float>> fp32_w(NM);
+        for (size_t i = 0; i < NM; ++i) {
+            fp32_w[i].resize(N * K);
+            for (auto& v : fp32_w[i]) v = dist(gen);
+        }
+
+        std::mt19937 agen(static_cast<uint32_t>(42u + cfg.sweep_dim + (size_t)cfg.graph));
+        auto act = prepare_cactus_activations(M, K, agen);
+
+        std::vector<float> reference(M * N);
+        reference_matmul_fp32(act.fp32.data(), fp32_w[0].data(),
+                              reference.data(), M, K, N);
+
+        // ── Prep + accuracy check (sequential — one-shot per backend) ──────
+        std::vector<BackendSlot> slots(active.size());
+        const size_t out_count = M * N;
+
+        for (size_t bi = 0; bi < active.size(); ++bi) {
+            auto& slot = slots[bi];
+            slot.backend = active[bi];
+            slot.entries.resize(NM);
+            slot.prepared = true;
+
+            for (size_t i = 0; i < NM; ++i) {
+                slot.entries[i].w = slot.backend->prepare_weights(fp32_w[i].data(), N, K);
+                if (!slot.entries[i].w) { slot.prepared = false; break; }
+                if (slot.backend->prepare_activations)
+                    slot.entries[i].a = slot.backend->prepare_activations(
+                        act.fp32.data(), M, K, slot.entries[i].w);
+            }
+
+            if (!slot.prepared) {
+                std::cout << "  " << slot.backend->name << "  prepare=FAIL\n";
+                for (auto& e : slot.entries)
+                    if (slot.backend->cleanup) slot.backend->cleanup(e.w, e.a);
+                slot.entries.clear();
+                continue;
+            }
+
+            std::vector<float> captured(out_count, 0.0f);
+            std::vector<float> backend_ref(out_count, 0.0f);
+            slot.backend->run_kernel(M, K, N, slot.entries[0].w, slot.entries[0].a,
+                                     act.int8.data(), act.scales.data(),
+                                     captured.data(), backend_ref.data());
+
+            bool has_backend_ref = false;
+            for (size_t i = 0; i < out_count && !has_backend_ref; ++i)
+                if (backend_ref[i] != 0.0f) has_backend_ref = true;
+            const float* ref = has_backend_ref ? backend_ref.data() : reference.data();
+            float tol = has_backend_ref ? 0.01f : 0.10f;
+            slot.acc = check_accuracy(ref, captured.data(), out_count, tol);
+        }
+
+        // FP32 source weights are no longer needed — every backend has its own
+        // quantized copy. Drop them so we don't pay 4× memory at high NM.
+        std::vector<std::vector<float>>().swap(fp32_w);
+
+        // ── Probe phase: measure each backend solo, mark slow ones ─────────
+        for (auto& slot : slots) {
+            if (!slot.prepared) continue;
+            double total = 0.0;
+            for (int p = 0; p < kProbeIters; ++p) {
+                size_t idx = static_cast<size_t>(p) % NM;
+                double t0 = now_ms();
+                slot.backend->run_kernel(M, K, N,
+                                         slot.entries[idx].w, slot.entries[idx].a,
+                                         act.int8.data(), act.scales.data(),
+                                         nullptr, nullptr);
+                total += now_ms() - t0;
+            }
+            slot.probe_avg_ms = total / kProbeIters;
+        }
+        double cactus_probe_ms = -1.0;
+        for (const auto& slot : slots) {
+            if (slot.prepared && std::string(slot.backend->framework) == "cactus") {
+                cactus_probe_ms = slot.probe_avg_ms;
+                break;
+            }
+        }
+        if (cactus_probe_ms > 0.0) {
+            for (auto& slot : slots) {
+                if (!slot.prepared) continue;
+                if (slot.probe_avg_ms > kSlowMultiplier * cactus_probe_ms)
+                    slot.skipped_slow = true;
+            }
+        } else {
+            static bool warned = false;
+            if (!warned) {
+                std::cerr << "[bench] cactus not in active backends — slow-skip "
+                             "disabled. Run will not auto-skip outlier-slow "
+                             "backends; expect long wall time.\n";
+                warned = true;
+            }
+        }
+
+        // ── Solo timed pass for skipped backends ───────────────────────────
+        // Warmup + small timed loop so the reported number reflects
+        // sustained throughput, not first-call setup overhead.
+        for (auto& slot : slots) {
+            if (!slot.prepared || !slot.skipped_slow) continue;
+            for (int w = 0; w < kSoloWarmup; ++w) {
+                size_t idx = static_cast<size_t>(w) % NM;
+                slot.backend->run_kernel(M, K, N,
+                                         slot.entries[idx].w, slot.entries[idx].a,
+                                         act.int8.data(), act.scales.data(),
+                                         nullptr, nullptr);
+            }
+            slot.total_ms = 0.0;
+            slot.effective_iters = 0;
+            for (int it = 0; it < kSoloIters; ++it) {
+                size_t idx = static_cast<size_t>(it) % NM;
+                double t0 = now_ms();
+                slot.backend->run_kernel(M, K, N,
+                                         slot.entries[idx].w, slot.entries[idx].a,
+                                         act.int8.data(), act.scales.data(),
+                                         nullptr, nullptr);
+                slot.total_ms += now_ms() - t0;
+                slot.effective_iters++;
+            }
+        }
+
+        // ── Interleaved warmup: iter w hits every backend in order ─────────
+        for (int w = 0; w < opt.warmup; ++w) {
+            size_t idx = static_cast<size_t>(w) % NM;
+            for (auto& slot : slots) {
+                if (!slot.prepared || slot.skipped_slow) continue;
+                slot.backend->run_kernel(M, K, N,
+                                         slot.entries[idx].w, slot.entries[idx].a,
+                                         act.int8.data(), act.scales.data(),
+                                         nullptr, nullptr);
+            }
+        }
+
+        // ── Interleaved timed loop ─────────────────────────────────────────
+        for (int it = 0; it < opt.iterations; ++it) {
+            size_t idx = static_cast<size_t>(it) % NM;
+            for (auto& slot : slots) {
+                if (!slot.prepared || slot.skipped_slow) continue;
+                double t0 = now_ms();
+                slot.backend->run_kernel(M, K, N,
+                                         slot.entries[idx].w, slot.entries[idx].a,
+                                         act.int8.data(), act.scales.data(),
+                                         nullptr, nullptr);
+                slot.total_ms += now_ms() - t0;
+                slot.effective_iters++;
+            }
+        }
+
+        // ── Report + CSV ───────────────────────────────────────────────────
+        for (auto& slot : slots) {
+            if (!slot.prepared) continue;
+            int iters = slot.effective_iters > 0 ? slot.effective_iters : 1;
+            double avg_ms = slot.total_ms / iters;
+            double avg_us = avg_ms * 1000.0;
+            double gops = compute_matmul_gops(M, K, N, iters, slot.total_ms);
+
+            std::cout << "  " << std::left << std::setw(28) << slot.backend->name
+                      << " " << std::fixed << std::setprecision(3) << avg_ms << " ms"
+                      << " (" << std::setprecision(2) << gops << " GOPS)"
+                      << "  acc=" << (slot.acc.passed ? "PASS" : "FAIL")
+                      << " nrmse=" << std::setprecision(4) << slot.acc.nrmse;
+            if (slot.skipped_slow)
+                std::cout << "  [slow — solo " << kSoloIters << "-iter pass]";
+            std::cout << "\n";
+
+            if (csv.is_open()) {
+                csv << matmul_graph_name(cfg.graph) << ","
+                    << cfg.sweep_dim << "," << M << "," << K << "," << N << ","
+                    << slot.backend->name << "," << slot.backend->framework << ","
+                    << std::fixed << std::setprecision(3) << avg_us << ","
+                    << std::setprecision(3) << gops << ","
+                    << std::setprecision(6) << slot.acc.nrmse << ","
+                    << std::setprecision(6) << slot.acc.max_abs_error << "\n";
+                csv.flush();
+            }
+
+            for (auto& e : slot.entries)
+                if (slot.backend->cleanup) slot.backend->cleanup(e.w, e.a);
+        }
+    }
+
+    set_thread_override(0);
+    return true;
+}
+
+static float attn_tolerance(const char* name) {
+    std::string n(name);
+    if (n.find("q4") != std::string::npos) return 0.20f;
+    if (n.find("int8") != std::string::npos || n.find("hybrid") != std::string::npos
+        || n.find("q8") != std::string::npos)
+        return 0.10f;
+    return 0.05f;
+}
+
+bool run_attn_benchmark(const AttnBenchOptions& opt) {
+    const auto& all = get_attn_backends();
+
+    std::vector<const AttnBackendVariant*> active;
+    for (const auto& b : all) {
+        if (!b.run) continue;
+        if (framework_matches_filter(b.framework, opt.backends_filter))
+            active.push_back(&b);
+    }
+    if (active.empty()) {
+        std::cerr << "[attn] no backends matched filter\n";
+        return false;
+    }
+
+    set_thread_override(opt.num_threads);
+
+    std::cout << "# attn-bench: warmup=" << opt.warmup
+              << " iter=" << opt.iterations
+              << " threads=" << thread_label(opt.num_threads)
+              << " model_dim=" << opt.model_dim
+              << " heads=" << opt.num_heads
+              << " backends=";
+    for (size_t i = 0; i < active.size(); ++i) {
+        if (i) std::cout << ",";
+        std::cout << active[i]->name;
+    }
+    std::cout << "\n";
+
+    std::ofstream csv;
+    if (!opt.csv_path.empty()) {
+        csv.open(opt.csv_path);
+        csv << "graph,sweep_dim,seq_len,cache_len,head_dim,q_heads,kv_heads,backend,framework,time_us,gflops,nrmse,max_err\n";
+    }
+
+    auto configs = build_attn_configs(opt);
+    std::mt19937 gen(270270u);
+    std::uniform_real_distribution<float> dist(-0.5f, 0.5f);
+
+    // Per-config: prep all (active, mode-matching) backends, then drive them
+    // round-robin across iterations for thermal fairness. Multiple Q/K/V
+    // "states" are cycled so the K/V working set exceeds L2/SLC. A probe
+    // phase excludes any backend >25× slower than cactus from the loop.
+    struct AttnSlot {
+        const AttnBackendVariant* backend = nullptr;
+        std::vector<void*> states;    // one per Q/K/V tuple
+        AccuracyResult acc;
+        bool prepared = false;
+        bool skipped_slow = false;
+        double probe_avg_ms = 0.0;
+        double total_ms = 0.0;
+        int effective_iters = 0;
+    };
+
+    for (const auto& cfg : configs) {
+        const auto& dims = cfg.dims;
+        const size_t sl = cfg.seq_len;
+        const size_t kvl = (cfg.mode == AttnMode::PREFILL) ? sl : (cfg.cache_len + 1);
+        const float scale = 1.0f / std::sqrt(static_cast<float>(dims.head_dim));
+
+        // Pick state count to push the per-state KV footprint past 64MB.
+        // Per-state working set ≈ Q + K + V + per-backend state overhead. We
+        // size against the dominant K+V FP32 reference: 2 * num_kv_heads *
+        // kvl * head_dim * sizeof(float).
+        const size_t per_state_kv_bytes = 2 * dims.num_kv_heads * kvl * dims.head_dim * sizeof(float);
+        const size_t NS_for_bypass = (kCacheBypassBytes + per_state_kv_bytes - 1)
+                                      / std::max(per_state_kv_bytes, size_t(1));
+        const size_t NS = std::min(kMaxAttnStateCount, std::max(static_cast<size_t>(2), NS_for_bypass));
+
+        std::cout << "\n── " << attn_graph_name(cfg.graph)
+                  << " sweep=" << cfg.sweep_dim
+                  << " (sl=" << sl << " kvl=" << kvl
+                  << " hd=" << dims.head_dim
+                  << " qh=" << dims.num_q_heads
+                  << " kvh=" << dims.num_kv_heads << ")"
+                  << " NS=" << NS << "\n";
+
+        size_t q_count = dims.num_q_heads * sl * dims.head_dim;
+        size_t kv_count = dims.num_kv_heads * kvl * dims.head_dim;
+
+        // Generate NS distinct (Q, K, V) tuples.
+        std::vector<std::vector<float>> q_set(NS), k_set(NS), v_set(NS);
+        for (size_t s = 0; s < NS; ++s) {
+            q_set[s].resize(q_count);
+            k_set[s].resize(kv_count);
+            v_set[s].resize(kv_count);
+            for (auto& x : q_set[s]) x = dist(gen);
+            for (auto& x : k_set[s]) x = dist(gen);
+            for (auto& x : v_set[s]) x = dist(gen);
+        }
+
+        // Reference computed against state 0 — accuracy check uses state 0 too.
+        std::vector<float> reference(q_count);
+        reference_attention_fp32(q_set[0].data(), k_set[0].data(), v_set[0].data(),
+                                 reference.data(),
+                                 dims.num_q_heads, dims.num_kv_heads,
+                                 sl, kvl, dims.head_dim, scale);
+
+        // ── Prep + accuracy (sequential per backend) ───────────────────────
+        std::vector<AttnSlot> slots;
+        for (const auto* backend : active) {
+            if (backend->mode != cfg.mode) continue;
+            slots.emplace_back();
+            auto& slot = slots.back();
+            slot.backend = backend;
+            slot.states.reserve(NS);
+            slot.prepared = true;
+
+            for (size_t s = 0; s < NS; ++s) {
+                void* st = backend->prepare(dims, sl, cfg.cache_len,
+                                             q_set[s].data(), k_set[s].data(), v_set[s].data());
+                if (!st) { slot.prepared = false; break; }
+                slot.states.push_back(st);
+            }
+
+            if (!slot.prepared) {
+                std::cout << "  " << backend->name << "  prepare=FAIL\n";
+                for (auto* st : slot.states) backend->cleanup(st);
+                slot.states.clear();
+                continue;
+            }
+
+            std::vector<float> captured(q_count, 0.0f);
+            backend->run(slot.states[0], captured.data());
+            slot.acc = check_accuracy(reference.data(), captured.data(), q_count,
+                                       attn_tolerance(backend->name));
+        }
+
+        // FP32 source K/V is no longer needed by any backend after prep.
+        std::vector<std::vector<float>>().swap(q_set);
+        std::vector<std::vector<float>>().swap(k_set);
+        std::vector<std::vector<float>>().swap(v_set);
+
+        // ── Probe phase: solo-time each backend, mark slow ones ────────────
+        for (auto& slot : slots) {
+            if (!slot.prepared) continue;
+            double total = 0.0;
+            for (int p = 0; p < kProbeIters; ++p) {
+                size_t idx = static_cast<size_t>(p) % NS;
+                double t0 = now_ms();
+                slot.backend->run(slot.states[idx], nullptr);
+                total += now_ms() - t0;
+            }
+            slot.probe_avg_ms = total / kProbeIters;
+        }
+        double cactus_probe_ms = -1.0;
+        for (const auto& slot : slots) {
+            if (slot.prepared && std::string(slot.backend->framework) == "cactus") {
+                cactus_probe_ms = slot.probe_avg_ms;
+                break;
+            }
+        }
+        if (cactus_probe_ms > 0.0) {
+            for (auto& slot : slots) {
+                if (!slot.prepared) continue;
+                if (slot.probe_avg_ms > kSlowMultiplier * cactus_probe_ms)
+                    slot.skipped_slow = true;
+            }
+        } else {
+            static bool warned = false;
+            if (!warned) {
+                std::cerr << "[bench] cactus not in active backends — slow-skip "
+                             "disabled. Run will not auto-skip outlier-slow "
+                             "backends; expect long wall time.\n";
+                warned = true;
+            }
+        }
+
+        // ── Solo timed pass for skipped backends ───────────────────────────
+        for (auto& slot : slots) {
+            if (!slot.prepared || !slot.skipped_slow) continue;
+            for (int w = 0; w < kSoloWarmup; ++w) {
+                size_t idx = static_cast<size_t>(w) % NS;
+                slot.backend->run(slot.states[idx], nullptr);
+            }
+            slot.total_ms = 0.0;
+            slot.effective_iters = 0;
+            for (int it = 0; it < kSoloIters; ++it) {
+                size_t idx = static_cast<size_t>(it) % NS;
+                double t0 = now_ms();
+                slot.backend->run(slot.states[idx], nullptr);
+                slot.total_ms += now_ms() - t0;
+                slot.effective_iters++;
+            }
+        }
+
+        // ── Interleaved warmup ─────────────────────────────────────────────
+        for (int w = 0; w < opt.warmup; ++w) {
+            size_t idx = static_cast<size_t>(w) % NS;
+            for (auto& slot : slots) {
+                if (!slot.prepared || slot.skipped_slow) continue;
+                slot.backend->run(slot.states[idx], nullptr);
+            }
+        }
+
+        // ── Interleaved timed loop ─────────────────────────────────────────
+        for (int it = 0; it < opt.iterations; ++it) {
+            size_t idx = static_cast<size_t>(it) % NS;
+            for (auto& slot : slots) {
+                if (!slot.prepared || slot.skipped_slow) continue;
+                double t0 = now_ms();
+                slot.backend->run(slot.states[idx], nullptr);
+                slot.total_ms += now_ms() - t0;
+                slot.effective_iters++;
+            }
+        }
+
+        // ── Report + CSV ───────────────────────────────────────────────────
+        for (auto& slot : slots) {
+            if (!slot.prepared) continue;
+            int iters = slot.effective_iters > 0 ? slot.effective_iters : 1;
+            double avg_ms = slot.total_ms / iters;
+            double avg_us = avg_ms * 1000.0;
+            double gflops = compute_attention_gflops(dims.num_q_heads, sl, kvl,
+                                                      dims.head_dim, iters, slot.total_ms);
+
+            std::cout << "  " << std::left << std::setw(28) << slot.backend->name
+                      << " " << std::fixed << std::setprecision(3) << avg_ms << " ms"
+                      << " (" << std::setprecision(2) << gflops << " GFLOPS)"
+                      << "  acc=" << (slot.acc.passed ? "PASS" : "FAIL")
+                      << " nrmse=" << std::setprecision(4) << slot.acc.nrmse;
+            if (slot.skipped_slow)
+                std::cout << "  [slow — solo " << kSoloIters << "-iter pass]";
+            std::cout << "\n";
+
+            if (csv.is_open()) {
+                csv << attn_graph_name(cfg.graph) << ","
+                    << cfg.sweep_dim << "," << sl << "," << cfg.cache_len << ","
+                    << dims.head_dim << "," << dims.num_q_heads << "," << dims.num_kv_heads << ","
+                    << slot.backend->name << "," << slot.backend->framework << ","
+                    << std::fixed << std::setprecision(3) << avg_us << ","
+                    << std::setprecision(3) << gflops << ","
+                    << std::setprecision(6) << slot.acc.nrmse << ","
+                    << std::setprecision(6) << slot.acc.max_abs_error << "\n";
+                csv.flush();
+            }
+
+            for (auto* st : slot.states) slot.backend->cleanup(st);
+        }
+    }
+
+    set_thread_override(0);
+    return true;
+}
+
+} // namespace bench

--- a/tests/bench/bench_driver.cpp
+++ b/tests/bench/bench_driver.cpp
@@ -357,8 +357,13 @@ bool run_attn_benchmark(const AttnBenchOptions& opt) {
         const float scale = 1.0f / std::sqrt(static_cast<float>(dims.head_dim));
 
         // NS cycles enough Q/K/V states to push the per-state KV footprint
-        // past kCacheBypassBytes; sized against K+V (dominant term).
-        const size_t per_state_kv_bytes = 2 * dims.num_kv_heads * kvl * dims.head_dim * sizeof(float);
+        // past kCacheBypassBytes. We size against the *smallest* backend storage
+        // (INT8 K+V plus fp32 group scales) so quantized backends don't get
+        // unfair L2/SLC locality on small cache_lens.
+        const size_t groups_per_token = std::max<size_t>(1, dims.head_dim / 32);
+        const size_t per_state_kv_bytes =
+            2 * dims.num_kv_heads * kvl * dims.head_dim * sizeof(int8_t) +
+            2 * dims.num_kv_heads * kvl * groups_per_token * sizeof(float);
         const size_t NS_for_bypass = (kCacheBypassBytes + per_state_kv_bytes - 1)
                                       / std::max(per_state_kv_bytes, size_t(1));
         const size_t NS = std::min(kMaxAttnStateCount, std::max(static_cast<size_t>(2), NS_for_bypass));

--- a/tests/bench/bench_driver.cpp
+++ b/tests/bench/bench_driver.cpp
@@ -11,25 +11,16 @@
 
 namespace bench {
 
-// Target weight-pool size we want to exceed so each iteration's working set
-// can't fit in L2/SLC (Apple Silicon SLC tops out around 32–48 MB on M-series).
-// 64 MB is a comfortable upper bound that still keeps total memory in check
-// across backends.
+// Working-set target — exceed Apple Silicon SLC (~32-48MB) so weight reads
+// miss to RAM, matching real inference where every layer has unique weights.
 static constexpr size_t kCacheBypassBytes = 64u * 1024u * 1024u;
 
-// Sanity caps. With ORT session caching done in backend_onnxrt.cpp, raising
-// NM is cheap. NM=4096 at d=128 is 64MB pool — exceeds Apple Silicon SLC
-// (~32-48MB) so weight reads genuinely miss to RAM, matching real-inference
-// access patterns where every layer has unique weights.
 static constexpr size_t kMaxMatrixCount = 4096;
 static constexpr size_t kMaxAttnStateCount = 512;
 
-// Per-config: probe each backend solo, then skip from the interleaved loop
-// any backend that's >25× slower than cactus. Slow ones drag the round-robin
-// (the loop is bounded by the slowest backend per iteration). Skipped
-// backends still get a separate solo timed pass — with warmup — so their
-// reported number reflects sustained performance, not first-call setup
-// overhead.
+// Slow backends are excluded from the interleaved loop (otherwise the
+// round-robin is bounded by the slowest per iteration), then re-timed in a
+// solo warmed pass so their number still reflects sustained performance.
 static constexpr int    kProbeIters     = 3;
 static constexpr double kSlowMultiplier = 25.0;
 static constexpr int    kSoloWarmup     = 5;
@@ -94,16 +85,9 @@ bool run_matmul_benchmark(const MatmulBenchOptions& opt) {
     std::mt19937 gen(270270u);
     std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
 
-    // Per-config interleaving: for each (M,K,N) shape we prep ALL backends'
-    // weights & activations up front, then drive them round-robin so each
-    // iteration is "one call to every backend, in order." This averages
-    // thermal/frequency state across backends instead of letting whichever
-    // backend runs first cool the CPU for whichever runs second.
-    //
-    // A probe phase ahead of the main loop excludes any backend >25× slower
-    // than cactus from the round-robin (otherwise the slowest backend gates
-    // the entire loop's wall time). Skipped backends still report a
-    // probe-derived time for visibility.
+    // Round-robin across backends per iteration averages thermal/frequency
+    // state — without it, whichever backend runs first cools the CPU for
+    // whichever runs second.
     struct Entry { void* w = nullptr; void* a = nullptr; };
     struct BackendSlot {
         const MatmulBackendVariant* backend = nullptr;
@@ -111,21 +95,18 @@ bool run_matmul_benchmark(const MatmulBenchOptions& opt) {
         AccuracyResult acc;
         bool prepared = false;
         bool skipped_slow = false;
-        double probe_avg_ms = 0.0;     // measured solo
-        double total_ms = 0.0;          // interleaved (200 iters) for normal backends; solo (kSoloIters, warmed) for skipped
-        int effective_iters = 0;        // how many iterations contributed to total_ms
+        double probe_avg_ms = 0.0;
+        double total_ms = 0.0;
+        int effective_iters = 0;
     };
 
     for (const auto& cfg : configs) {
         const size_t M = cfg.M, K = cfg.K, N = cfg.N;
 
-        // Dynamic weight-pool size: cycle through enough distinct matrices
-        // that the per-backend quantized weight set exceeds L2/SLC cache, so
-        // each iteration's weight load actually misses to RAM (matches real
-        // inference where every layer has unique weights). Floor=2 (always
-        // cycle something so we don't get register-level reuse on a single
-        // matrix); cap=kMaxMatrixCount so small dims don't blow up memory.
-        const size_t weight_bytes = N * K;  // INT8 quantized footprint
+        // NM cycles enough distinct quantized matrices to push the weight
+        // working set past kCacheBypassBytes. Floor=2 so a single matrix
+        // doesn't sit in registers across iterations.
+        const size_t weight_bytes = N * K;
         const size_t NM_for_bypass = (kCacheBypassBytes + weight_bytes - 1)
                                       / std::max(weight_bytes, size_t(1));
         const size_t NM = std::min(kMaxMatrixCount, std::max(size_t(2), NM_for_bypass));
@@ -148,7 +129,6 @@ bool run_matmul_benchmark(const MatmulBenchOptions& opt) {
         reference_matmul_fp32(act.fp32.data(), fp32_w[0].data(),
                               reference.data(), M, K, N);
 
-        // ── Prep + accuracy check (sequential — one-shot per backend) ──────
         std::vector<BackendSlot> slots(active.size());
         const size_t out_count = M * N;
 
@@ -188,11 +168,9 @@ bool run_matmul_benchmark(const MatmulBenchOptions& opt) {
             slot.acc = check_accuracy(ref, captured.data(), out_count, tol);
         }
 
-        // FP32 source weights are no longer needed — every backend has its own
-        // quantized copy. Drop them so we don't pay 4× memory at high NM.
+        // Drop FP32 source weights so we don't pay 4× memory at high NM.
         std::vector<std::vector<float>>().swap(fp32_w);
 
-        // ── Probe phase: measure each backend solo, mark slow ones ─────────
         for (auto& slot : slots) {
             if (!slot.prepared) continue;
             double total = 0.0;
@@ -230,9 +208,6 @@ bool run_matmul_benchmark(const MatmulBenchOptions& opt) {
             }
         }
 
-        // ── Solo timed pass for skipped backends ───────────────────────────
-        // Warmup + small timed loop so the reported number reflects
-        // sustained throughput, not first-call setup overhead.
         for (auto& slot : slots) {
             if (!slot.prepared || !slot.skipped_slow) continue;
             for (int w = 0; w < kSoloWarmup; ++w) {
@@ -256,7 +231,6 @@ bool run_matmul_benchmark(const MatmulBenchOptions& opt) {
             }
         }
 
-        // ── Interleaved warmup: iter w hits every backend in order ─────────
         for (int w = 0; w < opt.warmup; ++w) {
             size_t idx = static_cast<size_t>(w) % NM;
             for (auto& slot : slots) {
@@ -268,7 +242,6 @@ bool run_matmul_benchmark(const MatmulBenchOptions& opt) {
             }
         }
 
-        // ── Interleaved timed loop ─────────────────────────────────────────
         for (int it = 0; it < opt.iterations; ++it) {
             size_t idx = static_cast<size_t>(it) % NM;
             for (auto& slot : slots) {
@@ -283,7 +256,6 @@ bool run_matmul_benchmark(const MatmulBenchOptions& opt) {
             }
         }
 
-        // ── Report + CSV ───────────────────────────────────────────────────
         for (auto& slot : slots) {
             if (!slot.prepared) continue;
             int iters = slot.effective_iters > 0 ? slot.effective_iters : 1;
@@ -367,13 +339,9 @@ bool run_attn_benchmark(const AttnBenchOptions& opt) {
     std::mt19937 gen(270270u);
     std::uniform_real_distribution<float> dist(-0.5f, 0.5f);
 
-    // Per-config: prep all (active, mode-matching) backends, then drive them
-    // round-robin across iterations for thermal fairness. Multiple Q/K/V
-    // "states" are cycled so the K/V working set exceeds L2/SLC. A probe
-    // phase excludes any backend >25× slower than cactus from the loop.
     struct AttnSlot {
         const AttnBackendVariant* backend = nullptr;
-        std::vector<void*> states;    // one per Q/K/V tuple
+        std::vector<void*> states;
         AccuracyResult acc;
         bool prepared = false;
         bool skipped_slow = false;
@@ -388,10 +356,8 @@ bool run_attn_benchmark(const AttnBenchOptions& opt) {
         const size_t kvl = (cfg.mode == AttnMode::PREFILL) ? sl : (cfg.cache_len + 1);
         const float scale = 1.0f / std::sqrt(static_cast<float>(dims.head_dim));
 
-        // Pick state count to push the per-state KV footprint past 64MB.
-        // Per-state working set ≈ Q + K + V + per-backend state overhead. We
-        // size against the dominant K+V FP32 reference: 2 * num_kv_heads *
-        // kvl * head_dim * sizeof(float).
+        // NS cycles enough Q/K/V states to push the per-state KV footprint
+        // past kCacheBypassBytes; sized against K+V (dominant term).
         const size_t per_state_kv_bytes = 2 * dims.num_kv_heads * kvl * dims.head_dim * sizeof(float);
         const size_t NS_for_bypass = (kCacheBypassBytes + per_state_kv_bytes - 1)
                                       / std::max(per_state_kv_bytes, size_t(1));
@@ -408,7 +374,6 @@ bool run_attn_benchmark(const AttnBenchOptions& opt) {
         size_t q_count = dims.num_q_heads * sl * dims.head_dim;
         size_t kv_count = dims.num_kv_heads * kvl * dims.head_dim;
 
-        // Generate NS distinct (Q, K, V) tuples.
         std::vector<std::vector<float>> q_set(NS), k_set(NS), v_set(NS);
         for (size_t s = 0; s < NS; ++s) {
             q_set[s].resize(q_count);
@@ -419,14 +384,12 @@ bool run_attn_benchmark(const AttnBenchOptions& opt) {
             for (auto& x : v_set[s]) x = dist(gen);
         }
 
-        // Reference computed against state 0 — accuracy check uses state 0 too.
         std::vector<float> reference(q_count);
         reference_attention_fp32(q_set[0].data(), k_set[0].data(), v_set[0].data(),
                                  reference.data(),
                                  dims.num_q_heads, dims.num_kv_heads,
                                  sl, kvl, dims.head_dim, scale);
 
-        // ── Prep + accuracy (sequential per backend) ───────────────────────
         std::vector<AttnSlot> slots;
         for (const auto* backend : active) {
             if (backend->mode != cfg.mode) continue;
@@ -456,12 +419,10 @@ bool run_attn_benchmark(const AttnBenchOptions& opt) {
                                        attn_tolerance(backend->name));
         }
 
-        // FP32 source K/V is no longer needed by any backend after prep.
         std::vector<std::vector<float>>().swap(q_set);
         std::vector<std::vector<float>>().swap(k_set);
         std::vector<std::vector<float>>().swap(v_set);
 
-        // ── Probe phase: solo-time each backend, mark slow ones ────────────
         for (auto& slot : slots) {
             if (!slot.prepared) continue;
             double total = 0.0;
@@ -496,7 +457,6 @@ bool run_attn_benchmark(const AttnBenchOptions& opt) {
             }
         }
 
-        // ── Solo timed pass for skipped backends ───────────────────────────
         for (auto& slot : slots) {
             if (!slot.prepared || !slot.skipped_slow) continue;
             for (int w = 0; w < kSoloWarmup; ++w) {
@@ -514,7 +474,6 @@ bool run_attn_benchmark(const AttnBenchOptions& opt) {
             }
         }
 
-        // ── Interleaved warmup ─────────────────────────────────────────────
         for (int w = 0; w < opt.warmup; ++w) {
             size_t idx = static_cast<size_t>(w) % NS;
             for (auto& slot : slots) {
@@ -523,7 +482,6 @@ bool run_attn_benchmark(const AttnBenchOptions& opt) {
             }
         }
 
-        // ── Interleaved timed loop ─────────────────────────────────────────
         for (int it = 0; it < opt.iterations; ++it) {
             size_t idx = static_cast<size_t>(it) % NS;
             for (auto& slot : slots) {
@@ -535,7 +493,6 @@ bool run_attn_benchmark(const AttnBenchOptions& opt) {
             }
         }
 
-        // ── Report + CSV ───────────────────────────────────────────────────
         for (auto& slot : slots) {
             if (!slot.prepared) continue;
             int iters = slot.effective_iters > 0 ? slot.effective_iters : 1;

--- a/tests/bench/bench_driver.h
+++ b/tests/bench/bench_driver.h
@@ -1,0 +1,60 @@
+#ifndef BENCH_DRIVER_H
+#define BENCH_DRIVER_H
+
+#include "bench_common.h"
+
+#include <string>
+#include <vector>
+
+namespace bench {
+
+// ── Matmul backend interface ────────────────────────────────────────────────
+
+struct MatmulBackendVariant {
+    const char* name;
+    const char* framework;
+
+    // Prepare an opaque weights handle for the (N,K) shape from raw fp32 weights.
+    void* (*prepare_weights)(const float* fp32, size_t N, size_t K);
+
+    // Optional per-backend activation prep (some backends quantize once per call).
+    void* (*prepare_activations)(const float* fp32, size_t M, size_t K, void* weights);
+
+    // Run the kernel. If `output` is non-null, fill it with FP32 output for accuracy.
+    // If `reference` is non-null, the backend may fill it with its own internal
+    // ground-truth (some backends compare against their own reference).
+    void (*run_kernel)(size_t M, size_t K, size_t N,
+                       void* weights, void* activations,
+                       const int8_t* act_int8, const float* act_scales,
+                       float* output, float* reference);
+
+    void (*cleanup)(void* weights, void* activations);
+};
+
+void register_matmul_backend(MatmulBackendVariant v);
+const std::vector<MatmulBackendVariant>& get_matmul_backends();
+
+// ── Attention backend interface ─────────────────────────────────────────────
+
+struct AttnBackendVariant {
+    const char* name;
+    const char* framework;
+    AttnMode mode;
+
+    void* (*prepare)(const AttnDims& dims, size_t seq_len, size_t cache_len,
+                     const float* fp32_q, const float* fp32_k, const float* fp32_v);
+    void  (*run)(void* state, float* output);
+    void  (*cleanup)(void* state);
+};
+
+void register_attn_backend(AttnBackendVariant v);
+const std::vector<AttnBackendVariant>& get_attn_backends();
+
+// ── Drivers ─────────────────────────────────────────────────────────────────
+
+bool run_matmul_benchmark(const MatmulBenchOptions& opt);
+bool run_attn_benchmark(const AttnBenchOptions& opt);
+
+} // namespace bench
+
+#endif

--- a/tests/bench/bench_driver.h
+++ b/tests/bench/bench_driver.h
@@ -8,21 +8,19 @@
 
 namespace bench {
 
-// ── Matmul backend interface ────────────────────────────────────────────────
-
 struct MatmulBackendVariant {
     const char* name;
     const char* framework;
 
-    // Prepare an opaque weights handle for the (N,K) shape from raw fp32 weights.
     void* (*prepare_weights)(const float* fp32, size_t N, size_t K);
 
-    // Optional per-backend activation prep (some backends quantize once per call).
+    // May be null. Backends that quantize activations once per call set it.
     void* (*prepare_activations)(const float* fp32, size_t M, size_t K, void* weights);
 
-    // Run the kernel. If `output` is non-null, fill it with FP32 output for accuracy.
-    // If `reference` is non-null, the backend may fill it with its own internal
-    // ground-truth (some backends compare against their own reference).
+    // If `output` is non-null, fill it with FP32 output for accuracy. If
+    // `reference` is non-null, the backend may fill it with its own internal
+    // ground truth (used by backends whose precision differs from the FP32
+    // reference enough to need a tighter, kernel-internal tolerance).
     void (*run_kernel)(size_t M, size_t K, size_t N,
                        void* weights, void* activations,
                        const int8_t* act_int8, const float* act_scales,
@@ -33,8 +31,6 @@ struct MatmulBackendVariant {
 
 void register_matmul_backend(MatmulBackendVariant v);
 const std::vector<MatmulBackendVariant>& get_matmul_backends();
-
-// ── Attention backend interface ─────────────────────────────────────────────
 
 struct AttnBackendVariant {
     const char* name;
@@ -49,8 +45,6 @@ struct AttnBackendVariant {
 
 void register_attn_backend(AttnBackendVariant v);
 const std::vector<AttnBackendVariant>& get_attn_backends();
-
-// ── Drivers ─────────────────────────────────────────────────────────────────
 
 bool run_matmul_benchmark(const MatmulBenchOptions& opt);
 bool run_attn_benchmark(const AttnBenchOptions& opt);

--- a/tests/bench/matmul_bench.cpp
+++ b/tests/bench/matmul_bench.cpp
@@ -1,0 +1,26 @@
+#include "bench_common.h"
+#include "bench_driver.h"
+
+#include <iostream>
+
+int main(int argc, char** argv) {
+    bench::MatmulBenchOptions opt;
+    std::string err;
+    if (!bench::parse_matmul_bench_args(argc, argv, opt, err)) {
+        std::cerr << "Error: " << err << "\n"
+                  << "Usage: " << argv[0]
+                  << " [--iterations N] [--warmup N]\n"
+                  << "       [--graphs gemv_d,gemm_d,gemm_mn]\n"
+                  << "       [--dims 128,256,...]\n"
+                  << "       [--backends fw1,fw2] [--threads N|max] [--csv path]\n";
+        return 1;
+    }
+
+    const auto& backends = bench::get_matmul_backends();
+    std::cout << "Registered matmul backends: " << backends.size() << "\n";
+    for (const auto& b : backends)
+        std::cout << "  " << b.name << " (" << b.framework << ")\n";
+
+    if (!bench::run_matmul_benchmark(opt)) return 1;
+    return 0;
+}

--- a/tests/bench/plot.py
+++ b/tests/bench/plot.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Generate the 5-graph benchmark deck from matmul_bench / attn_bench CSV.
+
+Reads:
+  matmul_bench.csv  (graphs 1, 2, 3)
+  attn_bench.csv    (graphs 4, 5)
+
+Writes one PNG per graph + a combined "all_graphs.png" with all five panels.
+
+Layout matches the deck spec: X = time (ms), Y = swept dim, one bar per
+backend per row, log X-axis.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+try:
+    import pandas as pd
+    import numpy as np
+    import matplotlib.pyplot as plt
+    from matplotlib.patches import Patch
+except ImportError as e:
+    sys.exit(f"missing dependency: {e}. install with: pip install pandas matplotlib")
+
+
+# Graph spec: (csv stem, graph filter, title, y-axis label, sweep meaning).
+GRAPHS = [
+    ("matmul", "gemv_d",            "Graph 1 — GEMV (1 × d) @ (d × N)",                                "d"),
+    ("matmul", "gemm_d",            "Graph 2 — GEMM (M × d) @ (d × N), M=N=512",                       "d"),
+    ("matmul", "gemm_mn",           "Graph 3 — GEMM (M × d) @ (d × N), M=N swept, d=512",              "M=N"),
+    ("attn",   "attn_prefill_s",    "Graph 4 — Attention (S × d) @ (d × S), d=1024, h=8",              "S"),
+    ("attn",   "attn_decode_cache", "Graph 5 — Hybrid Attention (1 × d) @ (d × 1), d=1024, h=8",       "cache_len"),
+]
+
+# Stable backend → color mapping. Cactus stands out; the others share a muted
+# palette. Unknown backends fall back to matplotlib's default cycle.
+BACKEND_COLORS = {
+    "cactus_int8":                       "#1b9e77",
+    "cactus_prefill":                    "#1b9e77",
+    "cactus_decode":                     "#1b9e77",
+    "ggml_q8_0":                         "#377eb8",
+    "ggml_fa_q8_prefill":                "#377eb8",
+    "ggml_fa_q8_decode":                 "#377eb8",
+    "ggml_mm_q8_prefill":                "#80b1d3",
+    "ggml_mm_q8_decode":                 "#80b1d3",
+    "litert_neon":                       "#ff7f00",
+    "litert_ruy":                        "#fdbf6f",
+    "litert_ruy_prefill":                "#fdbf6f",
+    "litert_ruy_decode":                 "#fdbf6f",
+    "litert_neon_decode":                "#ff7f00",
+    "onnxrt_int8":                       "#e41a1c",
+    "onnxrt_gqa_prefill":                "#e41a1c",
+    "onnxrt_gqa_decode_fp16kv":          "#fb9a99",
+    "executorch_int8":                   "#999999",
+    "executorch_sdpa_prefill_fp32":      "#666666",
+    "executorch_qsdpa_decode_int8pc":    "#666666",
+}
+
+# Stable order so the legend doesn't shuffle between graphs.
+BACKEND_ORDER = list(BACKEND_COLORS.keys())
+
+# Asterisks for backends whose precision/scheme differs from cactus's. Listed
+# in plot footnotes so the y-axis comparison stays honest.
+BACKEND_ASTERISKS = {
+    "litert_neon":                       "*",
+    "litert_ruy":                        "*",
+    "litert_ruy_prefill":                "*",
+    "litert_ruy_decode":                 "*",
+    "litert_neon_decode":                "*",
+    "executorch_int8":                   "*",
+    "executorch_qsdpa_decode_int8pc":    "*",
+    "executorch_sdpa_prefill_fp32":      "†",
+    "onnxrt_gqa_decode_fp16kv":          "‡",
+}
+ASTERISK_LEGEND = {
+    "*": "per-channel INT8 quant (vs cactus's group=32)",
+    "†": "FP32 (vs FP16)",
+    "‡": "FP16 KV (vs INT8 KV)",
+}
+
+
+def color_for(backend: str) -> str:
+    return BACKEND_COLORS.get(backend, "#444444")
+
+
+def order_backends(backends: list[str]) -> list[str]:
+    known = [b for b in BACKEND_ORDER if b in backends]
+    unknown = sorted(set(backends) - set(known))
+    return known + unknown
+
+
+def plot_graph(ax, df: pd.DataFrame, graph_filter: str, title: str, x_label: str) -> bool:
+    """Line plot: X = swept dim (log), Y = time ms (log), one line per backend."""
+    sub = df[df["graph"] == graph_filter].copy()
+    if sub.empty:
+        ax.text(0.5, 0.5, f"(no rows for graph={graph_filter})",
+                ha="center", va="center", transform=ax.transAxes, color="#888")
+        ax.set_title(title)
+        ax.set_axis_off()
+        return False
+
+    sub["time_ms"] = sub["time_us"] / 1000.0
+    dims = sorted(sub["sweep_dim"].unique())
+    backends = order_backends(list(sub["backend"].unique()))
+
+    asterisks_used = set()
+    for backend in backends:
+        b_data = (sub[sub["backend"] == backend]
+                  .sort_values("sweep_dim"))
+        if b_data.empty:
+            continue
+        # Drop non-positive times (log scale can't show zero/negative).
+        b_data = b_data[b_data["time_ms"] > 0]
+        mark = BACKEND_ASTERISKS.get(backend, "")
+        label = backend + (" " + mark if mark else "")
+        if mark:
+            asterisks_used.add(mark)
+        ax.plot(b_data["sweep_dim"], b_data["time_ms"],
+                marker="o", markersize=5, linewidth=1.8,
+                label=label, color=color_for(backend))
+
+    ax.set_xlabel(x_label)
+    ax.set_ylabel("time (ms)")
+    ax.set_title(title, fontsize=11)
+    ax.set_xscale("log", base=2)
+    ax.set_yscale("log")
+    ax.set_xticks(dims)
+    ax.set_xticklabels([str(d) for d in dims])
+    ax.grid(True, which="major", alpha=0.35)
+    ax.grid(True, which="minor", alpha=0.15)
+    ax.set_axisbelow(True)
+    ax.legend(loc="best", fontsize=8, framealpha=0.95)
+
+    # Asterisk footnote — only show keys actually used in this panel.
+    if asterisks_used:
+        notes = [f"{k} {ASTERISK_LEGEND[k]}" for k in sorted(asterisks_used,
+                                                              key=lambda x: list(ASTERISK_LEGEND).index(x))]
+        ax.text(0.0, -0.16, "\n".join(notes),
+                transform=ax.transAxes, fontsize=7, color="#555",
+                ha="left", va="top")
+    return True
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--matmul-csv", default="matmul_bench.csv",
+                    help="path to matmul_bench CSV (default: matmul_bench.csv)")
+    ap.add_argument("--attn-csv",   default="attn_bench.csv",
+                    help="path to attn_bench CSV (default: attn_bench.csv)")
+    ap.add_argument("--out-dir",    default=".",
+                    help="output directory for PNGs (default: .)")
+    ap.add_argument("--no-combined", action="store_true",
+                    help="skip the combined all_graphs.png")
+    args = ap.parse_args()
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    csv_paths = {"matmul": Path(args.matmul_csv), "attn": Path(args.attn_csv)}
+    dfs: dict[str, pd.DataFrame] = {}
+    for key, path in csv_paths.items():
+        if not path.exists():
+            print(f"warn: {path} not found — graphs sourced from '{key}' will be empty", file=sys.stderr)
+            dfs[key] = pd.DataFrame(columns=["graph", "sweep_dim", "backend", "time_us"])
+            continue
+        dfs[key] = pd.read_csv(path)
+
+    # One PNG per graph.
+    for source, gfilter, title, ylabel in GRAPHS:
+        fig, ax = plt.subplots(figsize=(10, 5.5))
+        plot_graph(ax, dfs[source], gfilter, title, ylabel)
+        fig.tight_layout()
+        out_path = out_dir / f"{gfilter}.png"
+        fig.savefig(out_path, dpi=140, bbox_inches="tight")
+        plt.close(fig)
+        print(f"wrote {out_path}")
+
+    # Combined panel.
+    if not args.no_combined:
+        fig, axes = plt.subplots(3, 2, figsize=(16, 14))
+        axes_flat = axes.flatten()
+        for ax, (source, gfilter, title, ylabel) in zip(axes_flat, GRAPHS):
+            plot_graph(ax, dfs[source], gfilter, title, ylabel)
+        # Hide the unused 6th subplot.
+        axes_flat[-1].set_axis_off()
+        fig.suptitle("cactus vs llama.cpp vs litert vs executorch vs onnx — int8 kernels",
+                     fontsize=13, y=0.995)
+        fig.tight_layout(rect=(0, 0, 1, 0.985))
+        out_path = out_dir / "all_graphs.png"
+        fig.savefig(out_path, dpi=140, bbox_inches="tight")
+        plt.close(fig)
+        print(f"wrote {out_path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/run_benchmark.sh
+++ b/tests/run_benchmark.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# Run cactus matmul + attention benchmarks for the v2-bench graph suite.
+#
+# Builds tests/build (if needed) and runs both matmul_bench and attn_bench,
+# emitting CSV files that can be plotted by external tooling.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+BUILD_DIR="$SCRIPT_DIR/build"
+
+usage() {
+    cat <<EOF
+Usage: $0 [options]
+
+Build flags (forwarded to cmake):
+  --with-ggml         Enable llama.cpp / ggml backend (-DWITH_GGML=ON)
+  --with-litert       Enable LiteRT backend          (-DWITH_LITERT=ON)
+  --with-executorch   Enable ExecuTorch backend      (-DWITH_EXECUTORCH=ON)
+  --with-onnxrt       Enable ONNX Runtime backend    (-DWITH_ONNXRT=ON)
+  --external-frameworks
+                      Auto-enable any third-party tree found under ../third_party/
+
+Run options:
+  --skip-cactus       Don't (re)build the underlying libcactus.a
+  --skip-build        Skip CMake/make for tests/
+  --no-attn           Run only the matmul benchmark
+  --no-matmul         Run only the attention benchmark
+  --backends LIST     Comma-separated framework names (cactus,ggml,litert,...)
+  --threads N|max     Override thread count
+  --csv-dir DIR       Where to write CSVs (default: tests/build)
+
+All other args are forwarded to both benchmark executables.
+EOF
+}
+
+CMAKE_FLAGS=()
+PASS_ARGS=()
+RUN_MATMUL=1
+RUN_ATTN=1
+SKIP_CACTUS=0
+SKIP_BUILD=0
+EXTERNAL_AUTO=0
+CSV_DIR="$BUILD_DIR"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --with-ggml)        CMAKE_FLAGS+=("-DWITH_GGML=ON"); shift;;
+        --with-litert)      CMAKE_FLAGS+=("-DWITH_LITERT=ON"); shift;;
+        --with-executorch)  CMAKE_FLAGS+=("-DWITH_EXECUTORCH=ON"); shift;;
+        --with-onnxrt)      CMAKE_FLAGS+=("-DWITH_ONNXRT=ON"); shift;;
+        --external-frameworks) EXTERNAL_AUTO=1; shift;;
+        --no-attn)          RUN_ATTN=0; shift;;
+        --no-matmul)        RUN_MATMUL=0; shift;;
+        --skip-cactus)      SKIP_CACTUS=1; shift;;
+        --skip-build)       SKIP_BUILD=1; shift;;
+        --csv-dir)          CSV_DIR="$2"; shift 2;;
+        -h|--help)          usage; exit 0;;
+        *)                  PASS_ARGS+=("$1"); shift;;
+    esac
+done
+
+if [[ $EXTERNAL_AUTO -eq 1 ]]; then
+    [[ -d "$ROOT_DIR/../third_party/ggml"        ]] && CMAKE_FLAGS+=("-DWITH_GGML=ON")
+    [[ -d "$ROOT_DIR/../third_party/litert"      ]] && CMAKE_FLAGS+=("-DWITH_LITERT=ON")
+    [[ -d "$ROOT_DIR/../third_party/onnxruntime" ]] && CMAKE_FLAGS+=("-DWITH_ONNXRT=ON")
+    CMAKE_FLAGS+=("-DWITH_EXECUTORCH=ON")
+fi
+
+if [[ $SKIP_CACTUS -eq 0 ]]; then
+    if [[ ! -f "$ROOT_DIR/cactus/build/libcactus.a" ]]; then
+        echo "==> Building libcactus.a"
+        bash "$ROOT_DIR/cactus/build.sh"
+    else
+        echo "==> Reusing existing libcactus.a (use --skip-cactus to silence; rebuild with cactus/build.sh)"
+    fi
+fi
+
+if [[ $SKIP_BUILD -eq 0 ]]; then
+    mkdir -p "$BUILD_DIR"
+    pushd "$BUILD_DIR" > /dev/null
+    cmake "$SCRIPT_DIR" "${CMAKE_FLAGS[@]}"
+    make -j$(sysctl -n hw.ncpu 2>/dev/null || nproc 2>/dev/null || echo 4) matmul_bench attn_bench
+    popd > /dev/null
+fi
+
+mkdir -p "$CSV_DIR"
+
+if [[ $RUN_MATMUL -eq 1 ]]; then
+    echo
+    echo "==> Running matmul_bench"
+    "$BUILD_DIR/matmul_bench" --csv "$CSV_DIR/matmul_bench.csv" "${PASS_ARGS[@]}"
+fi
+
+if [[ $RUN_ATTN -eq 1 ]]; then
+    echo
+    echo "==> Running attn_bench"
+    "$BUILD_DIR/attn_bench" --csv "$CSV_DIR/attn_bench.csv" "${PASS_ARGS[@]}"
+fi
+
+echo
+echo "==> CSV results in $CSV_DIR"
+ls -la "$CSV_DIR"/*.csv 2>/dev/null || true


### PR DESCRIPTION
## Summary

Four commits on top of \`v2\`:

1. **\`da99f6ce\` Add cross-framework int8 op benchmark suite** — five-graph deck (3 matmul shapes + prefill + hybrid decode) comparing cactus to ggml/llama.cpp, LiteRT, ExecuTorch, ONNX Runtime under matched precision and cold-cache pressure.

2. **\`851aa65f\` Trim non-essential comments from bench suite** — formatting only, 147 lines removed.

3. **\`727e7995\` Optimize hybrid INT8/FP16 decode attention kernel** — vdotq_s32 INT8 K dot path, deferred K scale (single fp32 mul/group via vmlaq_n_f32), 4-position K/V interleave, FP16 V block accumulator widened to FP32 every BLOCK_SIZE positions, light prefetch, stack scratch buffers. ~2× faster decode at every cache length, accuracy unchanged. Portable to any ARMv8.2-A+ \`+dotprod+fp16\` core.

4. **\`fe7b8b15\` Extend hybrid INT8/FP16 decode fast path to sliding-window attention** — the seq_len=1 fast path now handles windowed layers (Gemma-style 4:1 sliding/global pattern) by clamping kv iteration to \`[max(0, q_pos − window), q_pos+1)\`. Dispatcher gates the fast path on an unrolled cache (\`position_offset <= cache_len\`) so the streaming-LLM ring buffer's slot/abs divergence falls back safely to the general path. Bench gains \`--kv_heads\` / \`--head_dim\` flags for GQA/MQA configs; \`accuracy_test\` gains a rolled-cache regression sweep that locks in the invariant.

## Numbers

**Kernel-level (single-thread, default config q=kv=8, hd=128):**

| cache_len | v2 baseline | this branch | speedup |
|---|---|---|---|
| 128 | 31µs | 16µs | 1.94× |
| 256 | 52µs | 22µs | 2.36× |
| 512 | 102µs | 46µs | 2.22× |
| 1024 | 202µs | 90µs | 2.24× |
| 2048 | 400µs | 188µs | 2.13× |
| 4096 | 797µs | 416µs | 1.91× |

**End-to-end Gemma 4 E2B-it** (35 layers — 28 sliding window=512, 7 global; q=8, kv=1, hd=256), greedy decoding, max_tokens=512, 15 interleaved samples per kernel:

|  | this branch | v2 baseline |
|---|---|---|
| decode tok/s (mean) | 32.5 | 29.2 |
| decode tok/s (median) | 32.4 | 29.6 |
| stdev | 1.6 | 1.0 |

**Speedup: 1.10× (10%) [95% CI 7-13%], t = 6.2, p < 0.0001.**

## Accuracy

8 random seeds × 6 cache lengths × 3 regimes (no window / windowed unrolled / windowed rolled-cache):

| regime | max nrmse | pass |
|---|---|---|
| no window | 0.0043 | ✓ |
| sliding window=512, unrolled | 0.0043 | ✓ |
| sliding window=512, rolled (roll=128/512/2048) | 0.0041 | ✓ |

All under the 0.005 INT8 group=32 noise floor.

## Test plan

- [x] \`accuracy_test\` passes all three regimes locally
- [x] \`attn_bench --graphs attn_decode_cache --backends cactus\` matches the reported speedups across cache_len ∈ {128, 256, 512, 1024, 2048, 4096}
- [x] End-to-end Gemma 4 E2B-it with the engine's \`chat\` binary, greedy decode, 15 interleaved warm samples, p < 0.0001 vs v2 baseline
- [x] Output coherent (greedy generation produces non-degenerate text)
- [ ] Reviewer to spot-check the rolled-cache test reference vs the general-path masking semantics
- [ ] Reviewer to verify the dispatcher gate covers all paths (\`is_causal == false\`, prefill, GQA configurations)