### PR TITLE
fix: resolve Python FFI buffer limits and single-quote escaping in to…

### DIFF
--- a/cactus-engine/src/chat_tools.h
+++ b/cactus-engine/src/chat_tools.h
@@ -177,7 +177,16 @@ inline std::string py_literal_to_json(const std::string& s, size_t& p) {
         char q = c; ++p;
         std::string out = "\"";
         while (p < s.size() && s[p] != q) {
-            if (s[p] == '\\' && p + 1 < s.size()) { out += s[p]; out += s[p + 1]; p += 2; continue; }
+            if (s[p] == '\\' && p + 1 < s.size()) {
+                if (s[p + 1] == '\'') {
+                    out += '\'';
+                } else {
+                    out += s[p];
+                    out += s[p + 1];
+                }
+                p += 2;
+                continue;
+            }
             if (s[p] == '"') out += '\\';
             out += s[p++];
         }

--- a/cactus-engine/tests/test_chat_tools.cpp
+++ b/cactus-engine/tests/test_chat_tools.cpp
@@ -1,0 +1,83 @@
+#include "test_utils.h"
+#include "../src/chat_tools.h"
+#include "picojson.h"
+#include <iostream>
+#include <string>
+#include <vector>
+
+using namespace TestUtils;
+
+static bool test_py_literal_to_json_single_quote() {
+    std::string s = "'hello \\'world\\''";
+    size_t p = 0;
+    std::string json_val = chat_tools::py_literal_to_json(s, p);
+
+    // Expected JSON: "hello 'world'"
+    std::string expected = "\"hello 'world'\"";
+    if (json_val != expected) {
+        std::cerr << "FAIL: expected " << expected << ", got " << json_val << std::endl;
+        return false;
+    }
+
+    // Ensure it parses as valid JSON
+    picojson::value v;
+    std::string err = picojson::parse(v, json_val);
+    if (!err.empty()) {
+        std::cerr << "FAIL: picojson parse error: " << err << std::endl;
+        return false;
+    }
+    if (!v.is<std::string>() || v.get<std::string>() != "hello 'world'") {
+        std::cerr << "FAIL: parsed string value mismatch: " << v.to_str() << std::endl;
+        return false;
+    }
+
+    return true;
+}
+
+static bool test_extract_lfm2_tool_calls_single_quote() {
+    std::string text = "<|tool_call_start|>my_tool(param='hello \\'world\\'', num=42)<|tool_call_end|>";
+    std::vector<std::string> calls;
+    chat_tools::extract_lfm2_tool_calls(text, calls);
+
+    if (calls.size() != 1) {
+        std::cerr << "FAIL: expected 1 call, got " << calls.size() << std::endl;
+        return false;
+    }
+
+    std::string call_json = calls[0];
+    // Expected: {"name": "my_tool", "arguments": {"param": "hello 'world'", "num": 42}}
+    picojson::value v;
+    std::string err = picojson::parse(v, call_json);
+    if (!err.empty()) {
+        std::cerr << "FAIL: extracted call is invalid JSON: " << err << " (JSON: " << call_json << ")" << std::endl;
+        return false;
+    }
+
+    if (!v.is<picojson::object>()) {
+        std::cerr << "FAIL: expected JSON object" << std::endl;
+        return false;
+    }
+
+    const auto& obj = v.get<picojson::object>();
+    if (obj.at("name").get<std::string>() != "my_tool") {
+        return false;
+    }
+
+    const auto& args = obj.at("arguments").get<picojson::object>();
+    if (args.at("param").get<std::string>() != "hello 'world'") {
+        return false;
+    }
+    if (args.at("num").get<double>() != 42.0) {
+        return false;
+    }
+
+    return true;
+}
+
+int main() {
+    TestRunner runner("Chat Tools Tests");
+    runner.run_test("py_literal_to_json_single_quote", test_py_literal_to_json_single_quote());
+    runner.run_test("extract_lfm2_tool_calls_single_quote", test_extract_lfm2_tool_calls_single_quote());
+    runner.print_summary();
+    return runner.all_passed() ? 0 : 1;
+}

--- a/python/cactus/bindings/cactus.py
+++ b/python/cactus/bindings/cactus.py
@@ -1231,7 +1231,7 @@ def cactus_rag_query(model, query, top_k=5):
     Returns:
         A dict with ranked results.
     """
-    buf = ctypes.create_string_buffer(65536)
+    buf = ctypes.create_string_buffer(1 << 20)
     rc = _lib.cactus_rag_query(model, _enc(query), buf, len(buf), top_k)
     if rc < 0:
         raise RuntimeError(_err("RAG query failed"))
@@ -1336,7 +1336,7 @@ def cactus_index_query(index, embedding, options=None):
     return {"results": [{"id": int(id_buffer[i]), "score": float(score_buffer[i])} for i in range(n)]}
 
 
-_INDEX_DOC_BUF_SIZE = 4096
+_INDEX_DOC_BUF_SIZE = 65536
 _INDEX_EMB_BUF_SIZE = 4096
 
 


### PR DESCRIPTION
### Description
This Pull Request addresses three issues identified within the Python FFI bindings and tool-calling parameter parsing logic:
1. **JSON Validation for Single-Quoted Parameter Parsing (`chat_tools.h`)**: LiquidAI models (`LFM2`/`LFM2.5`) format tool calls as Python-like arguments (e.g., `my_tool(param='val')`). If a parameter value contains an escaped single quote (`\'`), the parser function `py_literal_to_json` translated it literally as `\'` inside the resulting double-quoted JSON string (producing `"hello \'world\""`). Per RFC 8259, this is an invalid escape sequence. As a result, standard JSON parsers (e.g. C++ `picojson` and python's `json` module) threw syntax errors, aborting tool execution. This has been resolved by unescaping `\'` to `'` in the double-quoted JSON output.

2. **FFI Document Retrieval Buffer Limit (`cactus.py`)**: The vector database supports indexing documents up to 65,535 bytes (`Index::validate_documents`). However, the Python FFI binding `cactus_index_get` used a hardcoded buffer limit `_INDEX_DOC_BUF_SIZE = 4096`. Attempting to retrieve documents exceeding 4KB caused the FFI to return `-1`, raising a `RuntimeError` on the Python side. The buffer limit has been increased to `65536` to safely accommodate the database's actual limit.

3. **RAG Query Buffer Limit (`cactus.py`)**: Increased the query results buffer size in `cactus_rag_query` from 64KB to 1MB to safely support RAG queries that return multiple large snippets.
---
### Verification
* Created a C++ unit test suite at `cactus-engine/tests/test_chat_tools.cpp` to verify that Python-like literals and LFM2 tool calls containing apostrophes are extracted correctly and parsed successfully by `picojson`.
* Verified that the test suite compiles and passes successfully.
Please let me know if you would like any modifications or additions.
 
 ### Fixes #760 
