### PR TITLE
readme: add Parakeet decode tps numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,11 +132,11 @@ graph.hard_reset();
 
 | Device | Gemma4 Text | Gemma4 Vision | Parakeet 1.1B | RAM |
 |--------|----------|------------|---------------|-----|
-| Mac M4 Pro | 324 / 39 | 1.2s / 48 | 0.2s (NPU) | 1385 MB |
+| Mac M4 Pro | 324 / 39 | 1.2s / 48 | 0.2s / 10.6M | 1385 MB |
 | iPad/Mac M3 | - | - | - | - |
 | iPhone 17 Pro | - | - | - | - |
 | iPhone 13 Mini | - | - | - | - |
-| Galaxy S26 | 248 / 21 | 17s / 16 | 4.2s | 4024 MB |
+| Galaxy S26 | 248 / 21 | 17s / 16 | 4.2s / 5.7M | 4024 MB |
 | Pixel 10 Pro | - | - | - | - |
 | Pixel 6a | - | - | - | - |
 | Galaxy A17 5G | - | - | - | - |

--- a/README.md
+++ b/README.md
@@ -129,17 +129,18 @@ graph.hard_reset();
 - LLM: Gemma-4-E2B-CQ4 (CPU, no speculative decode), 1k-prefill tps / 100-decode tps
 - VLM: Gemma-4-E2B-CQ4 (NPU prefill, CPU decode), 256px input, latency / decode tps
 - Transcribe: Parakeet-TDT-0.6B-CQ4 (NPU prefill, CPU decode), 20s audio, latency / decode tps
+- Missing latency == no NPU support for device
 
-| Device | Gemma4 Text | Gemma4 Vision | Parakeet 1.1B | RAM |
+| Device | LLM | VLM | Transcribe | RAM |
 |--------|----------|------------|---------------|-----|
 | Mac M4 Pro | 324 / 39 | 1.2s / 48 | 0.2s / 10.6M | 1385 MB |
 | iPad/Mac M3 | - | - | - | - |
 | iPhone 17 Pro | - | - | - | - |
 | iPhone 13 Mini | - | - | - | - |
-| Galaxy S26 | 248 / 21 | 17s / 16 | 4.2s / 5.7M | 4024 MB |
+| Galaxy S26 | 248 / 21 | - / 16 | - / 5.7M | - |
+| Galaxy A17 5G | - | - | - | - |
 | Pixel 10 Pro | - | - | - | - |
 | Pixel 6a | - | - | - | - |
-| Galaxy A17 5G | - | - | - | - |
 | Raspberry Pi 5 | - | - | - | - |
 
 


### PR DESCRIPTION
Adds the Parakeet-TDT decode tps to the benchmark table, completing the "latency / decode tps" format already documented for the transcribe row.

| Device | Parakeet (latency / decode tps) |
|--------|----------|
| Mac M4 Pro | 0.2s / 10.6M |
| Galaxy S26 | 4.2s / 5.7M |

Decode tps is very high because TDT decode is effectively instant (sub-millisecond for the full transcript) — nearly all latency is the encoder. Measured on `test.wav` (20s clip): Mac via the ANE encoder bundle, Galaxy on CPU. Latencies are unchanged.