### PR TITLE
parakeet: honor should_stop during TDT transcription

### DIFF
--- a/cactus-engine/src/engine.h
+++ b/cactus-engine/src/engine.h
@@ -675,7 +675,8 @@ public:
     std::vector<uint32_t> transcribe_parakeet_tdt(const std::vector<float>& audio_features,
                                                   ParakeetTdtStreamState* stream = nullptr,
                                                   bool is_final = true,
-                                                  size_t end_frame = 0);
+                                                  size_t end_frame = 0,
+                                                  const std::atomic<bool>* should_stop = nullptr);
     std::vector<uint32_t> transcribe_whisper_seq2seq(const std::vector<float>& audio_features,
                                                      const std::vector<uint32_t>& decoder_prompt_tokens,
                                                      size_t max_tokens,

--- a/cactus-engine/src/model.cpp
+++ b/cactus-engine/src/model.cpp
@@ -2879,7 +2879,8 @@ std::vector<uint32_t> Model::transcribe_whisper_seq2seq(
 
 std::vector<uint32_t> Model::transcribe_parakeet_tdt(const std::vector<float>& audio_features,
                                                      ParakeetTdtStreamState* stream, bool is_final,
-                                                     size_t end_frame) {
+                                                     size_t end_frame,
+                                                     const std::atomic<bool>* should_stop) {
     std::vector<uint32_t> emitted;
     double raw_decode_ms = 0.0;
 
@@ -2938,6 +2939,7 @@ std::vector<uint32_t> Model::transcribe_parakeet_tdt(const std::vector<float>& a
             std::vector<__fp16> input_fp16(chunk_input_elems);
             bool all_ok = num_chunks > 0;
             for (size_t c = 0; c < num_chunks && all_ok; ++c) {
+                if (should_stop && should_stop->load()) return emitted;
                 const size_t frame_start = c * window_frames;
                 const size_t frame_end = std::min(frame_start + window_frames, copy_frames);
                 std::fill(input_fp16.begin(), input_fp16.end(), __fp16(0));
@@ -2966,6 +2968,7 @@ std::vector<uint32_t> Model::transcribe_parakeet_tdt(const std::vector<float>& a
         }
     }
     if (!used_npu) {
+        if (should_stop && should_stop->load()) return emitted;
         audio_enc->graph->execute();
     }
 
@@ -3093,6 +3096,7 @@ std::vector<uint32_t> Model::transcribe_parakeet_tdt(const std::vector<float>& a
     if (stream) snap_state = snapshot_state();
 
     while (time_index < commit_to) {
+        if (should_stop && should_stop->load()) break;
         const uint8_t* frame_ptr = hidden_ptr + time_index * frame_bytes;
         write_typed_buffer(ef_buf, ef_desc.precision, frame_ptr, frame_bytes, hidden_precision);
 

--- a/cactus-engine/src/transcribe.cpp
+++ b/cactus-engine/src/transcribe.cpp
@@ -335,7 +335,8 @@ int cactus_transcribe(
         float total_entropy_sum = 0.0f;
 
         if (is_parakeet) {
-            generated_tokens = handle->model->transcribe_parakeet_tdt(audio_features);
+            generated_tokens = handle->model->transcribe_parakeet_tdt(
+                audio_features, nullptr, true, 0, &handle->should_stop);
             auto t_first = std::chrono::high_resolution_clock::now();
             time_to_first_token =
                 std::chrono::duration_cast<std::chrono::microseconds>(t_first - start_time).count() / 1000.0;


### PR DESCRIPTION
## Problem
The Parakeet-TDT branch of `cactus_transcribe` never checked `should_stop`, so calling `cactus_stop` mid-transcription had no effect — the call ran to completion. The whisper and LLM-completion paths already honor it; only Parakeet-TDT did not. Still present on current main.

## Change
Thread `should_stop` into `transcribe_parakeet_tdt` (last param, default `nullptr` so the streaming caller is unaffected), pass `&handle->should_stop` from the non-streaming `cactus_transcribe` call, and check it in the NPU encoder chunk loop, before the CPU encoder graph execute, and in the decoder loop. The reset already happens at transcribe entry. +9/-3 across 3 files.

Note: the CPU encoder is a single `graph->execute()`, so on the CPU path worst-case stop latency is one encoder pass; the NPU path is chunked and the decoder is per-frame.

## Testing
Verified end-to-end via the CLI/python bindings on the `parakeet-tdt-0.6b-v3-cq4-apple` bundle, issuing `cactus_stop` 100ms into transcription:
- **Fixed:** returns empty/truncated immediately — stop honored.
- **Unfixed (same version + bundle, negative control):** returns the full transcript — stop ignored.
- Regression: normal (un-stopped) transcription output unchanged.