### PR TITLE
Fix C++ test build: expose vendored libs include (picojson)

### DIFF
--- a/cactus-engine/CMakeLists.txt
+++ b/cactus-engine/CMakeLists.txt
@@ -48,8 +48,8 @@ set_target_properties(cactus_engine PROPERTIES
 
 target_include_directories(cactus_engine
     PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+           ${CMAKE_CURRENT_SOURCE_DIR}/libs
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src
-            ${CMAKE_CURRENT_SOURCE_DIR}/libs
 )
 
 target_link_libraries(cactus_engine PUBLIC cactus_graph)


### PR DESCRIPTION
`cactus test` fails to compile on `main`:

```
fatal error: 'picojson.h' file not found
```

`gemma_tools.h` (added in #745) started `#include "picojson.h"`, which lives in `cactus-engine/libs/`. That directory was a **PRIVATE** include dir of `cactus_engine`, so it applied to the engine's own translation units (the engine and Python FFI build fine) but was **not** propagated to the C++ test binaries, which reach the header transitively via `test_*.cpp → ../src/utils.h → gemma_tools.h → picojson.h`.

Moving `libs` to a **PUBLIC** include dir fixes every test target at once (they all link `cactus_engine` in a loop). This is the correct semantics now that a public-facing header depends on the vendored lib.

Verified locally by building `test_llm` and `test_telemetry` — both now compile and link clean past the picojson include.