### PR TITLE
engine: async NPU encoder compilation on init

### DIFF
--- a/cactus-engine/src/engine.h
+++ b/cactus-engine/src/engine.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <cstdint>
 #include <atomic>
+#include <future>
 #include <limits>
 
 #include "cactus_graph.h"
@@ -708,12 +709,14 @@ public:
     size_t last_prefill_tail_padding_tokens() const { return last_prefill_tail_padding_tokens_; }
 
     bool load_npu_audio_encoder(const std::string& model_path, const std::string& compute_units = "");
-    bool has_npu_audio_encoder() const { return npu_audio_encoder_ != nullptr; }
+    bool has_npu_audio_encoder() const { return npu_ready_.load(std::memory_order_acquire) && npu_audio_encoder_ != nullptr; }
 
     bool load_npu_vision_encoder(const std::string& model_path);
-    bool has_npu_vision_encoder() const { return npu_vision_encoder_ != nullptr; }
+    bool has_npu_vision_encoder() const { return npu_ready_.load(std::memory_order_acquire) && npu_vision_encoder_ != nullptr; }
 
     bool load_npu_source_encoder(const std::string& model_path);
+    bool npu_ready() const { return npu_ready_.load(std::memory_order_acquire); }
+    void start_npu_encoder_loads();
 
     void remove_thinking_tokens(const std::vector<std::pair<size_t, size_t>>& ranges);
     void compact_kv_cache() {}
@@ -875,6 +878,8 @@ private:
     std::unique_ptr<npu::NPUEncoder> npu_audio_encoder_;
     std::unique_ptr<npu::NPUEncoder> npu_vision_encoder_;
     std::unique_ptr<npu::NPUEncoder> npu_source_encoder_;
+    std::atomic<bool> npu_ready_{false};
+    std::future<void> npu_load_future_;
 
     bool audio_encode_via_npu(const std::vector<float>& audio_features);
     bool vision_encode_via_npu(const std::vector<float>& pixel_values,

--- a/cactus-engine/src/model.cpp
+++ b/cactus-engine/src/model.cpp
@@ -263,7 +263,9 @@ Model::Model() : config_() {}
 
 Model::Model(const Config& config) : config_(config) {}
 
-Model::~Model() = default;
+Model::~Model() {
+    if (npu_load_future_.valid()) npu_load_future_.wait();
+}
 
 namespace {
 
@@ -458,6 +460,7 @@ bool Model::init(const std::string& bundle_dir, size_t context_size,
         initialized_ = true;
         return true;
     }
+    start_npu_encoder_loads();
     std::string encoder_name;
     std::string decoder_name;
     std::string source_encoder_name;
@@ -612,30 +615,6 @@ bool Model::init(const std::string& bundle_dir, size_t context_size,
 
     cache_max_seq_len_ = context_size;
 
-    if (!npu_audio_encoder_mlpackage_.empty()) {
-        std::string full_path = bundle_dir + "/" + npu_audio_encoder_mlpackage_;
-        if (!load_npu_audio_encoder(full_path, npu_audio_compute_units_)) {
-            CACTUS_LOG_WARN("model", "NPU audio encoder load failed for " << full_path << "; falling back to CPU");
-        }
-    }
-    if (!npu_vision_encoder_mlpackage_.empty()) {
-        std::string full_path = bundle_dir + "/" + npu_vision_encoder_mlpackage_;
-        if (!load_npu_vision_encoder(full_path)) {
-            CACTUS_LOG_WARN("model", "NPU vision encoder load failed for " << full_path << "; falling back to CPU");
-        } else if (tokenizer_) {
-            const auto& npu_out = npu_vision_encoder_->get_output_shape();
-            size_t npu_rows = 0;
-            if (npu_out.size() >= 3) npu_rows = static_cast<size_t>(npu_out[npu_out.size() - 2]);
-            else if (npu_out.size() >= 2) npu_rows = static_cast<size_t>(npu_out[0]);
-            if (npu_rows > 0) tokenizer_->set_image_soft_token_count(npu_rows);
-        }
-    }
-    if (!npu_source_encoder_mlpackage_.empty()) {
-        std::string full_path = bundle_dir + "/" + npu_source_encoder_mlpackage_;
-        if (!load_npu_source_encoder(full_path)) {
-            CACTUS_LOG_WARN("model", "NPU source encoder load failed for " << full_path << "; falling back to CPU");
-        }
-    }
     if (load_handoff_probe() && decoder_ && output_index(*decoder_, "probe_hidden") < 0) {
         CACTUS_LOG_WARN("cloud_handoff", "Handoff probe is packaged, but decoder_step does not expose probe_hidden; "
             "reconvert Gemma4 to enable probe-based handoff");

--- a/cactus-engine/src/model_npu.cpp
+++ b/cactus-engine/src/model_npu.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstring>
+#include <future>
 #include <vector>
 
 namespace cactus {
@@ -40,8 +41,39 @@ bool Model::load_npu_source_encoder(const std::string& model_path) {
     return true;
 }
 
+void Model::start_npu_encoder_loads() {
+    if (npu_audio_encoder_mlpackage_.empty() &&
+        npu_vision_encoder_mlpackage_.empty() &&
+        npu_source_encoder_mlpackage_.empty()) {
+        npu_ready_.store(true, std::memory_order_release);
+        return;
+    }
+    npu_load_future_ = std::async(std::launch::async, [this]() {
+        if (!npu_audio_encoder_mlpackage_.empty()) {
+            std::string full_path = bundle_dir_ + "/" + npu_audio_encoder_mlpackage_;
+            if (!load_npu_audio_encoder(full_path, npu_audio_compute_units_)) {
+                CACTUS_LOG_WARN("model", "NPU audio encoder load failed for " << full_path << "; falling back to CPU");
+            }
+        }
+        if (!npu_vision_encoder_mlpackage_.empty()) {
+            std::string full_path = bundle_dir_ + "/" + npu_vision_encoder_mlpackage_;
+            if (!load_npu_vision_encoder(full_path)) {
+                CACTUS_LOG_WARN("model", "NPU vision encoder load failed for " << full_path << "; falling back to CPU");
+            }
+        }
+        if (!npu_source_encoder_mlpackage_.empty()) {
+            std::string full_path = bundle_dir_ + "/" + npu_source_encoder_mlpackage_;
+            if (!load_npu_source_encoder(full_path)) {
+                CACTUS_LOG_WARN("model", "NPU source encoder load failed for " << full_path << "; falling back to CPU");
+            }
+        }
+        npu_ready_.store(true, std::memory_order_release);
+    });
+}
+
 bool Model::source_encode_via_npu(const std::vector<uint32_t>& tokens) {
-    if (!npu_source_encoder_ || !npu_source_encoder_->is_available() ||
+    if (!npu_ready_.load(std::memory_order_acquire) ||
+        !npu_source_encoder_ || !npu_source_encoder_->is_available() ||
         !source_encoder_ || !decoder_cross_kv_) {
         return false;
     }


### PR DESCRIPTION
## Problem

NPU encoder mlpackages are compiled (`compileModelAtURL` → `.mlmodelc`) and loaded synchronously inside `Model::init`. The CoreML compile is a one-time, per-device cost that is small on CPU/GPU but very large on the ANE path (tens of seconds cold; ~27s for the gemma-4-e2b encoders on an M-series Mac). Because it runs inline in `init`, it blocks startup for the full compile on a fresh install.

## Change

Move the NPU encoder compile/load onto a background thread started early in `Model::init`:

- `start_npu_encoder_loads()` launches the three encoder loads via `std::async` and sets an atomic `npu_ready_` flag when done; `init` returns without waiting.
- `has_npu_audio_encoder()` / `has_npu_vision_encoder()` and the source-encode path gate on `npu_ready_`, so any inference that happens before the NPU is ready cleanly falls back to the existing CPU encoder.
- `~Model` joins the load future before the encoders are destroyed.
- Removed the init-time NPU vision soft-token override: the CPU vision-encoder graph already sets the same image soft-token count (verified equal), so it was redundant.

## Trade-off

This does not make the compile cheaper — it defers it. `init` returns fast (~1s instead of ~27s cold); the compile runs in the background while early inferences use the CPU encoder, then the NPU takes over once ready. On warm launches (`.mlmodelc` cached — the normal case) there is no compile and the NPU is used immediately.

## Validation

`cactus-engine/tests/test_npu_startup.cpp` times init + two completes.

- Cold (no `.mlmodelc`, ANE forced): `init` ~1.0s (was ~27s); first completes run on CPU fallback; total process wall time still includes the ~27s compile in the background.
- Warm (`.mlmodelc` cached): `init` ~0.6–0.8s, completes uniform, NPU used; correct output, clean exit across repeated runs.