### PR TITLE
benchmarks: Mac M4 Pro and Galaxy S26 README numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,11 +132,11 @@ graph.hard_reset();
 
 | Device | Gemma4 Text | Gemma4 Vision | Parakeet 1.1B | RAM |
 |--------|----------|------------|---------------|-----|
-| Mac M4 Pro | - | - | - | - |
+| Mac M4 Pro | 324 / 39 | 1.2s / 48 | 1.2s (CPU) | 1385 MB |
 | iPad/Mac M3 | - | - | - | - |
 | iPhone 17 Pro | - | - | - | - |
 | iPhone 13 Mini | - | - | - | - |
-| Galaxy S26 | - | - | - | - |
+| Galaxy S26 | 248 / 21 | 17s / 16 | 4.2s | 4024 MB |
 | Pixel 10 Pro | - | - | - | - |
 | Pixel 6a | - | - | - | - |
 | Galaxy A17 5G | - | - | - | - |


### PR DESCRIPTION
## Summary

Fills the README benchmark table for the two devices measured so far — **Mac M4 Pro** and **Galaxy S26**. README-only change; numbers come from the existing `cactus test` engine suites (no new tooling).

| Device | Gemma4 Text (pf/dec tps) | Gemma4 Vision (lat/dec) | Parakeet (lat) | RAM |
|---|---|---|---|---|
| Mac M4 Pro | 324 / 39 | 1.2s / 48 (NPU) | 1.2s | 1385 MB |
| Galaxy S26 | 248 / 21 | 17s / 16 | 4.2s | 4024 MB |

## How the numbers were produced

All via existing suites on CQ4 bundles (`cactus download` apple bundle on Mac for the NPU vision encoder):

```
cactus test --component engine --suite llm --model google/gemma-4-E2B-it   # Gemma4 Text (test_1k_context: ~1k prefill / 100 decode)
cactus test --component engine --suite vlm --model google/gemma-4-E2B-it   # Gemma4 Vision (256px)
cactus test --component engine --suite stt --transcription-model <parakeet bundle>  # Parakeet (20s test.wav)
```

## Notes for reviewers

- **NPU vs CPU.** Per the table preamble, VLM/Transcribe are meant to use NPU prefill. NPU (Apple ANE) is Mac-only.
  - **Mac Gemma4 Vision is NPU** — the `cactus download` apple bundle ships `vision_encoder.mlpackage`; prefill jumps to ~240 tps / ~1.2s latency vs ~84 tps / ~3.3s on CPU.
  - **Mac Parakeet is CPU.** There is no published Parakeet-TDT apple bundle, and a local `--npu` transpile fails — coremltools can't convert the TDT audio encoder (`Unsupported fx node _assert_tensor_metadata`). So this cell is CPU until that conversion is supported.
  - **Galaxy S26 is CPU for all three** (no ANE path on Android).
- **Parakeet is a TDT transducer**, so `decode_tps` isn't meaningful — the Parakeet column reports latency for 20s of audio (RTF ≈ 16× on Mac, ≈ 4.8× on Samsung).
- **LLM number** uses the existing `test_1k_context` suite (≈1221 prefill tokens, 100 decode) rather than a new exact-1000 fixture, per the request to reuse existing tests.
- Device label "Galaxy S26" follows the existing table; the connected unit reports model `SM-S942U1`.
- The "Parakeet 1.1B" column header still reads 1.1B while the model is 0.6B (pre-existing; left untouched).
