### PR TITLE
gemma4: run the audio encoder correctly and fast on the Apple Neural Engine

### DIFF
--- a/python/cactus/transpile/hf_model.py
+++ b/python/cactus/transpile/hf_model.py
@@ -506,7 +506,7 @@ def _write_component_bundle(
     for manifest_key, mlpackage_path in (npu_encoder_mlpackages or {}).items():
         if mlpackage_path:
             manifest_payload[manifest_key] = mlpackage_path
-    if family == "parakeet_tdt" and "npu_audio_encoder" in manifest_payload:
+    if family in ("parakeet_tdt", "gemma4") and "npu_audio_encoder" in manifest_payload:
         manifest_payload["npu_audio_compute_units"] = "CPU_AND_NE"
     _write_json(manifest_path, manifest_payload)
     return manifest_path

--- a/python/cactus/transpile/model_adapters.py
+++ b/python/cactus/transpile/model_adapters.py
@@ -3533,6 +3533,22 @@ def _build_gemma3_causal_lm_component_specs(
     return specs
 
 
+def _gemma4_make_audio_mask_fp16_safe(model: torch.nn.Module) -> None:
+    backbone = getattr(model, "model", model)
+    audio_tower = getattr(backbone, "audio_tower", None)
+    if audio_tower is None:
+        return
+    seen: set[int] = set()
+    for mod in audio_tower.modules():
+        cfg = getattr(mod, "config", None)
+        if cfg is None or id(cfg) in seen:
+            continue
+        seen.add(id(cfg))
+        value = getattr(cfg, "attention_invalid_logits_value", None)
+        if isinstance(value, (int, float)) and value < -1e4:
+            cfg.attention_invalid_logits_value = -1e4
+
+
 def _build_gemma4_multimodal_component_specs(
     model: torch.nn.Module,
     *,
@@ -3616,6 +3632,7 @@ def _build_gemma4_multimodal_component_specs(
         native_image_soft_token_counts=native_image_soft_token_counts,
         native_image_pool_shapes=None,
     ).eval()
+    _gemma4_make_audio_mask_fp16_safe(model)
     audio_encoder = Gemma4AudioEncoderAdapter(model, weights_dir=weights_dir).eval()
 
     image_features: torch.Tensor | None = None


### PR DESCRIPTION
## Summary

The Gemma-4 audio encoder was quarantined to CPU+GPU on Apple devices because its CoreML graph produced wrong output on the Neural Engine. Root cause: the audio attention masked-fill constant is `attention_invalid_logits_value = -1e9`, which **overflows to -inf in the FLOAT16 NPU graph** (fp16 max is 65504). Fully-masked padded rows then softmax to NaN, and partial rows diverge on the ANE.

This routes the gemma4 audio encoder to the ANE and makes it numerically correct there:

1. Clamp `attention_invalid_logits_value` to a finite, fp16-safe `-1e4` before export. Logits are soft-capped to ±50, so masked positions still `exp()` to exactly 0 — masking is unchanged on every backend — but no value ever overflows fp16. (Same finite-mask pattern Parakeet already uses.)
2. Emit `npu_audio_compute_units = "CPU_AND_NE"` in the bundle manifest for `gemma4` (as already done for `parakeet_tdt`).

## Validation (Mac M4 Pro, int8 audio encoder, real `test.wav`)

Correctness on valid output tokens vs PyTorch fp32 ground truth:

| backend | cos vs torch fp32 |
|---|---|
| GPU (old path) | 0.9998 |
| **ANE (this PR)** | **0.9983** |

Before the fix the ANE diverged and CPU-only returned NaN; both are resolved.

Speed (median, fully warm):

| backend | latency |
|---|---|
| GPU | ~123 ms |
| **ANE** | **~84 ms (1.46x faster)** |

The finite mask also lets the encoder compile cleanly onto the ANE — the old `-inf` graph silently partition-fell-back and was never truly resident.

## Notes
- Vision encoder is intentionally left on CPU+GPU: it is ~2.4x slower on the ANE (a 2,520-token ViT is GPU-favorable) and the GPU output already matches torch.
- Deploying picks this up automatically on the next `cactus transpile … --npu` of the gemma4 bundle.

Signed-off-by: Noah Cylich <noahcylich@gmail.com>