### PR TITLE
security: fail-closed cloud TLS verification + safe model-archive extraction

### DIFF
--- a/cactus-engine/src/cloud.cpp
+++ b/cactus-engine/src/cloud.cpp
@@ -200,7 +200,7 @@ static std::string call_cloud_endpoint(const std::string& url,
     curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, std::min<long>(timeout_ms, 2000L));
     curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
 
-    if (!env_flag_enabled("CACTUS_CLOUD_STRICT_SSL")) {
+    if (env_flag_enabled("CACTUS_CLOUD_INSECURE_SSL")) {
         curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
         curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
     } else {

--- a/python/cactus/convert/export/qdq.py
+++ b/python/cactus/convert/export/qdq.py
@@ -140,7 +140,16 @@ def safe_extract_tar(tar_path: Path, out_dir: Path) -> None:
             target = (out_dir / member.name).resolve()
             if os.path.commonpath([str(out_resolved), str(target)]) != str(out_resolved):
                 raise RuntimeError(f"refusing unsafe tar member path: {member.name}")
-        tf.extractall(out_dir)
+            if member.issym() or member.islnk():
+                base = target.parent if member.issym() else out_dir
+                link_target = (base / member.linkname).resolve()
+                if os.path.commonpath([str(out_resolved), str(link_target)]) != str(out_resolved):
+                    raise RuntimeError(f"refusing unsafe tar link target: {member.name} -> {member.linkname}")
+        # filter="data" only exists on Python >=3.10.12/3.11.4/3.12; link targets are validated above for older patches.
+        if hasattr(tarfile, "data_filter"):
+            tf.extractall(out_dir, filter="data")
+        else:
+            tf.extractall(out_dir)
 
 
 def materialize_input(input_path: Path, tmp_dir: Path | None) -> tuple[Path, tempfile.TemporaryDirectory[str] | None]:


### PR DESCRIPTION
cloud.cpp: verify TLS peer/host by default; insecure mode only via explicit CACTUS_CLOUD_INSECURE_SSL=1 opt-out (previously verification was off unless CACTUS_CLOUD_STRICT_SSL was set). qdq.py: reject tar entries that are symlinks/hardlinks or escape the target dir, and use tarfile data filter when available.

Signed-off-by: Noah Cylich <noahcylich@gmail.com>
