### PR TITLE
convert: fold gemma4 audio projection scaling into the weight reparam

### DIFF
--- a/python/cactus/convert/cactus_adapters/tensor_io.py
+++ b/python/cactus/convert/cactus_adapters/tensor_io.py
@@ -292,7 +292,7 @@ def save_tensor_with_header(tensor, output_path, precision='INT8', transpose=Fal
             data = data * GEMMA4_WEIGHT_SCALE
         elif 'router_scale' in filename:
             data = data / GEMMA4_WEIGHT_SCALE
-        elif filename in ('token_embeddings.weights', 'output_weight.weights', 'embed_vision_embedding.weights', 'embed_vision_proj.weights'):
+        elif filename in ('token_embeddings.weights', 'output_weight.weights', 'embed_vision_embedding.weights', 'embed_vision_proj.weights', 'embed_audio_proj.weights'):
             data = data / GEMMA4_WEIGHT_SCALE
         elif filename == 'output_norm.weights':
             data = data * GEMMA4_WEIGHT_SCALE

--- a/python/cactus/convert/cactus_adapters/tensor_io.py
+++ b/python/cactus/convert/cactus_adapters/tensor_io.py
@@ -292,7 +292,7 @@ def save_tensor_with_header(tensor, output_path, precision='INT8', transpose=Fal
             data = data * GEMMA4_WEIGHT_SCALE
         elif 'router_scale' in filename:
             data = data / GEMMA4_WEIGHT_SCALE
-        elif filename in ('token_embeddings.weights', 'output_weight.weights', 'embed_vision_embedding.weights', 'embed_vision_proj.weights', 'embed_audio_proj.weights'):
+        elif filename in ('token_embeddings.weights', 'output_weight.weights', 'embed_vision_proj.weights', 'embed_audio_proj.weights'):
             data = data / GEMMA4_WEIGHT_SCALE
         elif filename == 'output_norm.weights':
             data = data * GEMMA4_WEIGHT_SCALE

--- a/python/cactus/convert/model_adapters/naming.py
+++ b/python/cactus/convert/model_adapters/naming.py
@@ -23,7 +23,6 @@ GEMMA4_MULT_BASENAMES = {"ffn_gate", "ffn_up", "per_layer_gate", "moe_gate_proj"
 GEMMA4_DIV_BASENAMES = {
     "token_embeddings",
     "output_weight",
-    "embed_vision_embedding",
 }
 
 

--- a/python/cactus/transpile/model_adapters.py
+++ b/python/cactus/transpile/model_adapters.py
@@ -1094,10 +1094,6 @@ def _gemma4_compute_native_like_audio_features(
     if not callable(getattr(embed_audio, "forward", None)):
         raise TypeError("Gemma4 audio embedder is not callable")
     projected = embed_audio(inputs_embeds=audio_encodings)
-    # Native Cactus Gemma4 scales audio soft tokens before merging them into
-    # the language stream. HF leaves this implicit in its fp16 path, but the
-    # quantized Cactus decoder expects the native-scaled representation.
-    projected = projected * (1.0 / 16.0)
     # The transpiled bundle is shape-specialized from representative media.
     # Native Gemma4 audio preprocessing emits an unpadded feature tensor for
     # that media, so the post-subsampling sequence is already the real token


### PR DESCRIPTION
## Summary

The gemma4 audio soft-token `1/16` scaling was applied at runtime in the transpile graph (`_gemma4_compute_native_like_audio_features`), while the equivalent vision projection scaling is applied at conversion time via the weight reparameterization. This split meant the same conceptual operation lived in two different stages depending on modality.

This change consolidates both into the conversion-time weight reparam:
- `embed_audio_proj.weights` is added to the gemma4 `÷16` set in `tensor_io.py`.
- The runtime `projected = projected * (1.0 / 16.0)` is removed from the audio path in `model_adapters.py`.

## Why this is equivalent

The gemma4 audio embedder projection (`embedding_projection`) is a bias-free `nn.Linear` preceded by a scale-less pre-norm, with the post-projection norm removed in gemma4. Because the projection is the last operation and has no bias, scaling its weight by `1/16` is mathematically identical to scaling its output by `1/16`. Audio now follows the exact pattern vision already uses.

## Verification

Reconverted and retranspiled gemma-4-e2b, then ran E2E:
- Audio: `test.wav` transcribes cleanly ("Hello hello hello quickly testing out getting a way file through voice memos").
- Vision: identifies the monkey image correctly ("Monkey", 93.4% confidence).