### PR TITLE
Fix Gemma tool declaration echoes

### DIFF
--- a/cactus-engine/src/complete.cpp
+++ b/cactus-engine/src/complete.cpp
@@ -85,15 +85,20 @@ std::vector<ToolConstraintSpec> build_tool_constraint_specs(const std::vector<To
     return specs;
 }
 
-void setup_tool_constraints(CactusModelHandle* handle, const std::vector<ToolFunction>& tools,
-                           bool force_tools, float& temperature) {
-    if (!force_tools || tools.empty()) return;
+bool setup_tool_constraints(CactusModelHandle* handle, const std::vector<ToolFunction>& tools,
+                            Config::ModelType model_type, bool force_tools, float& temperature) {
+    if (tools.empty()) return false;
 
-    handle->model->set_tool_constraints(build_tool_constraint_specs(tools));
+    const bool model_supported = model_type == Config::ModelType::NEEDLE ||
+        Config::is_gemma_family(model_type);
+    if (!model_supported) return false;
 
-    if (temperature == 0.0f) {
+    handle->model->set_tool_constraints(build_tool_constraint_specs(tools), force_tools);
+
+    if (force_tools && temperature == 0.0f) {
         temperature = 0.01f;
     }
+    return true;
 }
 
 size_t find_json_block_end(const std::string& json, size_t start) {
@@ -435,6 +440,7 @@ struct PreparedPrompt {
     std::vector<uint32_t> tokens;
     size_t context_token_count = 0;
     std::vector<std::vector<CactusModelHandle::ProcessedImage>> images;
+    bool tool_constraints_active = false;
 
     std::vector<std::vector<float>> audio_features;
     size_t audio_num_frames = 0;
@@ -625,10 +631,6 @@ PreparedPrompt prepare_prompt(
         formatted_tools = gemma::format_tools(prompt.tools, !Config::is_gemma3_family(prompt.model_type));
     }
 
-    if (apply_tool_constraints) {
-        setup_tool_constraints(handle, prompt.tools, prompt.options.force_tools, prompt.options.temperature);
-    }
-
     prompt.rendered = tokenizer->format_chat_prompt(
         prompt.messages,
         add_generation_prompt,
@@ -641,6 +643,10 @@ PreparedPrompt prepare_prompt(
     prompt.tokens = tokenizer->encode(prompt.rendered);
     prompt.context_token_count = prompt.tokens.size();
     prompt.images = images_from_message(prompt.messages);
+    if (apply_tool_constraints) {
+        prompt.tool_constraints_active = setup_tool_constraints(
+            handle, prompt.tools, prompt.model_type, prompt.options.force_tools, prompt.options.temperature);
+    }
     return prompt;
 }
 
@@ -829,6 +835,16 @@ int cactus_complete(
         }
         auto* tokenizer = handle->model->get_tokenizer();
         auto prompt = prepare_prompt(handle, messages_json, options_json, tools_json, true, true, pcm_buffer, pcm_buffer_size);
+        struct ToolConstraintGuard {
+            CactusModelHandle* handle = nullptr;
+            bool active = false;
+            ~ToolConstraintGuard() {
+                if (active && handle && handle->model) {
+                    handle->model->clear_tool_constraints();
+                }
+            }
+        } tool_constraint_guard{handle, prompt.tool_constraints_active};
+
         if (prompt.options.sample_seed != 0) {
             handle->model->set_sample_seed(prompt.options.sample_seed);
         }
@@ -994,7 +1010,7 @@ int cactus_complete(
         generated_tokens.push_back(next_token);
         handle->processed_tokens.push_back(next_token);
 
-        if (prompt.options.force_tools && !prompt.tools.empty()) {
+        if (prompt.tool_constraints_active) {
             handle->model->update_tool_constraints(next_token);
         }
 
@@ -1014,9 +1030,6 @@ int cactus_complete(
                 auto now = std::chrono::high_resolution_clock::now();
                 double elapsed_ms = std::chrono::duration_cast<std::chrono::microseconds>(now - start_time).count() / 1000.0;
                 if (cloud_result.ok && (!cloud_result.response.empty() || !cloud_result.function_calls.empty())) {
-                    if (prompt.options.force_tools && !prompt.tools.empty()) {
-                        handle->model->clear_tool_constraints();
-                    }
                     return return_cloud_completion(cloud_result, elapsed_ms, elapsed_ms, confidence, prompt_tokens,
                                                    "low confidence");
                 }
@@ -1050,7 +1063,7 @@ int cactus_complete(
 
                 entropy.add(token_entropy);
 
-                if (prompt.options.force_tools && !prompt.tools.empty()) {
+                if (prompt.tool_constraints_active) {
                     handle->model->update_tool_constraints(next_token);
                 }
 
@@ -1078,10 +1091,6 @@ int cactus_complete(
                         << wrong_probability << " confidence=" << confidence);
                 }
             }
-        }
-
-        if (prompt.options.force_tools && !prompt.tools.empty()) {
-            handle->model->clear_tool_constraints();
         }
 
         auto end_time = std::chrono::high_resolution_clock::now();
@@ -1135,9 +1144,6 @@ int cactus_complete(
             auto now = std::chrono::high_resolution_clock::now();
             double elapsed_ms = std::chrono::duration_cast<std::chrono::microseconds>(now - start_time).count() / 1000.0;
             if (cloud_result.ok && (!cloud_result.response.empty() || !cloud_result.function_calls.empty())) {
-                if (prompt.options.force_tools && !prompt.tools.empty()) {
-                    handle->model->clear_tool_constraints();
-                }
                 return return_cloud_completion(cloud_result, elapsed_ms, elapsed_ms, confidence, prompt_tokens,
                                                trigger_reason);
             }

--- a/cactus-engine/src/constraints.cpp
+++ b/cactus-engine/src/constraints.cpp
@@ -410,6 +410,7 @@ void ToolCallConstrainer::tokenize_grammar_elements() {
 
     call_start_sequence_ = tokenizer_->encode(call_start_tag_);
     call_end_sequence_ = tokenizer_->encode(call_end_tag_);
+    declaration_start_sequence_ = tokenizer_->encode(declaration_start_tag_);
     std::vector<uint32_t> response_sequence = tokenizer_->encode(response_start_tag_);
     if (call_start_sequence_.size() == 1) gemma_call_start_tokens_.insert(call_start_sequence_[0]);
     if (call_end_sequence_.size() == 1) gemma_call_end_tokens_.insert(call_end_sequence_[0]);
@@ -426,10 +427,12 @@ void ToolCallConstrainer::tokenize_grammar_elements() {
 
 void ToolCallConstrainer::init(Config::ModelType model_type,
                                const std::vector<ToolConstraintSpec>& tools,
-                               Tokenizer* tokenizer) {
+                               Tokenizer* tokenizer,
+                               bool force_call) {
     model_type_ = model_type;
     tool_specs_ = tools;
     tokenizer_ = tokenizer;
+    force_call_ = force_call;
     generated_text_.clear();
     current_bias_.clear();
     dense_ready_ = false;
@@ -442,10 +445,12 @@ void ToolCallConstrainer::init(Config::ModelType model_type,
     if (Config::is_gemma3_family(model_type_)) {
         call_start_tag_ = "<start_function_call>";
         call_end_tag_ = "<end_function_call>";
+        declaration_start_tag_ = "<start_function_declaration>";
         response_start_tag_ = "<start_function_response>";
     } else {
         call_start_tag_ = "<|tool_call>";
         call_end_tag_ = "<tool_call|>";
+        declaration_start_tag_ = "<|tool>";
         response_start_tag_ = "<|tool_response>";
     }
 
@@ -525,7 +530,7 @@ void ToolCallConstrainer::compute_bias() {
 
     if (!active_) return;
 
-    if (!is_needle()) {
+    if (!is_needle() && (force_call_ || state_ != State::GEMMA_START)) {
         for (uint32_t t : backtick_tokens_) {
             current_bias_[t] = BLOCK_BIAS;
         }
@@ -553,14 +558,30 @@ void ToolCallConstrainer::compute_bias() {
 
     switch (state_) {
         case State::GEMMA_START:
-            if (forced_tag_progress_ < call_start_sequence_.size()) {
+            if ((force_call_ || forced_tag_progress_ > 0) &&
+                forced_tag_progress_ < call_start_sequence_.size()) {
                 current_bias_[call_start_sequence_[forced_tag_progress_]] = FORCE_BIAS;
             }
-            for (uint32_t t : open_brace_tokens_) {
-                current_bias_[t] = BLOCK_BIAS;
+            if (forced_tag_progress_ < declaration_start_sequence_.size()) {
+                bool shares_forced_prefix = forced_tag_progress_ <= call_start_sequence_.size();
+                for (size_t i = 0; shares_forced_prefix && i < forced_tag_progress_; ++i) {
+                    shares_forced_prefix = declaration_start_sequence_[i] == call_start_sequence_[i];
+                }
+                if (shares_forced_prefix) {
+                    uint32_t declaration_next = declaration_start_sequence_[forced_tag_progress_];
+                    if (forced_tag_progress_ >= call_start_sequence_.size() ||
+                        declaration_next != call_start_sequence_[forced_tag_progress_]) {
+                        current_bias_[declaration_next] = BLOCK_BIAS;
+                    }
+                }
             }
-            for (uint32_t t : close_brace_tokens_) {
-                current_bias_[t] = BLOCK_BIAS;
+            if (force_call_) {
+                for (uint32_t t : open_brace_tokens_) {
+                    current_bias_[t] = BLOCK_BIAS;
+                }
+                for (uint32_t t : close_brace_tokens_) {
+                    current_bias_[t] = BLOCK_BIAS;
+                }
             }
             break;
 
@@ -629,8 +650,8 @@ void ToolCallConstrainer::reset() {
 }
 
 
-void Model::set_tool_constraints(const std::vector<ToolConstraintSpec>& tools) {
-    tool_constrainer_.init(config_.model_type, tools, tokenizer_.get());
+void Model::set_tool_constraints(const std::vector<ToolConstraintSpec>& tools, bool force_call) {
+    tool_constrainer_.init(config_.model_type, tools, tokenizer_.get(), force_call);
 }
 
 void Model::clear_tool_constraints() {

--- a/cactus-engine/src/engine.h
+++ b/cactus-engine/src/engine.h
@@ -477,7 +477,8 @@ public:
 
     void init(Config::ModelType model_type,
               const std::vector<ToolConstraintSpec>& tools,
-              Tokenizer* tokenizer);
+              Tokenizer* tokenizer,
+              bool force_call = true);
 
     const std::unordered_map<uint32_t, float>& get_bias() const { return current_bias_; }
     const std::vector<float>* get_dense_bias() const { return dense_ready_ ? &dense_bias_ : nullptr; }
@@ -496,6 +497,7 @@ private:
     };
 
     bool active_ = false;
+    bool force_call_ = true;
     State state_ = State::GEMMA_START;
     Config::ModelType model_type_ = Config::ModelType::GEMMA4;
     Tokenizer* tokenizer_ = nullptr;
@@ -505,9 +507,11 @@ private:
 
     std::string call_start_tag_;
     std::string call_end_tag_;
+    std::string declaration_start_tag_;
     std::string response_start_tag_;
     std::vector<uint32_t> call_start_sequence_;
     std::vector<uint32_t> call_end_sequence_;
+    std::vector<uint32_t> declaration_start_sequence_;
     size_t forced_tag_progress_ = 0;
 
     std::unordered_set<uint32_t> gemma_call_start_tokens_;
@@ -705,7 +709,7 @@ public:
     std::vector<size_t> compressible_layers() const;
     void apply_kv_compress_env_override();
 
-    void set_tool_constraints(const std::vector<ToolConstraintSpec>& tools);
+    void set_tool_constraints(const std::vector<ToolConstraintSpec>& tools, bool force_call = true);
     void clear_tool_constraints();
     void update_tool_constraints(uint32_t token_id);
 

--- a/cactus-engine/tests/test_llm.cpp
+++ b/cactus-engine/tests/test_llm.cpp
@@ -289,6 +289,69 @@ struct LengthTokenizer : public Tokenizer {
     bool load_vocabulary_with_config(const std::string&, const std::string&, const std::string&) override { return true; }
 };
 
+struct ToolSentinelTokenizer : public Tokenizer {
+    std::vector<uint32_t> encode(const std::string& text) const override {
+        if (text == "<|tool_call>") return {1};
+        if (text == "<tool_call|>") return {2};
+        if (text == "<|tool>") return {3};
+        if (text == "call:") return {4};
+        if (text == "{") return {5};
+        if (text == "}") return {6};
+        if (text == "<|\"|>") return {7};
+        return {8};
+    }
+    std::string decode(const std::vector<uint32_t>& tokens) const override {
+        if (tokens.empty()) return "";
+        switch (tokens.front()) {
+            case 1: return "<|tool_call>";
+            case 2: return "<tool_call|>";
+            case 3: return "<|tool>";
+            case 4: return "call:";
+            case 5: return "{";
+            case 6: return "}";
+            case 7: return "<|\"|>";
+            default: return "";
+        }
+    }
+    uint32_t get_vocab_size() const override { return 16; }
+    uint32_t get_unk_token() const override { return 0; }
+    uint32_t get_bos_token() const override { return 0; }
+    uint32_t get_eos_token() const override { return 0; }
+    bool load_vocabulary_with_config(const std::string&, const std::string&, const std::string&) override { return true; }
+};
+
+struct BranchingToolSentinelTokenizer : public Tokenizer {
+    std::vector<uint32_t> encode(const std::string& text) const override {
+        if (text == "<|tool_call>") return {1, 2};
+        if (text == "<|tool>") return {1, 3};
+        if (text == "<tool_call|>") return {4};
+        if (text == "call:") return {5};
+        if (text == "{") return {6};
+        if (text == "}") return {7};
+        if (text == "<|\"|>") return {8};
+        return {9};
+    }
+    std::string decode(const std::vector<uint32_t>& tokens) const override {
+        if (tokens.empty()) return "";
+        switch (tokens.front()) {
+            case 1: return "<|tool";
+            case 2: return "_call>";
+            case 3: return ">";
+            case 4: return "<tool_call|>";
+            case 5: return "call:";
+            case 6: return "{";
+            case 7: return "}";
+            case 8: return "<|\"|>";
+            default: return "";
+        }
+    }
+    uint32_t get_vocab_size() const override { return 16; }
+    uint32_t get_unk_token() const override { return 0; }
+    uint32_t get_bos_token() const override { return 0; }
+    uint32_t get_eos_token() const override { return 0; }
+    bool load_vocabulary_with_config(const std::string&, const std::string&, const std::string&) override { return true; }
+};
+
 bool test_tool_constraint_clear_releases_bias() {
     LengthTokenizer tok;
     ToolCallConstrainer constrainer;
@@ -304,6 +367,106 @@ bool test_tool_constraint_clear_releases_bias() {
         return false;
     }
     return true;
+}
+
+bool test_tool_constraint_blocks_declaration_echo() {
+    {
+        ToolSentinelTokenizer tok;
+        ToolCallConstrainer constrainer;
+        constrainer.init(Config::ModelType::GEMMA4, {{"get_weather", {"location"}, {}, {"location"}}}, &tok);
+
+        const auto& bias = constrainer.get_bias();
+        auto call_it = bias.find(1);
+        auto decl_it = bias.find(3);
+        if (call_it == bias.end() || call_it->second <= 0.0f) {
+            std::cerr << "  expected positive bias for single-token <|tool_call>\n";
+            return false;
+        }
+        if (decl_it == bias.end() || decl_it->second >= 0.0f) {
+            std::cerr << "  expected negative bias for single-token <|tool> declaration echo\n";
+            return false;
+        }
+    }
+
+    {
+        BranchingToolSentinelTokenizer tok;
+        ToolCallConstrainer constrainer;
+        constrainer.init(Config::ModelType::GEMMA4, {{"get_weather", {"location"}, {}, {"location"}}}, &tok);
+
+        const auto& start_bias = constrainer.get_bias();
+        auto start_call_it = start_bias.find(1);
+        if (start_call_it == start_bias.end() || start_call_it->second <= 0.0f) {
+            std::cerr << "  expected positive bias for shared <|tool prefix\n";
+            return false;
+        }
+
+        constrainer.update(1, tok.decode({1}));
+        const auto& branch_bias = constrainer.get_bias();
+        auto call_it = branch_bias.find(2);
+        auto decl_it = branch_bias.find(3);
+        if (call_it == branch_bias.end() || call_it->second <= 0.0f) {
+            std::cerr << "  expected positive bias for <|tool_call> branch\n";
+            return false;
+        }
+        if (decl_it == branch_bias.end() || decl_it->second >= 0.0f) {
+            std::cerr << "  expected negative bias for <|tool> branch\n";
+            return false;
+        }
+    }
+
+    {
+        ToolSentinelTokenizer tok;
+        ToolCallConstrainer constrainer;
+        constrainer.init(Config::ModelType::GEMMA4, {{"get_weather", {"location"}, {}, {"location"}}}, &tok,
+                         false);
+
+        const auto& bias = constrainer.get_bias();
+        if (bias.find(1) != bias.end() && bias.at(1) > 0.0f) {
+            std::cerr << "  optional mode should not force <|tool_call>\n";
+            return false;
+        }
+        auto decl_it = bias.find(3);
+        if (decl_it == bias.end() || decl_it->second >= 0.0f) {
+            std::cerr << "  optional mode should still block single-token <|tool>\n";
+            return false;
+        }
+    }
+
+    {
+        BranchingToolSentinelTokenizer tok;
+        ToolCallConstrainer constrainer;
+        constrainer.init(Config::ModelType::GEMMA4, {{"get_weather", {"location"}, {}, {"location"}}}, &tok,
+                         false);
+
+        const auto& start_bias = constrainer.get_bias();
+        if (start_bias.find(1) != start_bias.end() && start_bias.at(1) > 0.0f) {
+            std::cerr << "  optional mode should not force shared <|tool prefix\n";
+            return false;
+        }
+
+        constrainer.update(1, tok.decode({1}));
+        const auto& branch_bias = constrainer.get_bias();
+        auto call_it = branch_bias.find(2);
+        auto decl_it = branch_bias.find(3);
+        if (call_it == branch_bias.end() || call_it->second <= 0.0f) {
+            std::cerr << "  optional mode should complete a started <|tool_call> branch\n";
+            return false;
+        }
+        if (decl_it == branch_bias.end() || decl_it->second >= 0.0f) {
+            std::cerr << "  optional mode should block a started <|tool> branch\n";
+            return false;
+        }
+    }
+    return true;
+}
+
+static bool has_parsed_function_calls(const Metrics& m) {
+    return m.function_calls != "[]" && m.function_calls.find("\"name\"") != std::string::npos;
+}
+
+static bool has_declaration_echo(const std::string& response) {
+    return response.find("<|tool>declaration:") != std::string::npos ||
+           response.find("<start_function_declaration>declaration:") != std::string::npos;
 }
 
 bool test_tool_call() {
@@ -335,12 +498,16 @@ bool test_tool_call() {
 
     return EngineTestUtils::run_test("TOOL CALL TEST", g_model_path, messages, options_with_force_tools,
         [](int result, const StreamingData&, const std::string& response, const Metrics& m) {
-            bool has_function = response.find("\"function_calls\":[") != std::string::npos;
-            bool has_tool = has_function && response.find("get_weather") != std::string::npos;
+            bool has_function = has_parsed_function_calls(m);
+            bool has_tool = has_function
+                && (m.function_calls.find("\"name\":\"get_weather\"") != std::string::npos
+                    || m.function_calls.find("\"name\": \"get_weather\"") != std::string::npos);
+            bool echoed_declaration = has_declaration_echo(response);
             std::cout << "├─ Function call: " << (has_function ? "YES" : "NO") << "\n"
-                      << "├─ Correct tool: " << (has_tool ? "YES" : "NO") << "\n";
+                      << "├─ Correct tool: " << (has_tool ? "YES" : "NO") << "\n"
+                      << "├─ Declaration echo: " << (echoed_declaration ? "YES" : "NO") << "\n";
             m.print_json();
-            return result > 0 && has_function && has_tool;
+            return result > 0 && has_function && has_tool && !echoed_declaration;
         }, tools, -1, "What's the weather in San Francisco?");
 }
 
@@ -387,17 +554,19 @@ bool test_multiple_tool_call_invocations() {
 
     return EngineTestUtils::run_test("MULTIPLE TOOLS TEST", g_model_path, messages, options_with_force_tools,
         [](int result, const StreamingData&, const std::string& response, const Metrics& m) {
-            bool has_function = response.find("\"function_calls\":[") != std::string::npos;
+            bool has_function = has_parsed_function_calls(m);
             bool has_weather_tool = has_function
-                && (response.find("\"name\":\"get_weather\"") != std::string::npos
-                    || response.find("\"name\": \"get_weather\"") != std::string::npos);
+                && (m.function_calls.find("\"name\":\"get_weather\"") != std::string::npos
+                    || m.function_calls.find("\"name\": \"get_weather\"") != std::string::npos);
             bool has_message_tool = has_function
-                && (response.find("\"name\":\"send_message\"") != std::string::npos
-                    || response.find("\"name\": \"send_message\"") != std::string::npos);
+                && (m.function_calls.find("\"name\":\"send_message\"") != std::string::npos
+                    || m.function_calls.find("\"name\": \"send_message\"") != std::string::npos);
+            bool echoed_declaration = has_declaration_echo(response);
             std::cout << "├─ Function call: " << (has_function ? "YES" : "NO") << "\n"
-                      << "├─ Correct tool: " << (has_weather_tool && has_message_tool ? "YES" : "NO") << "\n";
+                      << "├─ Correct tool: " << (has_weather_tool && has_message_tool ? "YES" : "NO") << "\n"
+                      << "├─ Declaration echo: " << (echoed_declaration ? "YES" : "NO") << "\n";
             m.print_json();
-            return result > 0 && has_function && has_weather_tool && has_message_tool;
+            return result > 0 && has_function && has_weather_tool && has_message_tool && !echoed_declaration;
         }, tools, -1, "Send a message to Bob and get the weather for San Francisco.");
 }
 
@@ -668,6 +837,7 @@ int main() {
     runner.run_test("tool_calls", test_tool_call());
     runner.run_test("tool_multiple_tool_call_invocations", test_multiple_tool_call_invocations());
     runner.run_test("tool_constraint_clear_releases_bias", test_tool_constraint_clear_releases_bias());
+    runner.run_test("tool_constraint_blocks_declaration_echo", test_tool_constraint_blocks_declaration_echo());
     runner.run_test("partition_thinking_response", test_partition_thinking_response());
     runner.run_test("prompt_retains_thinking", test_prompt_gemma4_retains_thinking());
     runner.run_test("complete_thinking_api_clean", test_complete_gemma4_thinking_api_clean());


### PR DESCRIPTION
#Fixes #693

 Changes:
  - Blocks Gemma tool declaration echo paths when tools are present.
  - Preserves optional tool behavior unless force_tools is true.
  - Keeps full grammar forcing for force_tools=true.
  - Tightens LLM tests so empty function_calls no longer pass.

  Validation:
  - git diff --check
  - Local branch-logic simulation passed.
  - Could not run cactus test --suite llm locally because this machine/toolchain is x86 while cactus-kernels requires ARM NEON flags/headers.

  Reviewer request:
  Please run cactus test --suite llm on an ARM/Gemma4 setup and confirm tool cases produce non-empty function_calls and no <|tool>declaration: echo."
