### PR TITLE
fix(engine): anchor content search to obj_start in parse_messages_json

### DIFF
--- a/cactus-engine/src/utils.h
+++ b/cactus-engine/src/utils.h
@@ -1026,7 +1026,7 @@ inline std::vector<cactus::engine::ChatMessage> parse_messages_json(const std::s
         size_t role_end = json.find('"', role_start);
         msg.role = json.substr(role_start, role_end - role_start);
         
-        size_t content_pos = json.find("\"content\"", role_end);
+        size_t content_pos = json.find("\"content\"", obj_start);
         if (content_pos != std::string::npos && content_pos < obj_end) {
             size_t content_start = json.find('"', content_pos + 9) + 1;
             size_t content_end = content_start;

--- a/cactus-engine/tests/test_parse_messages.cpp
+++ b/cactus-engine/tests/test_parse_messages.cpp
@@ -1,0 +1,57 @@
+#include "../src/utils.h"
+#include "test_utils.h"
+
+bool test_role_first() {
+    std::vector<std::string> images;
+    auto messages = cactus::ffi::parse_messages_json(
+        R"([{"role":"user","content":"hello"}])", images);
+    return messages.size() == 1 && messages[0].role == "user" && messages[0].content == "hello";
+}
+
+bool test_content_first() {
+    std::vector<std::string> images;
+    auto messages = cactus::ffi::parse_messages_json(
+        R"([{"content":"hello","role":"user"}])", images);
+    return messages.size() == 1 && messages[0].role == "user" && messages[0].content == "hello";
+}
+
+bool test_content_first_with_escapes() {
+    std::vector<std::string> images;
+    auto messages = cactus::ffi::parse_messages_json(
+        R"([{"content":"line one\nline \"two\"","role":"user"}])", images);
+    return messages.size() == 1 && messages[0].content == "line one\nline \"two\"";
+}
+
+bool test_mixed_order_multi_message() {
+    std::vector<std::string> images;
+    auto messages = cactus::ffi::parse_messages_json(
+        R"([{"role":"system","content":"be terse"},{"content":"hi there","role":"user"}])", images);
+    return messages.size() == 2
+        && messages[0].role == "system" && messages[0].content == "be terse"
+        && messages[1].role == "user" && messages[1].content == "hi there";
+}
+
+bool test_content_first_with_image_paths() {
+    std::vector<std::string> images;
+    std::vector<std::string> audio;
+    auto messages = cactus::ffi::parse_messages_json(
+        R"([{"content":"describe this","role":"user","images":["a.png"],"audio":["b.wav"]}])",
+        images, &audio);
+    return messages.size() == 1 && messages[0].content == "describe this"
+        && messages[0].images.size() == 1 && images.size() == 1
+        && messages[0].audio.size() == 1 && audio.size() == 1;
+}
+
+int main() {
+    TestUtils::TestRunner runner("Parse Messages Tests");
+
+    runner.run_test("role_first", test_role_first());
+    runner.run_test("content_first", test_content_first());
+    runner.run_test("content_first_with_escapes", test_content_first_with_escapes());
+    runner.run_test("mixed_order_multi_message", test_mixed_order_multi_message());
+    runner.run_test("content_first_with_image_paths", test_content_first_with_image_paths());
+
+    runner.print_summary();
+
+    return runner.all_passed() ? 0 : 1;
+}


### PR DESCRIPTION
Fixes #757.

`parse_messages_json` searches for `"role"` starting at the message object's opening brace, so it finds the role key regardless of where it appears in the object. The search for `"content"`, however, started from the end of the parsed role value instead of the same starting point. When a message object serializes `content` before `role` (legal JSON, since key order isn't semantically significant, and something an unordered-map serializer such as Swift's `JSONSerialization` can produce), the content key sits earlier in the string than the search start, so it's never found within the object's bounds and `msg.content` is silently left empty.

This anchors the `content` search to `obj_start`, matching how `role` and the `images`/`audio` path arrays already search. The existing `content_pos < obj_end` bound is unchanged, so the search still can't cross into a later message object.

Added `cactus-engine/tests/test_parse_messages.cpp`, a standalone suite (no model weights needed) covering role-first order, content-first order, escaped content, mixed ordering across a multi-message array, and content-first with image/audio paths attached. Confirmed the content-first case fails on the unpatched function and passes after the fix.

Built and ran the full `cactus-engine` test component (all 15 targets) on an ARM64 Linux environment. No new failures. Two pre-existing, unrelated issues were investigated and ruled out as caused by this change: `test_index` needs `CACTUS_INDEX_PATH` set when run directly (passes once set); `test_telemetry`'s concurrency race test fails identically on the unpatched tree (confirmed by reverting the fix and rerunning), most likely a timing margin issue under emulation, not related to this diff.