### PR TITLE
added cactus_graph_set_grouped_scales to c++ api

### DIFF
--- a/cactus-engine/cactus_engine.h
+++ b/cactus-engine/cactus_engine.h
@@ -315,6 +315,8 @@ CACTUS_FFI_EXPORT int cactus_graph_mmap_weights(
     cactus_graph_t graph, const char* filename, cactus_node_t* out);
 CACTUS_FFI_EXPORT int cactus_graph_bind_mmap_weights(
     cactus_graph_t graph, cactus_node_t node, const char* filename);
+CACTUS_FFI_EXPORT int cactus_graph_set_grouped_scales(
+    cactus_graph_t graph, cactus_node_t node, size_t group_size, size_t num_groups, uint32_t flags, const void* scales);
 CACTUS_FFI_EXPORT int cactus_graph_bilinear_interpolation(
     cactus_graph_t graph, cactus_node_t pos_embeds, size_t dst_height, size_t dst_width, cactus_node_t* out);
 CACTUS_FFI_EXPORT int cactus_graph_release_weight_pages(cactus_graph_t graph, cactus_node_t node);

--- a/cactus-engine/src/graph_ffi.cpp
+++ b/cactus-engine/src/graph_ffi.cpp
@@ -636,6 +636,17 @@ int cactus_graph_bind_mmap_weights(cactus_graph_t graph, cactus_node_t node, con
     }
 }
 
+int cactus_graph_set_grouped_scales(cactus_graph_t graph, cactus_node_t node, size_t group_size, size_t num_groups, uint32_t flags, const void* scales) {
+    if (!graph || !scales) return fail_invalid("Invalid args to cactus_graph_set_grouped_scales");
+    try {
+        as_graph(graph)->graph.set_grouped_scales(static_cast<size_t>(node), group_size, num_groups, flags, scales);
+        return 0;
+    } catch (const std::exception& e) {
+        last_error_message = e.what();
+        return -1;
+    }
+}
+
 int cactus_graph_bilinear_interpolation(cactus_graph_t graph, cactus_node_t pos_embeds, size_t dst_height, size_t dst_width, cactus_node_t* out) {
     if (!graph || !out) return fail_invalid("Invalid args to cactus_graph_bilinear_interpolation");
     try {

--- a/cactus-graph/cactus_graph.h
+++ b/cactus-graph/cactus_graph.h
@@ -667,6 +667,7 @@ public:
     size_t mmap_embeddings(const std::string& filename);
     size_t mmap_weights(const std::string& filename);
     void bind_mmap_weights(size_t node_id, const std::string& filename);
+    void set_grouped_scales(size_t node_id, size_t group_size, size_t num_groups, uint32_t flags, const void* scales);
     void release_weight_pages(size_t node_id);
     void prefetch_weight_pages(size_t node_id);
     void release_all_weight_pages();

--- a/cactus-graph/src/io.cpp
+++ b/cactus-graph/src/io.cpp
@@ -186,6 +186,79 @@ namespace {
         }
     }
 
+    void clear_grouped_scale_metadata(BufferDesc& buffer) {
+        buffer.group_size = 0;
+        buffer.num_groups = 0;
+        buffer.activation_scales_data = nullptr;
+        buffer.owned_activation_scales.reset();
+        buffer.num_rows_for_activation_scales = 0;
+        buffer.cq_codebook = nullptr;
+        buffer.cq_input_scale = nullptr;
+        buffer.cq_input_scale_recip = nullptr;
+        buffer.cq_norms = nullptr;
+        buffer.cq_left_signs = nullptr;
+        buffer.cq_right_signs = nullptr;
+        buffer.cq_permutation = nullptr;
+        buffer.cq_rotation = nullptr;
+        buffer.cq_flags = 0;
+    }
+
+    void apply_grouped_scales(
+        BufferDesc& buffer,
+        Precision precision,
+        const std::vector<size_t>& shape,
+        size_t group_size,
+        size_t num_groups,
+        uint32_t flags,
+        const void* scales_base) {
+        clear_grouped_scale_metadata(buffer);
+        if (group_size == 0 || num_groups == 0 || scales_base == nullptr) {
+            return;
+        }
+
+        buffer.group_size = group_size;
+        buffer.num_groups = num_groups;
+
+        if (PrecisionTraits::is_cq(precision)) {
+            const char* scales = static_cast<const char*>(scales_base);
+            uint32_t bits = PrecisionTraits::cq_bits(precision);
+            uint32_t cb_size = 1u << bits;
+            uint32_t gs = static_cast<uint32_t>(group_size);
+            uint32_t K = gs * static_cast<uint32_t>(num_groups);
+            uint32_t N = static_cast<uint32_t>(shape.size() >= 2 ? shape[0] : 1);
+
+            size_t off = 0;
+            buffer.cq_codebook = reinterpret_cast<const __fp16*>(scales + off);
+            off += cb_size * sizeof(__fp16);
+            buffer.cq_input_scale = reinterpret_cast<const __fp16*>(scales + off);
+            off += K * sizeof(__fp16);
+            buffer.cq_input_scale_recip = reinterpret_cast<const __fp16*>(scales + off);
+            off += K * sizeof(__fp16);
+            buffer.cq_norms = reinterpret_cast<const __fp16*>(scales + off);
+            off += static_cast<size_t>(N) * num_groups * sizeof(__fp16);
+
+            if ((flags & FLAG_ORTHOGONAL_ROTATION) != 0) {
+                buffer.cq_rotation = reinterpret_cast<const __fp16*>(scales + off);
+                buffer.cq_flags = CACTUS_QUANT_FLAG_ORTHOGONAL;
+            } else {
+                buffer.cq_left_signs = reinterpret_cast<const int8_t*>(scales + off);
+                off += gs;
+                buffer.cq_right_signs = reinterpret_cast<const int8_t*>(scales + off);
+                off += gs;
+                buffer.cq_permutation = reinterpret_cast<const uint32_t*>(scales + off);
+                buffer.cq_flags = 0;
+            }
+            if ((flags & FLAG_INTERLEAVED_4ROW) != 0) {
+                buffer.cq_flags |= CACTUS_QUANT_FLAG_INTERLEAVED_4ROW;
+            }
+            return;
+        }
+
+        if (precision == Precision::INT8) {
+            buffer.set_activation_scales(const_cast<void*>(scales_base), shape.empty() ? 0 : shape[0]);
+        }
+    }
+
     GraphFile::GraphHeader read_graph_header(std::istream& in) {
         GraphFile::GraphHeader header;
         header.magic = read_u32(in);
@@ -297,46 +370,15 @@ size_t CactusGraph::mmap_embeddings(const std::string& filename) {
     set_external_input(node_id, const_cast<void*>(mapped_file->data()), precision);
 
     auto& buffer = nodes_[node_index_map_.at(node_id)]->output_buffer;
-    if (PrecisionTraits::is_cq(precision) && mapped_file->group_size() > 0) {
-        buffer.group_size = mapped_file->group_size();
-        buffer.num_groups = mapped_file->num_groups();
-
-        const char* scales_base = static_cast<const char*>(mapped_file->scales_data());
-        uint32_t bits = PrecisionTraits::cq_bits(precision);
-        uint32_t cb_size = 1u << bits;
-        uint32_t gs = static_cast<uint32_t>(mapped_file->group_size());
-        uint32_t K = gs * static_cast<uint32_t>(mapped_file->num_groups());
-        uint32_t N = static_cast<uint32_t>(shape.size() >= 2 ? shape[0] : 1);
-
-        size_t off = 0;
-        buffer.cq_codebook = reinterpret_cast<const __fp16*>(scales_base + off);
-        off += cb_size * sizeof(__fp16);
-        buffer.cq_input_scale = reinterpret_cast<const __fp16*>(scales_base + off);
-        off += K * sizeof(__fp16);
-        buffer.cq_input_scale_recip = reinterpret_cast<const __fp16*>(scales_base + off);
-        off += K * sizeof(__fp16);
-        buffer.cq_norms = reinterpret_cast<const __fp16*>(scales_base + off);
-        off += static_cast<size_t>(N) * mapped_file->num_groups() * sizeof(__fp16);
-
-        if (mapped_file->is_orthogonal_rotation()) {
-            buffer.cq_rotation = reinterpret_cast<const __fp16*>(scales_base + off);
-            buffer.cq_flags = CACTUS_QUANT_FLAG_ORTHOGONAL;
-        } else {
-            buffer.cq_left_signs = reinterpret_cast<const int8_t*>(scales_base + off);
-            off += gs;
-            buffer.cq_right_signs = reinterpret_cast<const int8_t*>(scales_base + off);
-            off += gs;
-            buffer.cq_permutation = reinterpret_cast<const uint32_t*>(scales_base + off);
-            buffer.cq_flags = 0;
-        }
-        if (mapped_file->is_interleaved_4row()) {
-            buffer.cq_flags |= CACTUS_QUANT_FLAG_INTERLEAVED_4ROW;
-        }
-    } else if (precision == Precision::INT8 && mapped_file->group_size() > 0) {
-        buffer.group_size = mapped_file->group_size();
-        buffer.num_groups = mapped_file->num_groups();
-        buffer.set_activation_scales(const_cast<void*>(mapped_file->scales_data()), shape.empty() ? 0 : shape[0]);
-    }
+    apply_grouped_scales(
+        buffer,
+        precision,
+        shape,
+        mapped_file->group_size(),
+        mapped_file->num_groups(),
+        (mapped_file->is_orthogonal_rotation() ? FLAG_ORTHOGONAL_ROTATION : 0) |
+            (mapped_file->is_interleaved_4row() ? FLAG_INTERLEAVED_4ROW : 0),
+        mapped_file->scales_data());
 
     size_t file_idx = mapped_files_.size();
     mapped_files_.push_back(std::move(mapped_file));
@@ -360,44 +402,15 @@ size_t CactusGraph::mmap_weights(const std::string& filename) {
     size_t node_id = input(shape, precision);
     set_external_input(node_id, const_cast<void*>(mapped_file->data()), precision);
 
-    if (PrecisionTraits::is_cq(precision) && mapped_file->group_size() > 0) {
-        auto& buffer = nodes_[node_index_map_.at(node_id)]->output_buffer;
-        buffer.group_size = mapped_file->group_size();
-        buffer.num_groups = mapped_file->num_groups();
-
-
-        const char* scales_base = static_cast<const char*>(mapped_file->scales_data());
-        uint32_t bits = PrecisionTraits::cq_bits(precision);
-        uint32_t cb_size = 1u << bits;
-        uint32_t gs = static_cast<uint32_t>(mapped_file->group_size());
-        uint32_t K = gs * static_cast<uint32_t>(mapped_file->num_groups());
-        uint32_t N = static_cast<uint32_t>(shape.size() >= 2 ? shape[0] : 1);
-
-        size_t off = 0;
-        buffer.cq_codebook = reinterpret_cast<const __fp16*>(scales_base + off);
-        off += cb_size * sizeof(__fp16);
-        buffer.cq_input_scale = reinterpret_cast<const __fp16*>(scales_base + off);
-        off += K * sizeof(__fp16);
-        buffer.cq_input_scale_recip = reinterpret_cast<const __fp16*>(scales_base + off);
-        off += K * sizeof(__fp16);
-        buffer.cq_norms = reinterpret_cast<const __fp16*>(scales_base + off);
-        off += static_cast<size_t>(N) * mapped_file->num_groups() * sizeof(__fp16);
-
-        if (mapped_file->is_orthogonal_rotation()) {
-            buffer.cq_rotation = reinterpret_cast<const __fp16*>(scales_base + off);
-            buffer.cq_flags = CACTUS_QUANT_FLAG_ORTHOGONAL;
-        } else {
-            buffer.cq_left_signs = reinterpret_cast<const int8_t*>(scales_base + off);
-            off += gs;
-            buffer.cq_right_signs = reinterpret_cast<const int8_t*>(scales_base + off);
-            off += gs;
-            buffer.cq_permutation = reinterpret_cast<const uint32_t*>(scales_base + off);
-            buffer.cq_flags = 0;
-        }
-        if (mapped_file->is_interleaved_4row()) {
-            buffer.cq_flags |= CACTUS_QUANT_FLAG_INTERLEAVED_4ROW;
-        }
-    }
+    apply_grouped_scales(
+        nodes_[node_index_map_.at(node_id)]->output_buffer,
+        precision,
+        shape,
+        mapped_file->group_size(),
+        mapped_file->num_groups(),
+        (mapped_file->is_orthogonal_rotation() ? FLAG_ORTHOGONAL_ROTATION : 0) |
+            (mapped_file->is_interleaved_4row() ? FLAG_INTERLEAVED_4ROW : 0),
+        mapped_file->scales_data());
 
     size_t file_idx = mapped_files_.size();
     mapped_files_.push_back(std::move(mapped_file));
@@ -430,63 +443,43 @@ void CactusGraph::bind_mmap_weights(size_t node_id, const std::string& filename)
     }
 
     set_external_input(node_id, const_cast<void*>(mapped_file->data()), precision);
-    buffer.group_size = 0;
-    buffer.num_groups = 0;
-    buffer.activation_scales_data = nullptr;
-    buffer.owned_activation_scales.reset();
-    buffer.num_rows_for_activation_scales = 0;
-    buffer.cq_codebook = nullptr;
-    buffer.cq_input_scale = nullptr;
-    buffer.cq_input_scale_recip = nullptr;
-    buffer.cq_norms = nullptr;
-    buffer.cq_left_signs = nullptr;
-    buffer.cq_right_signs = nullptr;
-    buffer.cq_permutation = nullptr;
-    buffer.cq_rotation = nullptr;
-    buffer.cq_flags = 0;
-
-    if (PrecisionTraits::is_cq(precision) && mapped_file->group_size() > 0) {
-        buffer.group_size = mapped_file->group_size();
-        buffer.num_groups = mapped_file->num_groups();
-
-        const char* scales_base = static_cast<const char*>(mapped_file->scales_data());
-        uint32_t bits = PrecisionTraits::cq_bits(precision);
-        uint32_t cb_size = 1u << bits;
-        uint32_t gs = static_cast<uint32_t>(mapped_file->group_size());
-        uint32_t K = gs * static_cast<uint32_t>(mapped_file->num_groups());
-        uint32_t N = static_cast<uint32_t>(shape.size() >= 2 ? shape[0] : 1);
-
-        size_t off = 0;
-        buffer.cq_codebook = reinterpret_cast<const __fp16*>(scales_base + off);
-        off += cb_size * sizeof(__fp16);
-        buffer.cq_input_scale = reinterpret_cast<const __fp16*>(scales_base + off);
-        off += K * sizeof(__fp16);
-        buffer.cq_input_scale_recip = reinterpret_cast<const __fp16*>(scales_base + off);
-        off += K * sizeof(__fp16);
-        buffer.cq_norms = reinterpret_cast<const __fp16*>(scales_base + off);
-        off += static_cast<size_t>(N) * mapped_file->num_groups() * sizeof(__fp16);
-
-        if (mapped_file->is_orthogonal_rotation()) {
-            buffer.cq_rotation = reinterpret_cast<const __fp16*>(scales_base + off);
-            buffer.cq_flags = CACTUS_QUANT_FLAG_ORTHOGONAL;
-        } else {
-            buffer.cq_left_signs = reinterpret_cast<const int8_t*>(scales_base + off);
-            off += gs;
-            buffer.cq_right_signs = reinterpret_cast<const int8_t*>(scales_base + off);
-            off += gs;
-            buffer.cq_permutation = reinterpret_cast<const uint32_t*>(scales_base + off);
-            buffer.cq_flags = 0;
-        }
-    } else if (precision == Precision::INT8 && mapped_file->group_size() > 0) {
-        buffer.group_size = mapped_file->group_size();
-        buffer.num_groups = mapped_file->num_groups();
-        buffer.set_activation_scales(const_cast<void*>(mapped_file->scales_data()), shape.empty() ? 0 : shape[0]);
-    }
+    apply_grouped_scales(
+        buffer,
+        precision,
+        shape,
+        mapped_file->group_size(),
+        mapped_file->num_groups(),
+        (mapped_file->is_orthogonal_rotation() ? FLAG_ORTHOGONAL_ROTATION : 0) |
+            (mapped_file->is_interleaved_4row() ? FLAG_INTERLEAVED_4ROW : 0),
+        mapped_file->scales_data());
 
     size_t file_idx = mapped_files_.size();
     mapped_files_.push_back(std::move(mapped_file));
     node_to_mapped_file_[node_id] = file_idx;
     weight_cache_[resolved_filename] = node_id;
+}
+
+void CactusGraph::set_grouped_scales(size_t node_id, size_t group_size, size_t num_groups, uint32_t flags, const void* scales) {
+    auto node_it = node_index_map_.find(node_id);
+    if (node_it == node_index_map_.end()) {
+        throw std::out_of_range("Unknown input node id: " + std::to_string(node_id));
+    }
+
+    auto& node = *nodes_[node_it->second];
+    if (node.op_type != OpType::INPUT) {
+        throw std::invalid_argument("Can only set grouped scales on input nodes");
+    }
+
+    auto& buffer = node.output_buffer;
+    if (!PrecisionTraits::is_cq(buffer.precision) && buffer.precision != Precision::INT8) {
+        throw std::runtime_error("Grouped scales are only supported for CQ and INT8 input buffers");
+    }
+    if (group_size == 0 || num_groups == 0 || scales == nullptr) {
+        clear_grouped_scale_metadata(buffer);
+        return;
+    }
+
+    apply_grouped_scales(buffer, buffer.precision, buffer.shape, group_size, num_groups, flags, scales);
 }
 
 void CactusGraph::release_weight_pages(size_t node_id) {

--- a/python/cactus/bindings/cactus.py
+++ b/python/cactus/bindings/cactus.py
@@ -266,7 +266,7 @@ _lib.cactus_graph_bilinear_interpolation.argtypes = [
 _lib.cactus_graph_bilinear_interpolation.restype = ctypes.c_int
 _bind_optional(
     "cactus_graph_set_grouped_scales",
-    [cactus_graph_t, cactus_node_t, ctypes.c_size_t, ctypes.c_size_t, ctypes.c_void_p],
+    [cactus_graph_t, cactus_node_t, ctypes.c_size_t, ctypes.c_size_t, ctypes.c_uint32, ctypes.c_void_p],
     ctypes.c_int,
 )
 _bind_optional(

--- a/python/cactus/bindings/graph.py
+++ b/python/cactus/bindings/graph.py
@@ -431,7 +431,7 @@ class Graph:
             raise RuntimeError("graph_bilinear_interpolation failed")
         return self._tensor_from_node(out.value)
 
-    def set_grouped_scales(self, tensor, group_size, num_groups, scales):
+    def set_grouped_scales(self, tensor, group_size, num_groups, scales, flags=0):
         tensor = self._ensure_tensor(tensor)
         arr = np.ascontiguousarray(scales, dtype=np.float16)
         rc = _lib.cactus_graph_set_grouped_scales(
@@ -439,6 +439,7 @@ class Graph:
             cactus_node_t(tensor.id),
             ctypes.c_size_t(int(group_size)),
             ctypes.c_size_t(int(num_groups)),
+            ctypes.c_uint32(int(flags)),
             arr.ctypes.data_as(ctypes.c_void_p),
         )
         if rc != 0:

--- a/python/cactus/transpile/component_bundle_runtime.py
+++ b/python/cactus/transpile/component_bundle_runtime.py
@@ -69,6 +69,7 @@ class LoadedTensorFile:
     scales: np.memmap | None
     group_size: int
     num_groups: int
+    flags: int
     is_interleaved: bool
     original_n: int
 
@@ -2421,6 +2422,7 @@ def _rebind_bound_constants(
                 cactus_node_t(tensor.id),
                 int(tensor_file.group_size),
                 int(tensor_file.num_groups),
+                int(tensor_file.flags),
                 tensor_file.scales.ctypes.data_as(ctypes.c_void_p),
             )
             if rc != 0:
@@ -2515,6 +2517,7 @@ def _open_cactus_tensor_file(path: str | Path) -> LoadedTensorFile:
         scales=scales,
         group_size=group_size,
         num_groups=num_groups,
+        flags=flags,
         is_interleaved=bool(flags & FLAG_INTERLEAVED),
         original_n=original_n,
     )


### PR DESCRIPTION
fixes qwen weight binding issue with transpilation. cactus_graph_set_grouped_scales was exported in the bindings/ffi but never created in the c++ api.