### PR TITLE
fix: add missing <iomanip> include for Linux ARM64 builds

### DIFF
--- a/cactus/telemetry/telemetry.cpp
+++ b/cactus/telemetry/telemetry.cpp
@@ -7,6 +7,7 @@
 #include <ctime>
 #include <random>
 #include <sstream>
+#include <iomanip>
 #include <string>
 #include <vector>
 #include <deque>


### PR DESCRIPTION
## Problem

Building on Linux ARM64 (aarch64, Ubuntu 22.04, g++11) fails with:

```
telemetry/telemetry.cpp: In function 'std::string cactus::telemetry::new_uuid()':
error: 'setfill' is not a member of 'std'; did you mean 'fill'?
error: 'setw' is not a member of 'std'
```

`std::setfill` and `std::setw` are declared in `<iomanip>`, which is not guaranteed to be pulled in transitively by other headers on GCC/Linux. Apple Clang happens to include it indirectly, masking the issue on macOS.

## Fix

Add `#include <iomanip>` to `cactus/telemetry/telemetry.cpp`.

## Tested on

- Jetson Orin Nano 8GB (aarch64, Ubuntu 22.04, g++ 11.4.0) — build succeeds after fix
- Needle 26M tool-call benchmark running at 375ms avg latency via the native ARM SIMD path

Affects any Linux ARM64 target: Jetson, Raspberry Pi, other SBCs.