### PR TITLE
Propagate test executable failures

### DIFF
--- a/tests/android/run.sh
+++ b/tests/android/run.sh
@@ -311,10 +311,11 @@ echo "Using embed_speaker model path: $device_model_dir/$embed_speaker_model_dir
 echo "Using assets path: $device_assets_dir/assets"
 echo "Using index path: $device_assets_dir/assets"
 
+failures=0
 for test_exe in "${test_executables[@]}"; do
     test_name=$(basename "$test_exe")
 
-    adb -s "$DEVICE_ID" shell "cd $device_test_dir && \
+    if ! adb -s "$DEVICE_ID" shell "cd $device_test_dir && \
         export CACTUS_TEST_MODEL=$device_model_dir/$model_dir && \
         export CACTUS_TEST_TRANSCRIBE_MODEL=$device_model_dir/$transcribe_model_dir && \
         export CACTUS_TEST_WHISPER_MODEL=$device_model_dir/$whisper_model_dir && \
@@ -324,7 +325,15 @@ for test_exe in "${test_executables[@]}"; do
         export CACTUS_TEST_ASSETS=$device_assets_dir/assets && \
         export CACTUS_INDEX_PATH=$device_assets_dir/assets && \
         export CACTUS_NO_CLOUD_TELE=${CACTUS_NO_CLOUD_TELE} && \
-        ./$test_name"
+        ./$test_name"; then
+        echo "Test executable failed: $test_name"
+        failures=$((failures + 1))
+    fi
 done
+
+if [ "$failures" -ne 0 ]; then
+    echo "$failures test executable(s) failed"
+    exit 1
+fi
 
 echo ""

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -287,10 +287,19 @@ fi
 
 echo "Found ${#test_executables[@]} test executable(s)"
 
+failures=0
 for executable in "${test_executables[@]}"; do
     exec_name=$(basename "$executable")
-    ./"$exec_name"
+    if ! ./"$exec_name"; then
+        echo "Test executable failed: $exec_name"
+        failures=$((failures + 1))
+    fi
 done
+
+if [ "$failures" -ne 0 ]; then
+    echo "$failures test executable(s) failed"
+    exit 1
+fi
 
 if [ "$EXHAUSTIVE_MODE" = true ]; then
     echo ""


### PR DESCRIPTION
## Summary

Fixes #677 by making the Cactus test runners return a non-zero exit code when any discovered test executable fails.

Previously, `tests/run.sh` and `tests/android/run.sh` executed multiple `test_*` binaries in a loop but did not accumulate failures. If an earlier executable failed and a later executable succeeded, the top-level test command could still finish successfully.

## What changed

- Added a `failures` counter to `tests/run.sh`.
- Added the same failure aggregation pattern to `tests/android/run.sh`.
- Each failed executable is reported by name.
- The runner exits `1` after the loop if one or more executables failed.
- Existing behavior is preserved when all test executables pass.

## Tests

Local validation on Windows using Git Bash:

    "C:\Program Files\Git\bin\bash.exe" -n tests/run.sh
    "C:\Program Files\Git\bin\bash.exe" -n tests/android/run.sh

Synthetic failure-count smoke check:

    "C:\Program Files\Git\bin\bash.exe" --noprofile --norc -lc 'failures=0; for status in 1 0; do if ! (exit "$status"); then failures=$((failures+1)); fi; done; test "$failures" -eq 1'

Repository check:

    git diff --check

## Notes

I did not run the full `cactus test` suite in this environment because it requires model downloads and a native build path. This PR is intentionally limited to shell runner exit-status propagation.

## DCO

Signed-off-by line is included in the commit.
