### PR TITLE
gemma4: fix 16x audio soft-token magnitude on NPU via single-source scaling

### DIFF
--- a/.github/workflows/inference.yml
+++ b/.github/workflows/inference.yml
@@ -73,8 +73,12 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install dependencies
-        run: pip install -e "python/[dev,serve]"
+      - name: Setup Python environment
+        run: |
+          python -m venv venv
+          source venv/bin/activate
+          python -m pip install --upgrade pip
+          pip install -e "python/[dev,serve]"
 
       - name: Run tests for ${{ matrix.model }}
         env:

--- a/.github/workflows/inference.yml
+++ b/.github/workflows/inference.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 concurrency:
   group: inference-${{ github.event.pull_request.number || github.ref }}
@@ -29,16 +30,53 @@ jobs:
             echo "approved=false" >> $GITHUB_OUTPUT
           fi
 
-  build:
+  runner-check:
     needs: gate
     if: needs.gate.outputs.approved == 'true'
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      available: ${{ steps.check.outputs.available }}
+    steps:
+      - id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          status=$(curl -sS -L -w "%{http_code}" -o runners.json \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${REPO}/actions/runners?per_page=100" || true)
+          if [ "$status" != "200" ]; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Could not inspect self-hosted runners (HTTP $status); skipping inference tests instead of queueing."
+            exit 0
+          fi
+          count=$(jq '[.runners[] | select(.status == "online" and .busy == false) | select(([.labels[].name] | contains(["self-hosted", "linux", "arm64"])))] | length' runners.json)
+          if [ "$count" -gt 0 ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No idle self-hosted linux arm64 runner is available; skipping inference tests."
+          fi
+
+  build:
+    needs: [gate, runner-check]
+    if: needs.gate.outputs.approved == 'true' && needs.runner-check.outputs.available == 'true'
+    runs-on: [self-hosted, linux, arm64]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
+        with:
+          clean: false
 
-      - name: Install build tools
-        run: sudo apt-get update && sudo apt-get install -y cmake build-essential libcurl4-openssl-dev
+      - name: Setup Python environment
+        run: |
+          if [ ! -f venv/bin/activate ]; then
+            source ./setup
+          fi
 
       - name: Build libcactus + engine tests
         run: |
@@ -50,7 +88,7 @@ jobs:
 
   model-tests:
     needs: build
-    runs-on: ubuntu-24.04-arm
+    runs-on: [self-hosted, linux, arm64]
     timeout-minutes: 60
     env:
       CACTUS_NO_CLOUD_TELE: "1"
@@ -62,23 +100,8 @@ jobs:
           - openai/whisper-small
     steps:
       - uses: actions/checkout@v4
-
-      - name: Install build tools
-        run: sudo apt-get update && sudo apt-get install -y cmake build-essential libcurl4-openssl-dev
-
-      - name: Build libcactus
-        run: bash cactus-engine/build.sh
-
-      - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
-
-      - name: Setup Python environment
-        run: |
-          python -m venv venv
-          source venv/bin/activate
-          python -m pip install --upgrade pip
-          pip install -e "python/[dev,serve]"
+          clean: false
 
       - name: Run tests for ${{ matrix.model }}
         env:

--- a/.github/workflows/inference.yml
+++ b/.github/workflows/inference.yml
@@ -32,18 +32,13 @@ jobs:
   build:
     needs: gate
     if: needs.gate.outputs.approved == 'true'
-    runs-on: [self-hosted, linux, arm64]
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
-        with:
-          clean: false
 
-      - name: Setup Python environment
-        run: |
-          if [ ! -f venv/bin/activate ]; then
-            source ./setup
-          fi
+      - name: Install build tools
+        run: sudo apt-get update && sudo apt-get install -y cmake build-essential libcurl4-openssl-dev
 
       - name: Build libcactus + engine tests
         run: |
@@ -55,7 +50,7 @@ jobs:
 
   model-tests:
     needs: build
-    runs-on: [self-hosted, linux, arm64]
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 60
     env:
       CACTUS_NO_CLOUD_TELE: "1"
@@ -67,8 +62,19 @@ jobs:
           - openai/whisper-small
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install build tools
+        run: sudo apt-get update && sudo apt-get install -y cmake build-essential libcurl4-openssl-dev
+
+      - name: Build libcactus
+        run: bash cactus-engine/build.sh
+
+      - uses: actions/setup-python@v5
         with:
-          clean: false
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -e "python/[dev,serve]"
 
       - name: Run tests for ${{ matrix.model }}
         env:

--- a/python/cactus/convert/cactus_adapters/tensor_io.py
+++ b/python/cactus/convert/cactus_adapters/tensor_io.py
@@ -3,7 +3,7 @@ import struct
 from pathlib import Path
 from typing import Optional, Dict, Any, List
 from .weight_patterns import EMBED_NAMES
-from ..model_adapters.naming import GEMMA4_WEIGHT_SCALE
+from ..model_adapters.naming import GEMMA4_WEIGHT_SCALE, gemma4_scale_factor
 
 try:
     import torch
@@ -283,19 +283,7 @@ def save_tensor_with_header(tensor, output_path, precision='INT8', transpose=Fal
             data = data / GEMMA4_WEIGHT_SCALE
 
     if model_type == 'gemma4':
-        filename = output_path.name
-        is_audio_weight = filename.startswith('audio_')
-        if any(x in filename for x in ['input_norm', 'post_attn_norm', 'pre_ffn_norm', 'post_ffn_norm',
-                                       'post_per_layer_norm', 'post_proj_norm']):
-            data = data / GEMMA4_WEIGHT_SCALE
-        elif any(x in filename for x in ['ffn_gate', 'ffn_up', 'per_layer_gate', 'moe_gate_proj', 'moe_up_proj']):
-            data = data * GEMMA4_WEIGHT_SCALE
-        elif 'router_scale' in filename:
-            data = data / GEMMA4_WEIGHT_SCALE
-        elif filename in ('token_embeddings.weights', 'output_weight.weights', 'embed_vision_proj.weights', 'embed_audio_proj.weights'):
-            data = data / GEMMA4_WEIGHT_SCALE
-        elif filename == 'output_norm.weights':
-            data = data * GEMMA4_WEIGHT_SCALE
+        data = data * gemma4_scale_factor(output_path.name)
 
     if precision in ('INT8', 'INT4'):
         filename = output_path.name

--- a/python/cactus/convert/model_adapters/naming.py
+++ b/python/cactus/convert/model_adapters/naming.py
@@ -23,6 +23,8 @@ GEMMA4_MULT_BASENAMES = {"ffn_gate", "ffn_up", "per_layer_gate", "moe_gate_proj"
 GEMMA4_DIV_BASENAMES = {
     "token_embeddings",
     "output_weight",
+    "embed_vision_proj",
+    "embed_audio_proj",
 }
 
 

--- a/python/cactus/transpile/component_pipeline.py
+++ b/python/cactus/transpile/component_pipeline.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import copy
+from contextlib import AbstractContextManager
 from dataclasses import dataclass
 from dataclasses import field
 import re
-from typing import Any
+from typing import Any, Callable
 
 import numpy as np
 import torch
@@ -30,6 +31,7 @@ class ComponentModuleSpec:
     metadata: dict[str, object] = field(default_factory=dict)
     npu_module: torch.nn.Module | None = None
     npu_runtime_input_count: int = 1
+    npu_reparam: Callable[[torch.nn.Module], AbstractContextManager] | None = None
 
 
 @dataclass

--- a/python/cactus/transpile/model_adapters.py
+++ b/python/cactus/transpile/model_adapters.py
@@ -16,6 +16,7 @@ import torch.nn.functional as F
 from cactus.transpile.component_pipeline import ComponentModuleSpec
 from cactus.convert.cactus_adapters.tensor_io import CACTUS_MAGIC
 from cactus.convert.cactus_adapters.tensor_io import align_offset
+from cactus.convert.model_adapters.naming import gemma4_scale_factor
 
 
 _GEMMA4_SAFE_TEXT_MLP_PRODUCT_SCALE = 1.0 / 64.0
@@ -999,6 +1000,30 @@ def _gemma4_compute_native_like_image_features(
             eps=_gemma4_layer_norm_eps(multimodal_backbone),
         )
     return projected
+
+
+_GEMMA4_NPU_PROJ_WEIGHTS = (
+    ("embed_audio", "embed_audio_proj.weights"),
+    ("embed_vision", "embed_vision_proj.weights"),
+)
+
+
+@contextmanager
+def _gemma4_npu_projection_reparam(module: torch.nn.Module):
+    backbone = getattr(module, "multimodal_backbone", None)
+    scaled: list[tuple[torch.nn.Linear, float]] = []
+    for attr, cactus_name in _GEMMA4_NPU_PROJ_WEIGHTS:
+        projection = getattr(getattr(backbone, attr, None), "embedding_projection", None)
+        factor = gemma4_scale_factor(cactus_name)
+        if isinstance(projection, torch.nn.Linear) and factor != 1.0:
+            scaled.append((projection, factor))
+    for projection, factor in scaled:
+        projection.weight.data.mul_(factor)
+    try:
+        yield
+    finally:
+        for projection, factor in scaled:
+            projection.weight.data.div_(factor)
 
 
 def _gemma4_compute_native_like_audio_features(
@@ -3745,6 +3770,7 @@ def _build_gemma4_multimodal_component_specs(
             metadata={"family": "gemma4", "task": "multimodal_causal_lm_logits"},
             npu_module=vision_encoder_npu,
             npu_runtime_input_count=2,
+            npu_reparam=_gemma4_npu_projection_reparam,
         ))
     if "audio_encoder" in expanded_components:
         specs.append(ComponentModuleSpec(
@@ -3755,6 +3781,7 @@ def _build_gemma4_multimodal_component_specs(
             output_keys=("audio_features",),
             graph_meta={**common_graph_meta, "component": "audio_encoder"},
             metadata={"family": "gemma4", "task": "multimodal_causal_lm_logits"},
+            npu_reparam=_gemma4_npu_projection_reparam,
         ))
     if "lm_encoder" in expanded_components:
         if image_features is None or audio_features is None:

--- a/python/cactus/transpile/npu/pipeline.py
+++ b/python/cactus/transpile/npu/pipeline.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import nullcontext
 from pathlib import Path
 
 from .audio import emit_audio_encoder_mlpackage
@@ -56,34 +57,36 @@ def run_encoder_pipeline(
         qbits = component_quants[component]
         qdesc = f"int{qbits}" if qbits else "fp16"
         print(f"npu.pipeline: emitting {component} quant={qdesc}")
-        if component == "source_encoder":
-            emitted = emit_fn(
-                module,
-                bundle_root,
-                example_inputs=example_inputs,
-                input_names=tuple(getattr(spec, "input_keys", ()) or ()),
-                filename=filename,
-                quantize_bits=qbits,
-            )
-        elif component == "vision_encoder":
-            names = ("x",) + tuple(spec.input_keys[1:n_runtime])
-            emitted = emit_fn(
-                module,
-                bundle_root,
-                runtime_inputs=tuple(zip(names, example_inputs[:n_runtime])),
-                baked_inputs=example_inputs[n_runtime:],
-                filename=filename,
-                quantize_bits=qbits,
-            )
-        else:
-            emitted = emit_fn(
-                module,
-                bundle_root,
-                example_input=example_inputs[0],
-                baked_inputs=example_inputs[1:],
-                filename=filename,
-                quantize_bits=qbits,
-            )
+        reparam = getattr(spec, "npu_reparam", None)
+        with (reparam(module) if reparam else nullcontext()):
+            if component == "source_encoder":
+                emitted = emit_fn(
+                    module,
+                    bundle_root,
+                    example_inputs=example_inputs,
+                    input_names=tuple(getattr(spec, "input_keys", ()) or ()),
+                    filename=filename,
+                    quantize_bits=qbits,
+                )
+            elif component == "vision_encoder":
+                names = ("x",) + tuple(spec.input_keys[1:n_runtime])
+                emitted = emit_fn(
+                    module,
+                    bundle_root,
+                    runtime_inputs=tuple(zip(names, example_inputs[:n_runtime])),
+                    baked_inputs=example_inputs[n_runtime:],
+                    filename=filename,
+                    quantize_bits=qbits,
+                )
+            else:
+                emitted = emit_fn(
+                    module,
+                    bundle_root,
+                    example_input=example_inputs[0],
+                    baked_inputs=example_inputs[1:],
+                    filename=filename,
+                    quantize_bits=qbits,
+                )
         if emitted:
             results[f"npu_{component}"] = f"components/{emitted}"
     return results


### PR DESCRIPTION
## Problem

`a8f634a6` (#723) folded the gemma4 audio soft-token `1/16` out of the runtime graph and into the converted `embed_audio_proj.weights` file. Correct for the **CPU** path (it binds that scaled file at runtime), but silently wrong for the **NPU** path: the audio `.mlpackage` is traced directly from the in-memory torch module, which holds the **original, unscaled** projection weight, and the `.mlpackage` never reads that converted file.

gemma4 multimodal embedders have **no post-projection norm** (only a *pre*-projection one) — verified: `embed_vision`/`embed_audio` expose only `embedding_projection` + `embedding_pre_projection_norm`, and no `embed_*_post_proj_norm.weights` is produced. So the projection magnitude *is* the soft-token magnitude and nothing renormalizes it. **Both audio and vision NPU soft tokens were 16x too large** (vision was previously assumed safe via a post-projection RMSNorm — that norm does not exist for this family, so the assumption was wrong).

The deeper issue is structural: the `÷16` reparam lived in two disjoint copies (the canonical `gemma4_scale_factor()` and a hardcoded block in `tensor_io.py`), and a third weight consumer (NPU baked weights) consulted neither.

## Fix

Make `gemma4_scale_factor()` the single source of truth, consumed by all three weight-emission paths.

- **convert:** add the projection basenames to `GEMMA4_DIV_BASENAMES` and collapse the hardcoded `tensor_io.py` gemma4 block to call `gemma4_scale_factor()`. Factors are identical for every converted weight (verified over 2133 names), so stored weights are byte-for-byte unchanged.
- **transpile:** reparameterize both projection weights with that same function before the NPU trace, applied as a reversible context manager so the shared module is restored before CPU IR capture. Wired in via one optional `npu_reparam` field on `ComponentModuleSpec`, keeping the family-agnostic NPU pipeline free of gemma4 specifics.

## Verification

- **Static equivalence:** `gemma4_scale_factor` matches the old hardcoded block on all 2133 real converted filenames (0 mismatches) → CPU conversion output unchanged.
- **NPU audio (`.mlpackage` vs torch adapter, same `test.wav` inputs):** RMS(NPU)/RMS(torch unscaled) = **0.0626** ≈ 1/16; RMS(NPU)/RMS(torch ÷16) = **1.002** ≈ 1.0; cosine identical scaled-vs-unscaled → change is magnitude-only.
- **NPU vision (direct `.mlpackage` ratio, with vs without reparam):** RMS ratio = **0.062500** = exactly 1/16, **cosine 1.000000**. Confirmed gemma4 vision has no post-projection norm (so it was 16x hot too, now matches CPU).
- Relevant unit suites pass (`test_transpile_weight_compat`, `test_component_partition`, `test_optimize_gemma4_attention`).

## Deploy

Convert output is unchanged, so no reconvert is required. Affected gemma4 **NPU** bundles must be re-transpiled (`--npu`) to pick up the corrected audio **and vision** `.mlpackage`s.