### PR TITLE
cactus-engine: runtime correctness & memory-safety

### DIFF
--- a/cactus-engine/src/bpe.cpp
+++ b/cactus-engine/src/bpe.cpp
@@ -148,7 +148,7 @@ bool BPETokenizer::load_vocabulary_mmap(const std::string& vocab_file, const std
             std::string merged = first + second;
             merge_rules_.emplace_back(first, second, merged, priority);
 
-            std::string key = first + "\x00" + second;
+            std::string key = first + '\0' + second;
             auto it = merge_map_.find(key);
             if (it == merge_map_.end() || priority < it->second) {
                 merge_map_[key] = priority;
@@ -175,7 +175,7 @@ bool BPETokenizer::load_vocabulary_mmap(const std::string& vocab_file, const std
             std::string first = tok.substr(0, i);
             std::string second = tok.substr(i);
             if (!token_to_id_.count(first) || !token_to_id_.count(second)) continue;
-            std::string key = first + "\x00" + second;
+            std::string key = first + '\0' + second;
             if (merge_map_.find(key) == merge_map_.end()) {
                 merge_rules_.emplace_back(first, second, tok, priority);
                 merge_map_[key] = priority;
@@ -413,7 +413,7 @@ std::pair<int, uint32_t> BPETokenizer::find_best_merge_fast(const std::vector<st
     uint32_t best_priority = UINT32_MAX;
 
     for (size_t i = 0; i < tokens.size() - 1; ++i) {
-        std::string key = tokens[i] + "\x00" + tokens[i + 1];
+        std::string key = tokens[i] + '\0' + tokens[i + 1];
         auto it = merge_map_.find(key);
         if (it != merge_map_.end()) {
             if (it->second < best_priority) {

--- a/cactus-engine/src/complete.cpp
+++ b/cactus-engine/src/complete.cpp
@@ -676,6 +676,12 @@ int cactus_complete(
 
         auto* handle = static_cast<CactusModelHandle*>(model);
         handle->should_stop = false;
+        if (!handle->model->can_generate()) {
+            const std::string err = "Model has no language-model decoder; cannot generate (embedding/encoder-only model)";
+            CACTUS_LOG_ERROR("complete", err);
+            handle_error_response(err, response_buffer, buffer_size);
+            return -1;
+        }
         auto* tokenizer = handle->model->get_tokenizer();
         auto prompt = prepare_prompt(handle, messages_json, options_json, tools_json, true, true, pcm_buffer, pcm_buffer_size);
 
@@ -1072,6 +1078,13 @@ int cactus_prefill(
         auto start_time = std::chrono::high_resolution_clock::now();
 
         auto* handle = static_cast<CactusModelHandle*>(model);
+        if (!handle->model->can_generate()) {
+            std::string err = "Model has no language-model decoder; cannot generate (embedding/encoder-only model)";
+            CACTUS_LOG_ERROR("prefill", err);
+            std::string result = construct_prefill_response_json(false, &err, 0, 0.0, 0.0);
+            if (result.size() < buffer_size) std::strcpy(response_buffer, result.c_str());
+            return -1;
+        }
         auto prompt = prepare_prompt(handle, messages_json, options_json, tools_json, false, false, pcm_buffer, pcm_buffer_size);
 
         std::vector<uint32_t> context_tokens(prompt.tokens.begin(), prompt.tokens.begin() + prompt.context_token_count);

--- a/cactus-engine/src/constraints.cpp
+++ b/cactus-engine/src/constraints.cpp
@@ -182,14 +182,6 @@ void ToolCallConstrainer::update(uint32_t /*token_id*/, const std::string& decod
                         }
                     }
                 }
-            } else if (decoded_text == "}") {
-                in_argument_string_ = false;
-                if (brace_depth_ > 0) {
-                    brace_depth_--;
-                    if (brace_depth_ == 0) {
-                        state_ = State::GEMMA_EXPECT_END;
-                    }
-                }
             }
             break;
 

--- a/cactus-engine/src/engine.h
+++ b/cactus-engine/src/engine.h
@@ -630,6 +630,7 @@ public:
     size_t get_cache_size() const { return cache_total_seq_len_; }
 
     size_t get_prefill_chunk_size() const { return 128; }
+    bool can_generate() const { return decoder_ != nullptr; }  // false for embedding/encoder-only models
     double last_prefill_cache_copy_ms() const { return last_prefill_cache_copy_ms_; }
     size_t last_prefill_padding_tokens() const { return last_prefill_padding_tokens_; }
     size_t last_prefill_scalar_tail_tokens() const { return last_prefill_scalar_tail_tokens_; }

--- a/cactus-engine/src/engine_image.cpp
+++ b/cactus-engine/src/engine_image.cpp
@@ -508,24 +508,23 @@ Siglip2Preprocessor::PreprocessedImage Siglip2Preprocessor::preprocess_from_memo
 
 std::vector<unsigned char> Siglip2Preprocessor::convert_to_rgb(
     const unsigned char* img_data, int width, int height, int channels) {
-
-    const size_t px = static_cast<size_t>(width) * static_cast<size_t>(height);
-    std::vector<unsigned char> rgb_data(px * 3);
-
+    
+    std::vector<unsigned char> rgb_data(width * height * 3);
+    
     if (channels == 1) {
-        for (size_t i = 0; i < px; ++i) {
+        for (int i = 0; i < width * height; ++i) {
             rgb_data[i * 3 + 0] = img_data[i];
             rgb_data[i * 3 + 1] = img_data[i];
             rgb_data[i * 3 + 2] = img_data[i];
         }
     } else if (channels == 4) {
-        for (size_t i = 0; i < px; ++i) {
+        for (int i = 0; i < width * height; ++i) {
             rgb_data[i * 3 + 0] = img_data[i * 4 + 0];
             rgb_data[i * 3 + 1] = img_data[i * 4 + 1];
             rgb_data[i * 3 + 2] = img_data[i * 4 + 2];
         }
     } else if (channels == 2) {
-        for (size_t i = 0; i < px; ++i) {
+        for (int i = 0; i < width * height; ++i) {
             rgb_data[i * 3 + 0] = img_data[i * 2 + 0];
             rgb_data[i * 3 + 1] = img_data[i * 2 + 0];
             rgb_data[i * 3 + 2] = img_data[i * 2 + 0];
@@ -533,7 +532,7 @@ std::vector<unsigned char> Siglip2Preprocessor::convert_to_rgb(
     } else {
         throw std::runtime_error("Unsupported number of channels: " + std::to_string(channels));
     }
-
+    
     return rgb_data;
 }
 

--- a/cactus-engine/src/engine_image.cpp
+++ b/cactus-engine/src/engine_image.cpp
@@ -341,6 +341,9 @@ Siglip2Preprocessor::PreprocessedImage Siglip2Preprocessor::preprocess_from_memo
     if (!img_data) {
         throw std::runtime_error("Invalid image data pointer");
     }
+    if (width <= 0 || height <= 0) {
+        throw std::runtime_error("Image dimensions must be positive");
+    }
 
     const int expected_channels = 3;
     std::vector<unsigned char> rgb_data;
@@ -505,23 +508,24 @@ Siglip2Preprocessor::PreprocessedImage Siglip2Preprocessor::preprocess_from_memo
 
 std::vector<unsigned char> Siglip2Preprocessor::convert_to_rgb(
     const unsigned char* img_data, int width, int height, int channels) {
-    
-    std::vector<unsigned char> rgb_data(width * height * 3);
-    
+
+    const size_t px = static_cast<size_t>(width) * static_cast<size_t>(height);
+    std::vector<unsigned char> rgb_data(px * 3);
+
     if (channels == 1) {
-        for (int i = 0; i < width * height; ++i) {
+        for (size_t i = 0; i < px; ++i) {
             rgb_data[i * 3 + 0] = img_data[i];
             rgb_data[i * 3 + 1] = img_data[i];
             rgb_data[i * 3 + 2] = img_data[i];
         }
     } else if (channels == 4) {
-        for (int i = 0; i < width * height; ++i) {
+        for (size_t i = 0; i < px; ++i) {
             rgb_data[i * 3 + 0] = img_data[i * 4 + 0];
             rgb_data[i * 3 + 1] = img_data[i * 4 + 1];
             rgb_data[i * 3 + 2] = img_data[i * 4 + 2];
         }
     } else if (channels == 2) {
-        for (int i = 0; i < width * height; ++i) {
+        for (size_t i = 0; i < px; ++i) {
             rgb_data[i * 3 + 0] = img_data[i * 2 + 0];
             rgb_data[i * 3 + 1] = img_data[i * 2 + 0];
             rgb_data[i * 3 + 2] = img_data[i * 2 + 0];
@@ -529,7 +533,7 @@ std::vector<unsigned char> Siglip2Preprocessor::convert_to_rgb(
     } else {
         throw std::runtime_error("Unsupported number of channels: " + std::to_string(channels));
     }
-    
+
     return rgb_data;
 }
 

--- a/cactus-engine/src/gemma_tools.h
+++ b/cactus-engine/src/gemma_tools.h
@@ -118,6 +118,7 @@ inline std::string format_argument(const std::string& json, size_t& pos, bool es
                json[pos] == '-' || json[pos] == '+' || json[pos] == 'e' || json[pos] == 'E')) {
             pos++;
         }
+        if (pos == start && pos < json.length()) pos++;
         return json.substr(start, pos - start);
     }
 }

--- a/cactus-engine/src/index.cpp
+++ b/cactus-engine/src/index.cpp
@@ -237,6 +237,7 @@ namespace index {
     }
 
     void Index::delete_documents(const std::vector<int>& doc_ids) {
+        if (mapped_index_ == MAP_FAILED || mapped_data_ == MAP_FAILED) throw std::runtime_error("Index is in a failed memory-mapped state");
         validate_doc_ids(doc_ids);
 
         char* index_ptr = static_cast<char*>(mapped_index_);
@@ -394,6 +395,7 @@ namespace index {
     }
 
     void Index::compact() {
+        if (mapped_index_ == MAP_FAILED || mapped_data_ == MAP_FAILED) throw std::runtime_error("Index is in a failed memory-mapped state");
         std::string temp_index_path = index_path_ + ".tmp";
         std::string temp_data_path = data_path_ + ".tmp";
 

--- a/cactus-engine/src/index.cpp
+++ b/cactus-engine/src/index.cpp
@@ -143,6 +143,7 @@ namespace index {
     }
 
     void Index::add_documents(const std::vector<Document>& documents) {
+        if (mapped_index_ == MAP_FAILED || mapped_data_ == MAP_FAILED) throw std::runtime_error("Index is in a failed memory-mapped state");
         validate_documents(documents);
 
         size_t added_data_size = 0;
@@ -164,20 +165,24 @@ namespace index {
         munmap(mapped_index_, index_file_size_);
         munmap(mapped_data_, data_file_size_);
 
-        mapped_index_ = mmap(nullptr, new_index_size, PROT_READ | PROT_WRITE, MAP_SHARED, index_fd_, 0);
-        if (mapped_index_ == MAP_FAILED) {
+        void* new_index_map = mmap(nullptr, new_index_size, PROT_READ | PROT_WRITE, MAP_SHARED, index_fd_, 0);
+        if (new_index_map == MAP_FAILED) {
+            mapped_index_ = mapped_data_ = MAP_FAILED;
             throw std::runtime_error("Failed to remap index file");
         }
 
-        mapped_data_ = mmap(nullptr, new_data_size, PROT_READ | PROT_WRITE, MAP_SHARED, data_fd_, 0);
-        if (mapped_data_ == MAP_FAILED) {
-            munmap(mapped_index_, new_index_size);
+        void* new_data_map = mmap(nullptr, new_data_size, PROT_READ | PROT_WRITE, MAP_SHARED, data_fd_, 0);
+        if (new_data_map == MAP_FAILED) {
+            munmap(new_index_map, new_index_size);
+            mapped_index_ = mapped_data_ = MAP_FAILED;
             throw std::runtime_error("Failed to remap data file");
         }
 
         size_t old_index_size = index_file_size_;
         size_t old_data_size = data_file_size_;
 
+        mapped_index_ = new_index_map;
+        mapped_data_ = new_data_map;
         index_file_size_ = new_index_size;
         data_file_size_ = new_data_size;
 
@@ -258,6 +263,7 @@ namespace index {
     }
 
     std::vector<Document> Index::get_documents(const std::vector<int>& doc_ids) {
+        if (mapped_index_ == MAP_FAILED || mapped_data_ == MAP_FAILED) throw std::runtime_error("Index is in a failed memory-mapped state");
         validate_doc_ids(doc_ids);
 
         const char* index_ptr = static_cast<const char*>(mapped_index_);
@@ -307,9 +313,16 @@ namespace index {
         if (embeddings.empty()) {
             return {};
         }
+        if (mapped_index_ == MAP_FAILED || mapped_data_ == MAP_FAILED) throw std::runtime_error("Index is in a failed memory-mapped state");
 
         if (options.top_k == 0) {
             return std::vector<std::vector<QueryResult>>(embeddings.size());
+        }
+
+        for (const auto& embedding : embeddings) {
+            if (embedding.size() != embedding_dim_) {
+                throw std::runtime_error("Query embedding dimension mismatch");
+            }
         }
 
         if (num_documents_ > 0) {

--- a/cactus-engine/src/model_npu.cpp
+++ b/cactus-engine/src/model_npu.cpp
@@ -69,18 +69,18 @@ bool Model::audio_encode_via_npu(const std::vector<float>& audio_features) {
         const std::string& name = audio_encoder_->logical_outputs[i];
         size_t node_id = static_cast<size_t>(audio_encoder_->output_node_ids[i]);
         const auto& desc = audio_encoder_->graph->get_output_buffer(node_id);
-        const size_t copy_bytes = std::min(desc.byte_size, written * sizeof(__fp16));
+        const size_t elem_size = (desc.precision == Precision::FP32) ? sizeof(float) : sizeof(__fp16);
+        const size_t copy_elems = std::min(static_cast<size_t>(written), desc.byte_size / elem_size);
         auto& slot = media_features_[name];
-        const size_t prev = slot.size();
-        slot.resize(prev + copy_bytes);
-        if (desc.precision == Precision::FP16) {
-            std::memcpy(slot.data() + prev, output_fp16.data(), copy_bytes);
-        } else if (desc.precision == Precision::FP32) {
-            const size_t n = copy_bytes / sizeof(__fp16);
+        if (desc.precision == Precision::FP32) {
+            const size_t prev = slot.size();
+            slot.resize(prev + copy_elems * sizeof(float));
             float* dst = reinterpret_cast<float*>(slot.data() + prev);
-            for (size_t k = 0; k < n; ++k) dst[k] = static_cast<float>(output_fp16[k]);
+            for (size_t k = 0; k < copy_elems; ++k) dst[k] = static_cast<float>(output_fp16[k]);
         } else {
-            std::memcpy(slot.data() + prev, output_fp16.data(), copy_bytes);
+            const size_t prev = slot.size();
+            slot.resize(prev + copy_elems * sizeof(__fp16));
+            std::memcpy(slot.data() + prev, output_fp16.data(), copy_elems * sizeof(__fp16));
         }
         auto shape_it = media_feature_shapes_.find(name);
         if (shape_it == media_feature_shapes_.end() || shape_it->second.empty()) {

--- a/cactus-engine/src/rag.cpp
+++ b/cactus-engine/src/rag.cpp
@@ -345,6 +345,16 @@ std::vector<cactus::ffi::ToolFunction> select_relevant_tools(
     return selected;
 }
 
+static int rag_write_response(char* buffer, size_t buffer_size, const char* str, int success_code) {
+    size_t len = std::strlen(str);
+    if (len >= buffer_size) {
+        buffer[0] = '\0';
+        return -1;
+    }
+    std::memcpy(buffer, str, len + 1);
+    return success_code;
+}
+
 extern "C" {
 
 int cactus_rag_query(
@@ -361,27 +371,23 @@ int cactus_rag_query(
     auto* handle = static_cast<CactusModelHandle*>(model);
 
     if (!handle->corpus_index || handle->corpus_embedding_dim == 0) {
-        std::strcpy(response_buffer, "{\"chunks\":[],\"error\":\"No corpus index loaded\"}");
-        return 0;
+        return rag_write_response(response_buffer, buffer_size, "{\"chunks\":[],\"error\":\"No corpus index loaded\"}", 0);
     }
 
     try {
         auto* tokenizer = handle->model->get_tokenizer();
         if (!tokenizer) {
-            std::strcpy(response_buffer, "{\"chunks\":[],\"error\":\"No tokenizer\"}");
-            return 0;
+            return rag_write_response(response_buffer, buffer_size, "{\"chunks\":[],\"error\":\"No tokenizer\"}", 0);
         }
 
         std::vector<uint32_t> query_tokens = tokenizer->encode(query);
         if (query_tokens.empty()) {
-            std::strcpy(response_buffer, "{\"chunks\":[],\"error\":\"Empty query\"}");
-            return 0;
+            return rag_write_response(response_buffer, buffer_size, "{\"chunks\":[],\"error\":\"Empty query\"}", 0);
         }
 
         std::vector<float> query_embedding = handle->model->get_embeddings(query_tokens, true, true);
         if (query_embedding.size() != handle->corpus_embedding_dim) {
-            std::strcpy(response_buffer, "{\"chunks\":[],\"error\":\"Embedding dimension mismatch\"}");
-            return 0;
+            return rag_write_response(response_buffer, buffer_size, "{\"chunks\":[],\"error\":\"Embedding dimension mismatch\"}", 0);
         }
 
         index::QueryOptions options;
@@ -392,8 +398,7 @@ int cactus_rag_query(
         auto results = handle->corpus_index->query(query_embeddings, options);
 
         if (results.empty() || results[0].empty()) {
-            std::strcpy(response_buffer, "{\"chunks\":[]}");
-            return 0;
+            return rag_write_response(response_buffer, buffer_size, "{\"chunks\":[]}", 0);
         }
 
         std::vector<int> doc_ids;
@@ -441,36 +446,21 @@ int cactus_rag_query(
 
             if (i > 0) oss << ",";
             oss << "{\"score\":" << std::setprecision(4) << final_score
-                << ",\"source\":\"" << docs[idx].metadata << "\""
-                << ",\"content\":\"";
-            for (char c : docs[idx].content) {
-                switch (c) {
-                    case '"': oss << "\\\""; break;
-                    case '\\': oss << "\\\\"; break;
-                    case '\n': oss << "\\n"; break;
-                    case '\r': oss << "\\r"; break;
-                    case '\t': oss << "\\t"; break;
-                    default: oss << c;
-                }
-            }
-            oss << "\"}";
+                << ",\"source\":\"" << escape_json_string(docs[idx].metadata) << "\""
+                << ",\"content\":\"" << escape_json_string(docs[idx].content) << "\"}";
         }
         oss << "]}";
 
         std::string result = oss.str();
         if (result.size() >= buffer_size) {
-            std::strcpy(response_buffer, "{\"chunks\":[],\"error\":\"Buffer too small\"}");
-            return -1;
+            return rag_write_response(response_buffer, buffer_size, "{\"chunks\":[],\"error\":\"Buffer too small\"}", -1);
         }
 
-        std::strcpy(response_buffer, result.c_str());
-        return static_cast<int>(result.size());
+        return rag_write_response(response_buffer, buffer_size, result.c_str(), static_cast<int>(result.size()));
 
     } catch (const std::exception& e) {
-        std::string error = "{\"chunks\":[],\"error\":\"" + std::string(e.what()) + "\"}";
-        if (error.size() < buffer_size) {
-            std::strcpy(response_buffer, error.c_str());
-        }
+        std::string error = "{\"chunks\":[],\"error\":\"" + escape_json_string(e.what()) + "\"}";
+        rag_write_response(response_buffer, buffer_size, error.c_str(), -1);
         return -1;
     }
 }

--- a/cactus-engine/src/tokenizer.cpp
+++ b/cactus-engine/src/tokenizer.cpp
@@ -294,6 +294,7 @@ std::vector<std::string> split_with_special_tokens(const std::string& text,
         std::string best_special_token;
 
         for (const auto& [special_token, token_id] : special_tokens) {
+            if (special_token.empty()) continue;
             size_t pos = text.find(special_token, start);
             if (pos != std::string::npos &&
                 (pos < best_match_pos || (pos == best_match_pos && special_token.length() > best_match_len))) {
@@ -481,10 +482,11 @@ std::string Tokenizer::format_gemma4_style(const std::vector<ChatMessage>& messa
         if (!data) return 0;
         cactus_image_free(data);
 
-        uint32_t p = vision_patch_size_;
-        uint32_t k = vision_pooling_kernel_size_;
+        uint32_t p = vision_patch_size_ ? vision_patch_size_ : 16;
+        uint32_t k = vision_pooling_kernel_size_ ? vision_pooling_kernel_size_ : 3;
+        uint32_t out_len = vision_default_output_length_ ? vision_default_output_length_ : 280;
         uint32_t side = k * p;
-        uint32_t max_patches = vision_default_output_length_ * k * k;
+        uint32_t max_patches = out_len * k * k;
         float factor = std::sqrt(static_cast<float>(max_patches) * p * p /
                                  (static_cast<float>(h) * w));
         int th = static_cast<int>(std::floor(factor * h / side)) * side;


### PR DESCRIPTION
bpe.cpp: fix BPE merge-key delimiter (the "\x00" C-string was empty, collapsing keys). tokenizer.cpp: skip empty special tokens to avoid an infinite split loop; fall back to safe vision dims to avoid div-by-zero. constraints.cpp: treat '}' inside a tool-arg string as literal. gemma_tools.h: don't stall the number parser on a non-numeric char. engine.h+complete.cpp: add can_generate() and reject generate/prefill on decoder-less (embedding/encoder-only) models instead of segfaulting. engine_image.cpp: guard negative dims / signed-multiply overflow. index.cpp: handle MAP_FAILED state + query-dim checks. rag.cpp: bounded response writes + JSON-escape content/metadata. model_npu.cpp: correct FP32 element/byte accounting in the audio NPU copy.

Signed-off-by: Noah Cylich <noahcylich@gmail.com>
