### PR TITLE
Correct docs to match current code

### DIFF
--- a/docs/cactus_engine.md
+++ b/docs/cactus_engine.md
@@ -489,11 +489,11 @@ int cactus_benchmark_tokens(
 Returns the number of bytes written to `response_buffer` on success, `-1` on error.
 
 ### `cactus_transcribe`
-Transcribes audio to text. Supports Whisper, Moonshine, and Parakeet models. Supports both file-based and buffer-based audio input.
+Transcribes audio to text using Whisper or Parakeet TDT models. Supports both file-based and buffer-based audio input.
 
 ```c
 int cactus_transcribe(
-    cactus_model_t model,           // Model handle (Whisper, Moonshine, or Parakeet model)
+    cactus_model_t model,           // Model handle (Whisper or Parakeet TDT model)
     const char* audio_file_path,    // Path to WAV file (16-bit PCM) - can be NULL if using pcm_buffer
     const char* prompt,             // Optional prompt to guide transcription (can be NULL)
     char* response_buffer,          // Buffer for response JSON
@@ -513,27 +513,13 @@ int cactus_transcribe(
 **Options Format:**
 ```json
 {
-    "max_tokens": 448,
-    "temperature": 0.0,
-    "top_p": 0.0,
-    "top_k": 0,
-    "use_vad": true,
-    "cloud_handoff_threshold": 0.0,
-    "custom_vocabulary": ["word1", "word2"],
-    "vocabulary_boost": 5.0
+    "max_tokens": 448
 }
 ```
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `max_tokens` | int | auto | Maximum tokens to generate; defaults to an estimate based on audio length |
-| `temperature` | float | 0.0 | Sampling temperature |
-| `top_p` | float | 0.0 | Top-p (nucleus) sampling |
-| `top_k` | int | 0 | Top-k sampling |
-| `use_vad` | bool | true | Split audio using voice activity detection before transcribing |
-| `cloud_handoff_threshold` | float | model default | Maximum token entropy norm above which cloud handoff is flagged |
-| `custom_vocabulary` | array | [] | Words or phrases to boost recognition probability |
-| `vocabulary_boost` | float | 5.0 | Log-probability bias for custom_vocabulary tokens (0.0–20.0) |
+| `max_tokens` | int | auto | Maximum tokens to generate. When unset, it defaults to the larger of 100 and an audio-length estimate (`audio_sec × 20` for Whisper, `audio_sec × 30` for Parakeet). For Whisper the result is then capped so the prompt tokens plus generated tokens fit the decoder's 448-position limit. |
 
 **Response Format:**
 ```json
@@ -543,10 +529,8 @@ int cactus_transcribe(
     "cloud_handoff": false,
     "response": "Transcribed text here.",
     "function_calls": [],
-    "segments": [
-        {"start": 0.0, "end": 2.5, "text": "Transcribed text here."}
-    ],
-    "confidence": 0.92,
+    "segments": [],
+    "confidence": 1.0,
     "time_to_first_token_ms": 120.0,
     "total_time_ms": 450.0,
     "prefill_tps": 50.0,
@@ -559,8 +543,8 @@ int cactus_transcribe(
 ```
 
 - `response`: Full transcription text
-- `segments`: Array of `{"start": float, "end": float, "text": string}` objects with timestamps (seconds). Whisper produces phrase-level segments from timestamp tokens; Parakeet TDT produces word-level segments from native TDT frame timing; Parakeet CTC and Moonshine produce one segment per transcription window (consecutive VAD speech regions grouped up to 30 seconds), with `start`/`end` reflecting the window's boundaries in the source audio.
-- `cloud_handoff`: true when `cloud_handoff_threshold > 0`, the transcribed text is non-empty and longer than 5 characters, and the peak token entropy norm exceeded `cloud_handoff_threshold`
+- `segments`: Always empty for the current native transcription paths
+- `cloud_handoff`: Always false for transcription
 
 **Example (file-based):**
 ```c
@@ -583,38 +567,6 @@ char response[16384];
 int result = cactus_transcribe(whisper, NULL, NULL,
                                 response, sizeof(response), NULL, NULL, NULL,
                                 pcm_data, pcm_size);
-```
-
-**Transcription Options Format:**
-```json
-{
-    "max_tokens": 100,
-    "custom_vocabulary": ["Omeprazole", "HIPAA", "Cactus"],
-    "vocabulary_boost": 3.0
-}
-```
-
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `max_tokens` | int | auto | Maximum tokens to generate. When unset, scales with audio length (`audio_sec × 20` for Whisper, `× 30` for Parakeet), then clamped to the Whisper decoder ceiling of 448. |
-| `custom_vocabulary` | array | [] | List of words or phrases to bias the decoder toward. Useful for proper nouns, acronyms, medical terms, and domain-specific jargon. |
-| `vocabulary_boost` | float | 5.0 | Logit bias strength applied to tokens from `custom_vocabulary`. Clamped to 0.0–20.0. Higher values make the listed words more likely to appear. |
-
-**Note:** Custom vocabulary biasing is supported for Whisper and Moonshine models. Each vocabulary entry is tokenized into sub-tokens and the boost is applied per-token at each decoder step.
-
-**Example (with custom vocabulary):**
-```c
-cactus_model_t whisper = cactus_init("../../weights/whisper-small", NULL, false);
-
-const char* options = "{\"custom_vocabulary\": [\"Omeprazole\", \"HIPAA\", \"Cactus\"], \"vocabulary_boost\": 3.0}";
-
-char response[16384];
-int result = cactus_transcribe(whisper, "medical_notes.wav", NULL,
-                                response, sizeof(response), options, NULL, NULL,
-                                NULL, 0);
-if (result > 0) {
-    printf("Transcription: %s\n", response);
-}
 ```
 
 ### `cactus_embed`

--- a/docs/cactus_graph.md
+++ b/docs/cactus_graph.md
@@ -369,9 +369,10 @@ loaded.execute();
 GraphFile::save_node(graph, node_id, "output.bin");
 ```
 
-#### Loading Graphs
+#### GraphFile Namespace
 ```cpp
-CactusGraph loaded = GraphFile::load_graph("graph.cactus");
+GraphFile::SerializedGraph serialized = GraphFile::load_graph("graph.cactus");
+CactusGraph loaded = CactusGraph::from_serialized(serialized);
 ```
 
 The `GraphFile` namespace currently exposes `save_graph`, `load_graph`, and

--- a/docs/cactus_kernels.md
+++ b/docs/cactus_kernels.md
@@ -441,9 +441,9 @@ cactus-kernels/
     attention.cpp           # attention kernels (FP16)
     attention_hybrid.cpp    # hybrid INT8/FP16 attention
     blas.cpp                # BLAS-backed paths
-    conv.cpp                # conv1d variants
+    conv.cpp                # conv1d variants, STFT
     conv2d.cpp              # conv2d variants
-    dsp.cpp                 # rfft, irfft, mel filter bank, spectrogram, STFT
+    dsp.cpp                 # rfft, irfft, mel filter bank, spectrogram
     fused.cpp               # fused op kernels
     image.cpp               # image load/resize/normalize/patches
     lstm.cpp                # LSTM cell, BiLSTM sequence
@@ -460,10 +460,8 @@ cactus-kernels/
     test_dsp.cpp
     test_elementwise.cpp
     test_matmul.cpp
-    test_performance.cpp    # perf benchmarks (run via `cactus test --suite performance`)
     test_quant.cpp
     test_reduce.cpp
-    android/                # on-device test runner for Android
 ```
 
 ## See Also

--- a/docs/cactus_quants.md
+++ b/docs/cactus_quants.md
@@ -207,7 +207,7 @@ steps entirely: `cactus run <model-id>` will fetch the pre-built bundle (or fall
 back to local convert+transpile if no bundle is published), then run.
 
 The CQ matmul kernels live in `cactus-kernels/src/matmul.cpp`. At inference,
-the kernel applies the inverse Hadamard rotation to the FP16 activation (not the weight),
+the kernel applies a Walsh-Hadamard transform to the FP16 activation (not the weight),
 then performs a fused codebook-lookup + norm-scale + matmul in a single NEON pass.
 
 ## See Also

--- a/docs/cactus_transpiler.md
+++ b/docs/cactus_transpiler.md
@@ -392,7 +392,7 @@ weights/<model>/
   optimized_ir.json        # IR after fusion passes (debugging)
   graph.cactus             # serialized runtime graph
   graph_bindings.json      # weight binding metadata
-  result.json              # execution results (if --execute)
+  result.json              # execution results (if --execute-after-transpile)
   components/              # for multimodal models
     manifest.json          # component order, input/output names
     vision_encoder/
@@ -440,10 +440,9 @@ cactus transpile <model-id-or-path> [options]
 | `--no-fuse-rope` | Disable RoPE fusion |
 | `--no-fuse-attention` | Disable attention fusion |
 
-NPU emission (CoreML `.mlpackage`s for Apple Silicon audio/vision encoders) is
-implemented on the underlying `python -m cactus.transpile.hf_model` script
-(`--npu`, `--npu-quantize`, `--npu-audio-quantize`, `--npu-vision-quantize`)
-but is not yet exposed on the user-facing `cactus transpile` argparser.
+NPU emission (CoreML `.mlpackage`s for Apple Silicon audio and vision encoders)
+is available through the `--npu`, `--npu-quantize`, `--npu-audio-quantize`, and
+`--npu-vision-quantize` flags on `cactus transpile`.
 
 ### `cactus run`
 
@@ -482,11 +481,10 @@ tested adapters for:
 
 | Family | Tasks | Component Split |
 |--------|-------|-----------------|
-| Gemma 3/3n/4 | text, multimodal | yes (vision + audio + LM + decoder) |
+| Gemma 3/4 | text, multimodal | yes (vision + audio + LM + decoder) |
 | Qwen 3/3.5 | text, vision | no |
 | LFM2/2.5 | text, vision | no |
 | Whisper | encoder | no |
-| Moonshine | encoder | no |
 | Parakeet CTC | encoder | no |
 | Parakeet TDT | transcription | yes (encoder + decoder) |
 


### PR DESCRIPTION
Audits the `docs/` reference set against the actual implementation and fixes every claim that had drifted from the code. Each change was traced back to a specific source location, and the code (not the prior docs) was treated as the source of truth throughout.

## What changed

**cactus_engine.md — Transcription**
- `cactus_transcribe` handles Whisper and Parakeet TDT natively; other model types route to `cactus_complete`. Dropped Moonshine from the supported list and the signature comment.
- Removed options that the transcribe path parses but never acts on (`use_vad`, `cloud_handoff_threshold`, `custom_vocabulary`, `vocabulary_boost`) and the sampling params (`temperature`/`top_p`/`top_k`) that do not affect the native Whisper/Parakeet output. The `custom_vocabulary` helpers exist in `utils.h` but are never called, and `vocab_bias_` is never read during sampling.
- `segments` is always empty and `cloud_handoff` is always false for transcription, so the response example and field notes now reflect that. Tightened the `max_tokens` auto-scaling description to match the real `max(100, audio_sec × rate)` floor and the `448 − prompt_tokens` Whisper cap.

**cactus_graph.md**
- `GraphFile::load_graph` returns a `SerializedGraph`, not a `CactusGraph`. The example now loads via `CactusGraph::from_serialized`.

**cactus_kernels.md**
- STFT lives in `conv.cpp`, not `dsp.cpp`.
- Removed the nonexistent `test_performance.cpp` and `android/` entries from the test tree.

**cactus_quants.md**
- The CQ matmul applies a forward Walsh-Hadamard transform to the activation, not an "inverse Hadamard rotation."

**cactus_transpiler.md**
- The `--npu*` flags are exposed on `cactus transpile` now, not just the underlying script.
- The reference-execution flag is `--execute-after-transpile`.
- Removed the Moonshine family row (no transpile adapter) and the Gemma 3n variant (not in the transpiler).

## Verification

Every changed claim was cross-checked against the source twice independently. Findings that turned out to be false (the quickstart C++ snippet arg count and the choose-bindings link paths, which `assemble-docs.sh` rewrites correctly) were left untouched.