### PR TITLE
move cactus transpile functionality to cactus convert

### DIFF
--- a/cactus-engine/CMakeLists.txt
+++ b/cactus-engine/CMakeLists.txt
@@ -74,6 +74,19 @@ set(ENGINE_SOURCES
     src/npu.cpp
 )
 
+set(MODEL_SOURCES
+    models/model_lfm2.cpp
+    models/model_lfm2vl.cpp
+    models/model_parakeet_tdt.cpp
+    models/model_qwen.cpp
+    models/model_siglip2.cpp
+    models/model_whisper.cpp
+    models/gemma4/model_gemma4.cpp
+    models/gemma4/model_gemma4_mm.cpp
+    models/gemma4/model_gemma4_audio.cpp
+    models/gemma4/model_gemma4_vision.cpp
+)
+
 if(APPLE)
     enable_language(OBJCXX)
     list(APPEND ENGINE_SOURCES src/npu_ane.mm)

--- a/python/cactus/cli/__init__.py
+++ b/python/cactus/cli/__init__.py
@@ -13,7 +13,7 @@ from .test import cmd_test
 from .convert import cmd_convert
 from .eval import cmd_eval
 from .misc import cmd_auth, cmd_clean, cmd_list
-from .transpile import cmd_run_transpiled, cmd_transpile
+from .transpile import cmd_run_transpiled
 
 
 def create_parser():
@@ -63,7 +63,7 @@ def create_parser():
 
    -----------------------------------------------------------------
 
-  cactus download <model>              downloads CQ model weights
+  cactus download <model>              downloads CQ model files
                                        auto-resolves Cactus-Compute CQ repo
 
     Optional flags:
@@ -76,15 +76,13 @@ def create_parser():
   -----------------------------------------------------------------
 
   cactus convert <model> [output_dir]  converts HuggingFace model to CQ format
+                                       and transpiles the graph into the same folder
 
     Optional flags:
     --bits 1|2|3|4                     CQ quantization bits (default: 4)
     --token <token>                    HuggingFace API token
 
   -----------------------------------------------------------------
-
-  cactus transpile <model>             transpiles a HuggingFace model into
-                                       Cactus component graph bundle files
 
   cactus run <bundle_dir>              runs a transpiled Cactus bundle
   cactus run-transpiled <bundle_dir>   explicit transpiled bundle runner
@@ -164,7 +162,7 @@ def create_parser():
 
     parser._action_groups = []
 
-    download_parser = subparsers.add_parser('download', help='Download CQ model weights')
+    download_parser = subparsers.add_parser('download', help='Download CQ model files')
     download_parser.add_argument('model_id', nargs='?', default=DEFAULT_MODEL_ID,
                                  help=f'HuggingFace model ID or Cactus-Compute CQ repo (default: {DEFAULT_MODEL_ID})')
     download_parser.add_argument('--language-bits', type=int, choices=[1, 2, 3, 4], default=4,
@@ -221,19 +219,6 @@ def create_parser():
                             help='Optional path to save transpiled bundle results as JSON')
     run_parser.add_argument('--thinking', action='store_true',
                             help='Enable thinking/reasoning for models that support it')
-
-    transpile_parser = subparsers.add_parser('transpile', help='Transpile a HuggingFace model into Cactus component graphs')
-    transpile_parser.add_argument('model_id', help='HuggingFace model ID to transpile (aliases: gemma4, parakeet, whisper, qwen, lfm)')
-    transpile_parser.add_argument(
-        '--execute-after-transpile',
-        action='store_true',
-        help='Also run the transpiled graph immediately. By default `cactus transpile` saves the bundle and skips execution.',
-    )
-    transpile_parser.add_argument(
-        '--allow-unconverted-weights',
-        action='store_true',
-        help='Debug only: allow transpiling without converted Cactus CQ weights.',
-    )
 
     run_transpiled_parser = subparsers.add_parser('run-transpiled', help='Run a saved transpiled component bundle')
     run_transpiled_parser.add_argument('bundle_dir',
@@ -344,7 +329,7 @@ def create_parser():
 def preprocess_eval_args(parser, argv):
     args, unknown = parser.parse_known_args(argv)
 
-    if getattr(args, 'command', None) in ('eval', 'transpile'):
+    if getattr(args, 'command', None) == 'eval':
         setattr(args, 'extra_args', unknown)
         return args
 
@@ -367,8 +352,6 @@ def main():
         sys.exit(cmd_build(args))
     elif args.command == 'run':
         sys.exit(cmd_run(args))
-    elif args.command == 'transpile':
-        sys.exit(cmd_transpile(args))
     elif args.command == 'run-transpiled':
         sys.exit(cmd_run_transpiled(args))
     elif args.command == 'transcribe':

--- a/python/cactus/cli/convert.py
+++ b/python/cactus/cli/convert.py
@@ -1,30 +1,63 @@
+from __future__ import annotations
+
+import argparse
+
 from .common import (
+    GREEN,
+    RED,
     get_weights_dir,
     print_color,
-    RED, GREEN, YELLOW,
 )
+from .transpile import cmd_transpile, resolve_model_id_alias
 
 
 def cmd_convert(args):
-    """Convert a HuggingFace model to CQ format using the convert pipeline."""
-    model_id = args.model_name
+    """Convert a HuggingFace model to CQ format and transpile it in place."""
+    model_id = resolve_model_id_alias(args.model_name)
     output_dir = args.output_dir
     if output_dir is None:
         output_dir = str(get_weights_dir(model_id))
-    bits = getattr(args, 'bits', 4) or 4
-    token = getattr(args, 'token', None)
-    cache_dir = getattr(args, 'cache_dir', None)
+
+    bits = getattr(args, "bits", 4) or 4
+    token = getattr(args, "token", None)
+    cache_dir = getattr(args, "cache_dir", None)
 
     try:
         from ..convert.cli import main as cq_main
-        cq_args = ['convert', '--model', model_id, '--out', str(output_dir), '--bits', str(bits)]
+
+        cq_args = [
+            "convert",
+            "--model",
+            model_id,
+            "--out",
+            str(output_dir),
+            "--bits",
+            str(bits),
+        ]
         if token:
-            cq_args.extend(['--token', token])
+            cq_args.extend(["--token", token])
         if cache_dir:
-            cq_args.extend(['--cache-dir', cache_dir])
-        cq_args.append('--force')
+            cq_args.extend(["--cache-dir", cache_dir])
+        cq_args.append("--force")
+
         cq_main(cq_args)
-        print_color(GREEN, f"Model converted to {output_dir}")
+
+        transpile_args = argparse.Namespace(
+            model_id=model_id,
+            execute_after_transpile=False,
+            allow_unconverted_weights=False,
+            extra_args=[
+                "--weights-dir",
+                str(output_dir),
+                "--artifact-dir",
+                str(output_dir),
+            ],
+        )
+        rc = cmd_transpile(transpile_args)
+        if rc != 0:
+            return rc
+
+        print_color(GREEN, f"Model converted and transpiled to {output_dir}")
         return 0
     except SystemExit as e:
         return e.code if e.code else 0

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -5,7 +5,7 @@ description = "Cactus Python tools"
 requires-python = ">=3.10"
 dependencies = [
     "torch",
-    "transformers",
+    "transformers>=5.5.4,<6",
     "numpy",
     "huggingface-hub",
 ]

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,7 +1,7 @@
 torch==2.8.0
 torchvision==0.23.0
 torchaudio==2.8.0
-transformers==5.0.0
+transformers==5.5.4
 pillow==11.3.0
 num2words==0.5.12
 huggingface_hub==1.4.1

--- a/python/tests/test_cli_transpile_defaults.py
+++ b/python/tests/test_cli_transpile_defaults.py
@@ -1,159 +1,108 @@
 from __future__ import annotations
 
+from argparse import Namespace
 from pathlib import Path
 
 from cactus import cli
-from cactus.cli import transpile as transpile_cli
+from cactus.cli import convert as convert_cli
 
 
-def _fake_completed_process(returncode: int = 0):
-    class _Result:
-        def __init__(self, code: int):
-            self.returncode = code
-
-    return _Result(returncode)
-
-
-def test_cmd_transpile_requires_converted_weights_by_default(monkeypatch) -> None:
+def test_cmd_convert_transpiles_into_same_weights_folder(monkeypatch, tmp_path: Path) -> None:
     parser = cli.create_parser()
-    args = cli.preprocess_eval_args(parser, ["transpile", "gemma4"])
+    args = parser.parse_args(["convert", "gemma4"])
 
-    captured: list[tuple[list[str], Path, dict[str, str]]] = []
+    model_dir = tmp_path / "weights" / "gemma-4-e2b-it"
+    calls: list[tuple[str, object]] = []
 
-    def _unexpected_runtime_build():
-        raise AssertionError("runtime build should not run before CQ weights are available")
+    def _fake_cq_main(command):
+        calls.append(("cq", list(command)))
+        return 0
 
-    monkeypatch.setattr(transpile_cli, "_ensure_python_runtime_library", _unexpected_runtime_build)
-    monkeypatch.setattr(transpile_cli, "get_weights_dir", lambda model_id: Path("/tmp/missing-weights"))
+    def _fake_cmd_transpile(transpile_args):
+        calls.append(("transpile", transpile_args))
+        assert transpile_args.model_id == "google/gemma-4-E2B-it"
+        assert transpile_args.execute_after_transpile is False
+        assert transpile_args.allow_unconverted_weights is False
+        assert transpile_args.extra_args == [
+            "--weights-dir",
+            str(model_dir),
+            "--artifact-dir",
+            str(model_dir),
+        ]
+        return 0
 
-    def _fake_run(command, cwd=None, env=None):
-        captured.append((list(command), Path(cwd), dict(env or {})))
-        return _fake_completed_process(0)
+    monkeypatch.setattr(convert_cli, "get_weights_dir", lambda model_id: model_dir)
+    monkeypatch.setattr(convert_cli, "cmd_transpile", _fake_cmd_transpile)
 
-    monkeypatch.setattr(transpile_cli.subprocess, "run", _fake_run)
+    import cactus.convert.cli as cq_cli
 
-    rc = transpile_cli.cmd_transpile(args)
+    monkeypatch.setattr(cq_cli, "main", _fake_cq_main)
 
-    assert rc == 1
-    assert not captured
-
-
-def test_cmd_transpile_allows_unconverted_weights_for_debug(monkeypatch) -> None:
-    parser = cli.create_parser()
-    args = cli.preprocess_eval_args(parser, ["transpile", "gemma4", "--allow-unconverted-weights"])
-
-    captured: list[tuple[list[str], Path, dict[str, str]]] = []
-
-    monkeypatch.setattr(transpile_cli, "_ensure_python_runtime_library", lambda: Path("/tmp/libcactus.dylib"))
-    monkeypatch.setattr(transpile_cli, "get_weights_dir", lambda model_id: Path("/tmp/missing-weights"))
-
-    def _fake_run(command, cwd=None, env=None):
-        captured.append((list(command), Path(cwd), dict(env or {})))
-        return _fake_completed_process(0)
-
-    monkeypatch.setattr(transpile_cli.subprocess, "run", _fake_run)
-
-    rc = transpile_cli.cmd_transpile(args)
+    rc = convert_cli.cmd_convert(args)
 
     assert rc == 0
-    assert captured
-    command, cwd, env = captured[0]
-    assert command[:5] == [
-        transpile_cli.sys.executable,
-        "-m",
-        "cactus.transpile.hf_model",
-        "--model-id",
-        transpile_cli.DEFAULT_MODEL_ID,
+    assert calls[0][0] == "cq"
+    assert calls[0][1] == [
+        "convert",
+        "--model",
+        "google/gemma-4-E2B-it",
+        "--out",
+        str(model_dir),
+        "--bits",
+        "4",
+        "--force",
     ]
-    assert "--allow-unconverted-weights" in command
-    assert "--skip-execute" in command
-    assert cwd == transpile_cli.PROJECT_ROOT
-    assert env["CACTUS_LIB_PATH"] == "/tmp/libcactus.dylib"
+    assert calls[1][0] == "transpile"
 
 
-def test_cmd_transpile_can_execute_immediately_when_requested(monkeypatch, tmp_path: Path) -> None:
+def test_cmd_convert_honors_explicit_output_dir(monkeypatch, tmp_path: Path) -> None:
     parser = cli.create_parser()
-    args = cli.preprocess_eval_args(
-        parser,
-        ["transpile", "gemma4", "--execute-after-transpile", "--artifact-dir", "/tmp/gemma4-bundle"],
-    )
+    args = parser.parse_args(["convert", "google/gemma-4-E2B-it", str(tmp_path / "custom")])
 
-    captured: list[list[str]] = []
+    cq_calls: list[list[str]] = []
 
-    monkeypatch.setattr(transpile_cli, "_ensure_python_runtime_library", lambda: Path("/tmp/libcactus.dylib"))
-    ready_weights_dir = tmp_path / "weights" / "gemma-4-e2b-it"
-    ready_weights_dir.mkdir(parents=True)
-    (ready_weights_dir / "weights_manifest.json").write_text("{}")
+    def _fake_cq_main(command):
+        cq_calls.append(list(command))
+        return 0
 
-    monkeypatch.setattr(transpile_cli, "get_weights_dir", lambda model_id: ready_weights_dir)
+    transpile_calls: list[Namespace] = []
 
-    def _fake_run(command, cwd=None, env=None):
-        captured.append(list(command))
-        return _fake_completed_process(0)
+    def _fake_cmd_transpile(transpile_args):
+        transpile_calls.append(transpile_args)
+        return 0
 
-    monkeypatch.setattr(transpile_cli.subprocess, "run", _fake_run)
+    monkeypatch.setattr(convert_cli, "cmd_transpile", _fake_cmd_transpile)
 
-    rc = transpile_cli.cmd_transpile(args)
+    import cactus.convert.cli as cq_cli
+
+    monkeypatch.setattr(cq_cli, "main", _fake_cq_main)
+
+    rc = convert_cli.cmd_convert(args)
 
     assert rc == 0
-    assert captured
-    command = captured[0]
-    assert "--skip-execute" not in command
-    assert "--artifact-dir" in command
-    assert "/tmp/gemma4-bundle" in command
+    assert cq_calls[0] == [
+        "convert",
+        "--model",
+        "google/gemma-4-E2B-it",
+        "--out",
+        str(tmp_path / "custom"),
+        "--bits",
+        "4",
+        "--force",
+    ]
+    assert transpile_calls[0].extra_args == [
+        "--weights-dir",
+        str(tmp_path / "custom"),
+        "--artifact-dir",
+        str(tmp_path / "custom"),
+    ]
 
 
-def test_cmd_transpile_rejects_empty_default_weights_dir(monkeypatch, tmp_path: Path) -> None:
+def test_cli_no_longer_registers_transpile_command() -> None:
     parser = cli.create_parser()
-    args = cli.preprocess_eval_args(parser, ["transpile", "whisper-small"])
-
-    empty_weights_dir = tmp_path / "weights" / "whisper-small"
-    empty_weights_dir.mkdir(parents=True)
-
-    captured: list[list[str]] = []
-
-    monkeypatch.setattr(transpile_cli, "_ensure_python_runtime_library", lambda: Path("/tmp/libcactus.dylib"))
-    monkeypatch.setattr(transpile_cli, "get_weights_dir", lambda model_id: empty_weights_dir)
-
-    def _fake_run(command, cwd=None, env=None):
-        captured.append(list(command))
-        return _fake_completed_process(0)
-
-    monkeypatch.setattr(transpile_cli.subprocess, "run", _fake_run)
-
-    rc = transpile_cli.cmd_transpile(args)
-
-    assert rc == 1
-    assert not captured
-
-
-def test_cmd_transpile_uses_ready_default_weights_dir(monkeypatch, tmp_path: Path) -> None:
-    parser = cli.create_parser()
-    args = cli.preprocess_eval_args(parser, ["transpile", "parakeet"])
-
-    ready_weights_dir = tmp_path / "weights" / "parakeet-tdt-0.6b-v3"
-    ready_weights_dir.mkdir(parents=True)
-    (ready_weights_dir / "weights_manifest.json").write_text("{}")
-
-    captured: list[list[str]] = []
-
-    monkeypatch.setattr(transpile_cli, "_ensure_python_runtime_library", lambda: Path("/tmp/libcactus.dylib"))
-    monkeypatch.setattr(transpile_cli, "get_weights_dir", lambda model_id: ready_weights_dir)
-
-    def _fake_run(command, cwd=None, env=None):
-        captured.append(list(command))
-        return _fake_completed_process(0)
-
-    monkeypatch.setattr(transpile_cli.subprocess, "run", _fake_run)
-
-    rc = transpile_cli.cmd_transpile(args)
-
-    assert rc == 0
-    assert captured
-    command = captured[0]
-    assert "--weights-dir" in command
-    assert str(ready_weights_dir) in command
-
-
-def test_lfm_alias_points_to_vl_450m() -> None:
-    assert transpile_cli.MODEL_ID_ALIASES["lfm"] == "LiquidAI/LFM2-VL-450M"
+    try:
+        parser.parse_args(["transpile", "gemma4"])
+    except SystemExit as exc:
+        assert exc.code != 0
+    else:
+        raise AssertionError("transpile should no longer be a public CLI command")

--- a/setup
+++ b/setup
@@ -82,6 +82,15 @@ else
     echo -e "${YELLOW}Warning: requirements.txt not found${NC}"
 fi
 
+echo ""
+echo -e "${BLUE}Step 3b: Upgrading Transformers...${NC}"
+if python3 -m pip install --upgrade "transformers==5.5.4" -q; then
+    echo -e "${GREEN}✓ Transformers upgraded to 5.5.4${NC}"
+else
+    echo -e "${RED}Failed to upgrade Transformers${NC}"
+    return 1
+fi
+
 if [ -f "$PARENT_REQUIREMENTS" ] && [ "$PARENT_REQUIREMENTS" != "$REQUIREMENTS_FILE" ]; then
     echo ""
     echo -e "${BLUE}Detected parent repo requirements at: $PARENT_REQUIREMENTS${NC}"


### PR DESCRIPTION
cactus convert now converts weights to CQ and runs transpilation. Transpiled graph is stored alongside weights in the weights/ folder in root. Also, upgraded requirements.txt and setup to use a newer version of transformers since there were some versioning issues. 

restored CMakeLists to include manual model files, since there are still some dependencies involving them (in cactus_engine/model.cpp). without them, cactus build fails. we can figure out how to remove them in a future commit