### PR TITLE
Fix onboarding quickstart bugs and guard destructive `cactus clean`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ A low-latency AI engine for mobile devices & wearables.
 ## Quick Demo (Mac)
 
 - Step 1: `brew install cactus-compute/cactus/cactus`
-- Step 2: `cactus transcribe` or `cactus run` 
+- Step 2: `cactus run`
 
 ## Cactus Engine
 
@@ -230,7 +230,7 @@ cactus build               # default static lib
 ┌────────────────────────────────────────────────────────────────────────────────┐
 │                                                                                │
 │ Step 0: if on Linux (Ubuntu/Debian)                                            │
-│ sudo apt-get install python3 python3-venv python3-pip cmake                    │
+│ sudo apt-get install python3.12 python3.12-venv python3-pip cmake              │
 │   build-essential libcurl4-openssl-dev                                         │
 │                                                                                │
 │ Step 1: clone and setup                                                        │

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -62,7 +62,7 @@ Install Cactus and run your first on-device AI completion.
     **From Source (Linux):**
 
     ```bash
-    sudo apt-get install python3 python3-venv python3-pip cmake build-essential libcurl4-openssl-dev
+    sudo apt-get install python3.12 python3.12-venv python3-pip cmake build-essential libcurl4-openssl-dev
     git clone https://github.com/cactus-compute/cactus && cd cactus && source ./setup && cactus build --python
     ```
 

--- a/python/cactus/cli/__init__.py
+++ b/python/cactus/cli/__init__.py
@@ -174,7 +174,7 @@ def create_parser():
     --android                          run on connected Android
     --enable-telemetry                 send cloud telemetry (off by default)
 
-  cactus clean                         delete build artifacts
+  cactus clean                         delete build artifacts, weights, venv
   cactus --help                        show this help
 
   -----------------------------------------------------------------
@@ -297,7 +297,8 @@ def create_parser():
     auth_parser.add_argument("--status", action="store_true",
                              help="Show current key status")
 
-    subparsers.add_parser("clean", help="Delete build artifacts")
+    clean_parser = subparsers.add_parser("clean", help="Delete build artifacts, downloaded weights, and venv")
+    clean_parser.add_argument("--yes", "-y", action="store_true", help="Skip confirmation prompt")
 
     subparsers.add_parser("list", help="List local converted weights and bundles")
 

--- a/python/cactus/cli/clean.py
+++ b/python/cactus/cli/clean.py
@@ -1,11 +1,12 @@
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 from .common import (
     PROJECT_ROOT,
     print_color,
-    GREEN, YELLOW, BLUE,
+    RED, GREEN, YELLOW, BLUE,
 )
 
 
@@ -14,6 +15,24 @@ def cmd_clean(args):
     print_color(BLUE, "Cleaning all build artifacts from Cactus project...")
     print(f"Project root: {PROJECT_ROOT}")
     print()
+
+    destructive_targets = [
+        PROJECT_ROOT / "weights",
+        PROJECT_ROOT / "transpiled",
+        PROJECT_ROOT / "venv",
+    ]
+    present = [t for t in destructive_targets if t.exists()]
+    if present and not args.yes:
+        print_color(YELLOW, "This also deletes the following (not just build artifacts):")
+        for t in present:
+            print(f"  - {t}")
+        print_color(YELLOW, "Downloaded weights are NOT re-fetched by setup and will be lost.")
+        if not sys.stdin.isatty():
+            print_color(RED, "Refusing to proceed without confirmation. Re-run with --yes to skip this prompt.")
+            return 0
+        if input("Continue? [y/N]: ").strip().lower() not in ("y", "yes"):
+            print_color(YELLOW, "Aborted.")
+            return 0
 
     def remove_if_exists(path):
         if path.is_dir():
@@ -110,7 +129,7 @@ def cmd_clean(args):
 
     print()
     print_color(GREEN, "Clean complete!")
-    print("All build artifacts have been removed.")
+    print("All build artifacts, weights, and venv have been removed.")
     print()
 
     print_color(BLUE, "Re-running setup...")


### PR DESCRIPTION
Three low-lift fixes from a repo cleanliness pass. No C++ touched; Python + docs only.

## Changes
**1. README quick demo no longer leads with a broken command.**
`cactus transcribe` requires `--file` (`required=True`), so the bare command in the Mac quick demo errored immediately. Dropped it; kept the working `cactus run`.

**2. Linux install docs match `setup`'s Python requirement.**
`setup` hard-requires `python3.12`, but README (Step 0) and `docs/quickstart.md` told users to `apt-get install python3 python3-venv`, so `source ./setup` dead-ended with "python3.12 is not installed". Both now install `python3.12`/`python3.12-venv`. (README ASCII box re-padded to stay aligned.)

**3. `cactus clean` no longer silently deletes weights + venv.**
`cmd_clean` removes `weights/`, `transpiled/`, and `venv/`, but both help strings said only "delete build artifacts", with no confirmation. Downloaded weights are **not** re-fetched by `setup`, so this was permanent data loss.
- Help now states it removes weights + venv.
- Added `--yes`/`-y` to skip the prompt.
- Before deleting, it lists the non-rebuildable targets and prompts `[y/N]`; on non-interactive stdin it **refuses** unless `--yes` is passed.

## Testing
Targeted verification (the engine `cactus test` suite is C++-only and doesn't exercise CLI/docs):
- `cactus --help` / `cactus clean --help` show the updated text and `--yes/-y`.
- All three guard paths exercised with `rmtree`/`unlink` tripwires proving zero deletions: non-TTY refuse, interactive `n` abort (rc=0), `--yes` bypass.
- `weights/` + `venv/` inodes and child counts identical before/after a guard run; repo integrity confirmed (only 4 files changed, no deletions).