### PR TITLE
axis reductions fast path -> v2

### DIFF
--- a/cactus-kernels/src/reduce.cpp
+++ b/cactus-kernels/src/reduce.cpp
@@ -7,6 +7,35 @@ template<typename FinalizeFn>
 static void axis_reduce_f32_impl(const __fp16* input, __fp16* output,
                                  size_t outer_size, size_t axis_size, size_t inner_size,
                                  FinalizeFn finalize) {
+    if (inner_size == 1) {
+        CactusThreading::parallel_for(outer_size, CactusThreading::Thresholds::AXIS_REDUCE,
+            [&](size_t start_outer, size_t end_outer) {
+                constexpr size_t W = SIMD_F16_WIDTH;
+                const size_t vec_axis = simd_align(axis_size);
+
+                for (size_t outer = start_outer; outer < end_outer; ++outer) {
+                    const __fp16* row = input + outer * axis_size;
+                    float32x4_t sum_lo = vdupq_n_f32(0.0f);
+                    float32x4_t sum_hi = vdupq_n_f32(0.0f);
+
+                    for (size_t a = 0; a < vec_axis; a += W) {
+                        float32x4_t lo, hi;
+                        f16x8_split_f32(vld1q_f16(row + a), lo, hi);
+                        sum_lo = vaddq_f32(sum_lo, lo);
+                        sum_hi = vaddq_f32(sum_hi, hi);
+                    }
+
+                    float total = vaddvq_f32(vaddq_f32(sum_lo, sum_hi));
+                    for (size_t a = vec_axis; a < axis_size; ++a) {
+                        total += static_cast<float>(row[a]);
+                    }
+
+                    output[outer] = static_cast<__fp16>(finalize(total, axis_size));
+                }
+            });
+        return;
+    }
+
     CactusThreading::parallel_for_2d(outer_size, inner_size, CactusThreading::Thresholds::AXIS_REDUCE,
         [&](size_t outer, size_t inner) {
             constexpr size_t W = SIMD_F16_WIDTH;
@@ -41,6 +70,37 @@ static void axis_reduce_f16_impl(const __fp16* input, __fp16* output,
                                  size_t outer_size, size_t axis_size, size_t inner_size,
                                  float16x8_t init_vec, __fp16 init_scalar,
                                  SimdReduceOp simd_reduce, ScalarReduceOp scalar_reduce) {
+    if (inner_size == 1) {
+        CactusThreading::parallel_for(outer_size, CactusThreading::Thresholds::AXIS_REDUCE,
+            [&](size_t start_outer, size_t end_outer) {
+                constexpr size_t W = SIMD_F16_WIDTH;
+                const size_t vec_axis = simd_align(axis_size);
+
+                for (size_t outer = start_outer; outer < end_outer; ++outer) {
+                    const __fp16* row = input + outer * axis_size;
+                    float16x8_t acc = init_vec;
+
+                    for (size_t a = 0; a < vec_axis; a += W) {
+                        acc = simd_reduce(acc, vld1q_f16(row + a));
+                    }
+
+                    __fp16 result = init_scalar;
+                    __fp16 arr[W];
+                    vst1q_f16(arr, acc);
+                    for (size_t j = 0; j < W; ++j) {
+                        result = scalar_reduce(result, arr[j]);
+                    }
+
+                    for (size_t a = vec_axis; a < axis_size; ++a) {
+                        result = scalar_reduce(result, row[a]);
+                    }
+
+                    output[outer] = result;
+                }
+            });
+        return;
+    }
+
     CactusThreading::parallel_for_2d(outer_size, inner_size, CactusThreading::Thresholds::AXIS_REDUCE,
         [&](size_t outer, size_t inner) {
             constexpr size_t W = SIMD_F16_WIDTH;
@@ -154,6 +214,44 @@ double cactus_variance_all_f16(const __fp16* data, size_t num_elements) {
 }
 
 void cactus_variance_axis_f16(const __fp16* input, __fp16* output, size_t outer_size, size_t axis_size, size_t inner_size) {
+    if (inner_size == 1) {
+        CactusThreading::parallel_for(outer_size, CactusThreading::Thresholds::AXIS_REDUCE,
+            [&](size_t start_outer, size_t end_outer) {
+                constexpr size_t W = SIMD_F16_WIDTH;
+                const size_t vec_axis = simd_align(axis_size);
+
+                for (size_t outer = start_outer; outer < end_outer; ++outer) {
+                    const __fp16* row = input + outer * axis_size;
+                    float32x4_t sum_lo = vdupq_n_f32(0.0f);
+                    float32x4_t sum_hi = vdupq_n_f32(0.0f);
+                    float32x4_t sq_lo = vdupq_n_f32(0.0f);
+                    float32x4_t sq_hi = vdupq_n_f32(0.0f);
+
+                    for (size_t a = 0; a < vec_axis; a += W) {
+                        float32x4_t lo, hi;
+                        f16x8_split_f32(vld1q_f16(row + a), lo, hi);
+                        sum_lo = vaddq_f32(sum_lo, lo);
+                        sum_hi = vaddq_f32(sum_hi, hi);
+                        sq_lo = vfmaq_f32(sq_lo, lo, lo);
+                        sq_hi = vfmaq_f32(sq_hi, hi, hi);
+                    }
+
+                    float sum = vaddvq_f32(vaddq_f32(sum_lo, sum_hi));
+                    float sum_sq = vaddvq_f32(vaddq_f32(sq_lo, sq_hi));
+                    for (size_t a = vec_axis; a < axis_size; ++a) {
+                        const float x = static_cast<float>(row[a]);
+                        sum += x;
+                        sum_sq += x * x;
+                    }
+
+                    const float mean = sum / static_cast<float>(axis_size);
+                    const float mean_sq = sum_sq / static_cast<float>(axis_size);
+                    output[outer] = static_cast<__fp16>(mean_sq - mean * mean);
+                }
+            });
+        return;
+    }
+
     CactusThreading::parallel_for_2d(outer_size, inner_size, CactusThreading::Thresholds::AXIS_REDUCE,
         [&](size_t outer, size_t inner) {
             float sum = 0.0f, sum_sq = 0.0f;

--- a/cactus-kernels/tests/test_reduce.cpp
+++ b/cactus-kernels/tests/test_reduce.cpp
@@ -109,8 +109,119 @@ bool test_sum_axis() {
     return true;
 }
 
-bool run_benchmarks() {
-    auto bench = [](const char* label, size_t n, auto fn) {
+bool test_neon_sum_axis_inner1_correctness() {
+    const size_t outer_size = 2;
+    const size_t axis_size = 9;
+    const size_t inner_size = 1;
+
+    std::vector<__fp16> input = {
+        1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f,
+        2.0f, 4.0f, 6.0f, 8.0f, 10.0f, 12.0f, 14.0f, 16.0f, 18.0f
+    };
+    std::vector<__fp16> output(outer_size * inner_size);
+    std::vector<__fp16> expected = {45.0f, 90.0f};
+
+    cactus_sum_axis_f16(input.data(), output.data(), outer_size, axis_size, inner_size);
+    return TestUtils::compare_arrays(output.data(), expected.data(), expected.size(), 1e-2f);
+}
+
+bool test_neon_mean_axis_inner1_correctness() {
+    const size_t outer_size = 2;
+    const size_t axis_size = 9;
+    const size_t inner_size = 1;
+
+    std::vector<__fp16> input = {
+        1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f,
+        2.0f, 4.0f, 6.0f, 8.0f, 10.0f, 12.0f, 14.0f, 16.0f, 18.0f
+    };
+    std::vector<__fp16> output(outer_size * inner_size);
+    std::vector<__fp16> expected = {5.0f, 10.0f};
+
+    cactus_mean_axis_f16(input.data(), output.data(), outer_size, axis_size, inner_size);
+    return TestUtils::compare_arrays(output.data(), expected.data(), expected.size(), 1e-2f);
+}
+
+bool test_neon_variance_axis_inner1_correctness() {
+    const size_t outer_size = 2;
+    const size_t axis_size = 9;
+    const size_t inner_size = 1;
+
+    std::vector<__fp16> input = {
+        1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f,
+        2.0f, 4.0f, 6.0f, 8.0f, 10.0f, 12.0f, 14.0f, 16.0f, 18.0f
+    };
+    std::vector<__fp16> output(outer_size * inner_size);
+    std::vector<__fp16> expected = {6.6667f, 26.6667f};
+
+    cactus_variance_axis_f16(input.data(), output.data(), outer_size, axis_size, inner_size);
+    return TestUtils::compare_arrays(output.data(), expected.data(), expected.size(), 0.05f);
+}
+
+bool test_neon_variance_axis_non_inner1_correctness() {
+    const size_t outer_size = 2;
+    const size_t axis_size = 9;
+    const size_t inner_size = 3;
+
+    std::vector<__fp16> input(outer_size * axis_size * inner_size);
+    auto idx = [&](size_t outer, size_t axis, size_t inner) {
+        return outer * axis_size * inner_size + axis * inner_size + inner;
+    };
+
+    for (size_t a = 0; a < axis_size; ++a) {
+        input[idx(0, a, 0)] = static_cast<__fp16>(1.0f + static_cast<float>(a));
+        input[idx(0, a, 1)] = static_cast<__fp16>(2.0f + static_cast<float>(a));
+        input[idx(0, a, 2)] = static_cast<__fp16>(-4.0f + static_cast<float>(a));
+
+        input[idx(1, a, 0)] = static_cast<__fp16>(2.0f + 2.0f * static_cast<float>(a));
+        input[idx(1, a, 1)] = static_cast<__fp16>(3.0f + 2.0f * static_cast<float>(a));
+        input[idx(1, a, 2)] = static_cast<__fp16>(-8.0f + 2.0f * static_cast<float>(a));
+    }
+
+    std::vector<__fp16> output(outer_size * inner_size);
+    std::vector<__fp16> expected = {
+        6.6667f, 6.6667f, 6.6667f,
+        26.6667f, 26.6667f, 26.6667f
+    };
+
+    cactus_variance_axis_f16(input.data(), output.data(), outer_size, axis_size, inner_size);
+    return TestUtils::compare_arrays(output.data(), expected.data(), expected.size(), 0.05f);
+}
+
+bool test_neon_min_axis_inner1_correctness() {
+    const size_t outer_size = 2;
+    const size_t axis_size = 9;
+    const size_t inner_size = 1;
+
+    std::vector<__fp16> input = {
+        1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f,
+        2.0f, 4.0f, 6.0f, 8.0f, 10.0f, 12.0f, 14.0f, 16.0f, 18.0f
+    };
+    std::vector<__fp16> output(outer_size * inner_size);
+    std::vector<__fp16> expected = {1.0f, 2.0f};
+
+    cactus_min_axis_f16(input.data(), output.data(), outer_size, axis_size, inner_size);
+    return TestUtils::compare_arrays(output.data(), expected.data(), expected.size(), 1e-2f);
+}
+
+bool test_neon_max_axis_inner1_correctness() {
+    const size_t outer_size = 2;
+    const size_t axis_size = 9;
+    const size_t inner_size = 1;
+
+    std::vector<__fp16> input = {
+        1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f,
+        2.0f, 4.0f, 6.0f, 8.0f, 10.0f, 12.0f, 14.0f, 16.0f, 18.0f
+    };
+    std::vector<__fp16> output(outer_size * inner_size);
+    std::vector<__fp16> expected = {9.0f, 18.0f};
+
+    cactus_max_axis_f16(input.data(), output.data(), outer_size, axis_size, inner_size);
+    return TestUtils::compare_arrays(output.data(), expected.data(), expected.size(), 1e-2f);
+}
+
+bool run_benchmarks(TestRunner& runner) {
+    (void)runner;
+    auto benchmark = [&](const std::string& label, size_t n, auto fn) {
         fn();
         Timer t;
         for (int i = 0; i < 100; i++) fn();
@@ -128,11 +239,49 @@ bool run_benchmarks() {
     volatile double sink_d = 0.0;
     volatile __fp16 sink_h = static_cast<__fp16>(0.0f);
 
-    bench("sum_all 1M", n, [&]{ sink_d = cactus_sum_all_f16(data.data(), n); });
-    bench("mean_all 1M", n, [&]{ sink_d = cactus_mean_all_f16(data.data(), n); });
-    bench("variance_all 1M", n, [&]{ sink_d = cactus_variance_all_f16(data.data(), n); });
-    bench("min_all 1M", n, [&]{ sink_h = cactus_min_all_f16(data.data(), n); });
-    bench("max_all 1M", n, [&]{ sink_h = cactus_max_all_f16(data.data(), n); });
+    benchmark("sum_all 1M", n, [&]{ sink_d = cactus_sum_all_f16(data.data(), n); });
+    benchmark("mean_all 1M", n, [&]{ sink_d = cactus_mean_all_f16(data.data(), n); });
+    benchmark("variance_all 1M", n, [&]{ sink_d = cactus_variance_all_f16(data.data(), n); });
+    benchmark("min_all 1M", n, [&]{ sink_h = cactus_min_all_f16(data.data(), n); });
+    benchmark("max_all 1M", n, [&]{ sink_h = cactus_max_all_f16(data.data(), n); });
+
+    const size_t outer = 1024;
+    const size_t axis = 1024;
+    const size_t inner1 = 1;
+    std::vector<__fp16> axis_input(outer * axis * inner1);
+    std::vector<__fp16> axis_output(outer * inner1);
+    fill_random_fp16(axis_input, -1.0f, 1.0f);
+
+    benchmark("sum_axis 1024x1024", axis_input.size(), [&]{
+        cactus_sum_axis_f16(axis_input.data(), axis_output.data(), outer, axis, inner1);
+    });
+    benchmark("mean_axis 1024x1024", axis_input.size(), [&]{
+        cactus_mean_axis_f16(axis_input.data(), axis_output.data(), outer, axis, inner1);
+    });
+    benchmark("variance_axis 1024x1024", axis_input.size(), [&]{
+        cactus_variance_axis_f16(axis_input.data(), axis_output.data(), outer, axis, inner1);
+    });
+    benchmark("min_axis 1024x1024", axis_input.size(), [&]{
+        cactus_min_axis_f16(axis_input.data(), axis_output.data(), outer, axis, inner1);
+    });
+    benchmark("max_axis 1024x1024", axis_input.size(), [&]{
+        cactus_max_axis_f16(axis_input.data(), axis_output.data(), outer, axis, inner1);
+    });
+
+    const size_t channels = 4;
+    std::vector<__fp16> variance_input_non_inner1(outer * axis * channels);
+    std::vector<__fp16> variance_output_non_inner1(outer * channels);
+    fill_random_fp16(variance_input_non_inner1, -1.0f, 1.0f);
+
+    benchmark("variance_axis 1024x1024x4", variance_input_non_inner1.size(), [&]{
+        cactus_variance_axis_f16(
+            variance_input_non_inner1.data(),
+            variance_output_non_inner1.data(),
+            outer,
+            axis,
+            channels
+        );
+    });
 
     (void)sink_d; (void)sink_h;
     return true;
@@ -145,8 +294,14 @@ int main() {
     runner.run_test("variance_all", test_variance_all());
     runner.run_test("min_max_all", test_min_max_all());
     runner.run_test("sum_axis", test_sum_axis());
+    runner.run_test("Kernel Sum Axis Inner1 FP16 Correctness", test_neon_sum_axis_inner1_correctness());
+    runner.run_test("Kernel Mean Axis Inner1 FP16 Correctness", test_neon_mean_axis_inner1_correctness());
+    runner.run_test("Kernel Variance Axis Inner1 FP16 Correctness", test_neon_variance_axis_inner1_correctness());
+    runner.run_test("Kernel Variance Axis Non-Inner1 FP16 Correctness", test_neon_variance_axis_non_inner1_correctness());
+    runner.run_test("Kernel Min Axis Inner1 FP16 Correctness", test_neon_min_axis_inner1_correctness());
+    runner.run_test("Kernel Max Axis Inner1 FP16 Correctness", test_neon_max_axis_inner1_correctness());
     runner.print_benchmarks_header();
-    runner.run_bench("benchmarks", run_benchmarks());
+    runner.run_bench("benchmarks", run_benchmarks(runner));
     runner.print_summary();
     return runner.all_passed() ? 0 : 1;
 }

--- a/python/src/cli.py
+++ b/python/src/cli.py
@@ -48,8 +48,12 @@ DEFAULT_MODEL_ID = "google/gemma-4-E2B-it"
 DEFAULT_TEST_MODEL_ID = "google/gemma-4-E2B-it"
 WEIGHTS_VARIANT_CHOICES = ["auto", "apple", "standard"]
 
-with open(PROJECT_ROOT / "models.json") as _f:
-    MODELS_REGISTRY = json.load(_f)
+# dont fail if models.json is missing or malformed - just have an empty registry and rely on HF download_args
+try:
+    with open(PROJECT_ROOT / "models.json", "r", encoding="utf-8") as f:
+        MODEL_REGISTRY = json.load(f)
+except Exception:
+    MODEL_REGISTRY = {}
 
 RED = '\033[0;31m'
 GREEN = '\033[0;32m'
@@ -718,7 +722,7 @@ def check_libcurl():
 
 
 def cmd_build(args):
-    """Build the Cactus library and chat binary."""
+    """Build the Cactus library."""
     if getattr(args, 'apple', False):
         return cmd_build_apple(args)
     if getattr(args, 'android', False):
@@ -728,8 +732,8 @@ def cmd_build(args):
     if getattr(args, 'python', False):
         return cmd_build_python(args)
 
-    print_color(BLUE, "Building Cactus chat...")
-    print("=" * 23)
+    print_color(BLUE, "Building Cactus library...")
+    print("=" * 24)
 
     if not check_command('cmake'):
         print_color(RED, "Error: CMake is not installed")
@@ -745,7 +749,6 @@ def cmd_build(args):
 
     cactus_dir = PROJECT_ROOT / "cactus"
     lib_path = cactus_dir / "build" / "libcactus.a"
-    vendored_curl = PROJECT_ROOT / "cactus-engine" / "libs" / "curl" / "macos" / "libcurl.a"
 
     print_color(YELLOW, "Building Cactus library...")
     build_script = cactus_dir / "build.sh"
@@ -756,144 +759,8 @@ def cmd_build(args):
     if result.returncode != 0:
         print_color(RED, "Failed to build cactus library")
         return 1
-
-    tests_dir = PROJECT_ROOT / "cactus-engine" / "tests"
-    build_dir = tests_dir / "build"
-    build_dir.mkdir(parents=True, exist_ok=True)
-
-    print("Compiling chat.cpp...")
-
-    chat_cpp = tests_dir / "chat.cpp"
-    if not chat_cpp.exists():
-        print_color(RED, f"Error: chat.cpp not found at {chat_cpp}")
-        return 1
-
-    is_darwin = platform.system() == "Darwin"
-
-    sdl2_available = False
-    sdl2_flags = []
-    sdl2_link = []
-    if is_darwin:
-        sdl2_check = subprocess.run(["brew", "list", "sdl2"], capture_output=True)
-        if sdl2_check.returncode == 0:
-            sdl2_prefix_result = subprocess.run(["brew", "--prefix", "sdl2"], capture_output=True, text=True)
-            if sdl2_prefix_result.returncode == 0:
-                sdl2_prefix = sdl2_prefix_result.stdout.strip()
-                sdl2_flags = ["-DHAVE_SDL2", f"-I{sdl2_prefix}/include", f"-I{sdl2_prefix}/include/SDL2"]
-                sdl2_link = [f"-L{sdl2_prefix}/lib", "-lSDL2"]
-                sdl2_available = True
-    else:
-        sdl2_check = subprocess.run(["pkg-config", "--exists", "sdl2"], capture_output=True)
-        if sdl2_check.returncode == 0:
-            cflags = subprocess.run(["pkg-config", "--cflags", "sdl2"], capture_output=True, text=True)
-            libs = subprocess.run(["pkg-config", "--libs", "sdl2"], capture_output=True, text=True)
-            if cflags.returncode == 0 and libs.returncode == 0:
-                sdl2_flags = ["-DHAVE_SDL2"] + cflags.stdout.strip().split()
-                sdl2_link = libs.stdout.strip().split()
-                sdl2_available = True
-
-    if sdl2_available:
-        print_color(GREEN, "SDL2 found - building with live audio support")
-    else:
-        print_color(YELLOW, "SDL2 not found - live mic recording will be disabled")
-        print_color(YELLOW, "Install SDL2 for live mic support: brew install sdl2 (macOS)")
-        print_color(YELLOW, "Then run `cactus build`")
-
-    if is_darwin:
-        if not vendored_curl.exists():
-            print_color(RED, f"Error: vendored libcurl not found at {vendored_curl}")
-            print("Build it first and place it in libs/curl/macos/libcurl.a")
-            return 1
-        compiler = "clang++"
-        cmd = [
-            compiler, "-std=c++20", "-O3",
-            "-DACCELERATE_NEW_LAPACK",
-            f"-I{PROJECT_ROOT}",
-            f"-I{PROJECT_ROOT / 'cactus-engine'}",
-            f"-I{PROJECT_ROOT / 'cactus-graph'}",
-            f"-I{PROJECT_ROOT / 'cactus-kernels'}",
-            *sdl2_flags,
-            str(chat_cpp),
-            str(lib_path),
-            "-o", "chat",
-            str(vendored_curl),
-            "-framework", "Accelerate",
-            "-framework", "CoreML",
-            "-framework", "Foundation",
-            "-framework", "Security",
-            "-framework", "SystemConfiguration",
-            "-framework", "CFNetwork",
-            *sdl2_link,
-        ]
-    else:
-        compiler = "g++"
-        cmd = [
-            compiler, "-std=c++20", "-O3",
-            f"-I{PROJECT_ROOT}",
-            f"-I{PROJECT_ROOT / 'cactus-engine'}",
-            f"-I{PROJECT_ROOT / 'cactus-graph'}",
-            f"-I{PROJECT_ROOT / 'cactus-kernels'}",
-            *sdl2_flags,
-            str(chat_cpp),
-            str(lib_path),
-            "-o", "chat",
-            "-lcurl",
-            "-pthread",
-            *sdl2_link,
-        ]
-
-    if not check_command(compiler):
-        print_color(RED, f"Error: {compiler} is not installed")
-        return 1
-
-    result = subprocess.run(cmd, cwd=build_dir)
-    if result.returncode != 0:
-        print_color(RED, "Build failed")
-        return 1
-
-    print_color(GREEN, f"Build complete: {build_dir / 'chat'}")
-
-    asr_cpp = tests_dir / "asr.cpp"
-    if asr_cpp.exists():
-        print("Compiling asr.cpp...")
-
-        if is_darwin:
-            cmd = [
-                compiler, "-std=c++20", "-O3",
-                "-DACCELERATE_NEW_LAPACK",
-                f"-I{PROJECT_ROOT}",
-                *sdl2_flags,
-                str(asr_cpp),
-                str(lib_path),
-                "-o", "asr",
-                str(vendored_curl),
-                "-framework", "Accelerate",
-                "-framework", "CoreML",
-                "-framework", "Foundation",
-                "-framework", "Security",
-                "-framework", "SystemConfiguration",
-                "-framework", "CFNetwork",
-                *sdl2_link,
-            ]
-        else:
-            cmd = [
-                compiler, "-std=c++20", "-O3",
-                f"-I{PROJECT_ROOT}",
-                *sdl2_flags,
-                str(asr_cpp),
-                str(lib_path),
-                "-o", "asr",
-                "-lcurl",
-                "-pthread",
-                *sdl2_link,
-            ]
-
-        result = subprocess.run(cmd, cwd=build_dir)
-        if result.returncode != 0:
-            print_color(RED, "ASR build failed")
-            return 1
-
-        print_color(GREEN, f"Build complete: {build_dir / 'asr'}")
+    print_color(GREEN, "Cactus library built successfully!")
+    print(f"Library location: {lib_path}")
 
     return 0
 
@@ -1250,7 +1117,7 @@ def _cmd_transcribe_ios(weights_dir, audio_file, args):
         print_color(RED, f"Error: audio file not found: {audio_path}")
         return 1
 
-    ios_script = PROJECT_ROOT / "tests" / "ios" / "run.sh"
+    ios_script = PROJECT_ROOT / "tests" / "ios" / "test.sh"
     if not ios_script.exists():
         print_color(RED, f"Error: iOS runner not found at {ios_script}")
         return 1
@@ -1504,7 +1371,21 @@ def cmd_test(args):
         if cmd_download(dl_args) != 0:
             return 1
 
-    test_script = PROJECT_ROOT / "tests" / "run.sh"
+    test_filter = args.only
+    for _test_name in ['llm', 'vlm', 'stt', 'embed', 'rag', 'graph', 'index', 'kernel', 'kv_cache', 'performance']:
+        if getattr(args, _test_name, False):
+            test_filter = _test_name
+            break
+
+    if test_filter == "kernel":
+        test_script = PROJECT_ROOT / "cactus-kernels" / "test.sh"
+        test_cwd = PROJECT_ROOT / "cactus-kernels"
+    elif test_filter in ("graph", "kv_cache"):
+        test_script = PROJECT_ROOT / "cactus-graph" / "test.sh"
+        test_cwd = PROJECT_ROOT / "cactus-graph"
+    else:
+        test_script = PROJECT_ROOT / "cactus-engine" / "test.sh"
+        test_cwd = PROJECT_ROOT / "cactus-engine"
 
     if not test_script.exists():
         print_color(RED, f"Error: Test script not found at {test_script}")
@@ -1522,11 +1403,6 @@ def cmd_test(args):
         cmd.append("--android")
     if args.ios:
         cmd.append("--ios")
-    test_filter = args.only
-    for _test_name in ['llm', 'vlm', 'stt', 'embed', 'rag', 'graph', 'index', 'kernel', 'kv_cache', 'performance']:
-        if getattr(args, _test_name, False):
-            test_filter = _test_name
-            break
     if test_filter:
         cmd.extend(["--only", test_filter])
     env = os.environ.copy()
@@ -1535,7 +1411,7 @@ def cmd_test(args):
     else:
         env["CACTUS_NO_CLOUD_TELE"] = "1"
 
-    result = subprocess.run(cmd, cwd=PROJECT_ROOT / "tests", env=env)
+    result = subprocess.run(cmd, cwd=test_cwd, env=env)
     return result.returncode
 
 


### PR DESCRIPTION
pr for adding a fast path for skipping columnwise gather when inner_size = 1 and instead loading directly into register. 

also fixed a bug in cli.py where it was using outdated run scripts for cactus test (run.sh instead of test.sh), and running chat.cpp test, which does not exist in this branch