### PR TITLE
transpiler: JAX attention causality + reduction precision, attention-output layout guard

### DIFF
--- a/python/cactus/transpile/jax_semantic_rewrites.py
+++ b/python/cactus/transpile/jax_semantic_rewrites.py
@@ -685,7 +685,9 @@ def _rewrite_jax_prefill_attentions(graph: IRGraph) -> None:
         node = graph.nodes[node_id]
         if node.op not in {"permute", "view", "reshape"}:
             continue
-        is_decoder_step = str(graph.meta.get("component", "") or "").lower() == "decoder_step"
+        component = str(graph.meta.get("component", "") or "").strip().lower()
+        is_decoder_step = component == "decoder_step"
+        is_causal_prefill = component in {"decoder_prefill_chunk", "decoder_media_step"}
         if node.op == "permute" and tuple(int(dim) for dim in node.attrs.get("permutation", ())) != (0, 2, 1, 3):
             continue
         if node.op in {"view", "reshape"} and not is_decoder_step:
@@ -733,7 +735,7 @@ def _rewrite_jax_prefill_attentions(graph: IRGraph) -> None:
             additive_mask=additive_mask,
             scale=scale,
             output_layout="bthd",
-            is_causal=mask_id is None and is_self_attention,
+            is_causal=is_causal_prefill and mask_id is None and is_self_attention,
             rewritten_from="jax_prefill_attention",
         )
 
@@ -787,7 +789,7 @@ def _legalize_remaining_jax_reductions(graph: IRGraph) -> None:
     new_order: list[str] = []
     for node_id in list(graph.order):
         node = graph.nodes[node_id]
-        if node.op not in {"sum", "mean", "min", "max"} or len(node.inputs) != 1 or len(node.outputs) != 1:
+        if node.op not in {"sum", "mean"} or len(node.inputs) != 1 or len(node.outputs) != 1:
             new_order.append(node_id)
             continue
         input_value = graph.values.get(node.inputs[0])

--- a/python/cactus/transpile/optimize_graph.py
+++ b/python/cactus/transpile/optimize_graph.py
@@ -669,7 +669,7 @@ def normalize_attention_layouts(graph: IRGraph) -> bool:
         output_id = node.outputs[0]
         output_value = graph.values.get(output_id)
         output_users = list(output_value.users) if output_value is not None else []
-        if len(output_users) != 1:
+        if len(output_users) != 1 or output_id in graph.outputs:
             continue
         output_user = graph.nodes.get(output_users[0])
         if output_user is None or output_user.op != "permute" or len(output_user.inputs) != 1 or len(output_user.outputs) != 1:


### PR DESCRIPTION
Three transpiler correctness fixes, each reached and validated with a runnable repro on the real capture/transpile pipeline (this branch vs `origin/main`). Final state: **2 files, 4 lines.**

### Contributions (validated)

**1. JAX prefill `is_causal` gating** (`jax_semantic_rewrites.py`)
A maskless self-attention is treated as causal only when the component is a known causal-prefill (`decoder_prefill_chunk` / `decoder_media_step`). Previously *any* maskless self-attention was forced causal, so bidirectional/encoder self-attention captured via JAX was silently causal-masked.
*Validated:* a maskless JAX self-attention (no component set) transpiled to output matching the **causal** reference and differing from true full attention by ~0.27; with the gate it matches full attention (FP16 noise).

**2. JAX `min`/`max` kept in native FP32** (`jax_semantic_rewrites.py`)
`min`/`max` are no longer legalized through FP16 (cast→reduce→cast). FP16 saturates at ±65504, so attention-mask sentinels (`-1e4`, `finfo.min`) and large logits overflow and corrupt exact min/max selection. `sum`/`mean` still legalize to FP16 (averaging at the engine working precision). Also `.strip()` the component-meta string.
*Validated:* a `min`/`max` node on FP32 gets 0 precision-casts on this branch vs 2 (forced FP16) before; `sum` still gets the FP16 pair.

**3. Attention-output layout guard** (`optimize_graph.py`)
`normalize_attention_layouts` no longer folds an attention's output permute into the op when that attention output is itself a graph output — folding left `graph.outputs` referencing a value no longer produced by any node (a dangling output). Reachable for models that return a raw attention tensor (encoders / feature extractors).
*Validated:* with the guard the graph output is preserved; without it, the output value is folded away and dangling.

### Excluded after validation
The original `fuse_attention` mask-input preservation was **dropped** — proven unreachable and, where its path is reachable, cosmetic:
- `fuse_attention` runs post-canonicalization (op always `attention`) and `match_attention` sets q/k/v = `inputs[0:3]`, so a non-window masked node is always idempotent. Instrumenting the mask-preserving branch across the full test suite + repros gave **0 hits**.
- The only masked-node rewrite is **sliding-window**, where both origin and this branch correctly drop the mask input (the window is carried by `window_size`); the sole difference was a leftover `additive_mask=True` attr on origin. Kernel test (`window_size=2`, no mask, `additive_mask` True vs absent) → **identical output (0.0 diff)**, since with no mask tensor the flag has nothing to apply to.

A correct guard would be >3 lines for no observable gain, so it was removed rather than kept as dead code.

### Verification
`pytest python/tests` + `pytest python/cactus/convert/tests` → **264 passed, 1 skipped** (JAX capture tests included).