### PR TITLE
build: fail early on unsupported (non-ARM64) targets

### DIFF
--- a/cactus-kernels/CMakeLists.txt
+++ b/cactus-kernels/CMakeLists.txt
@@ -4,6 +4,15 @@ project(CactusKernels LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+if(NOT APPLE AND NOT CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64)$")
+    message(FATAL_ERROR
+        "Cactus targets ARM64 (AArch64) with an ARMv8.2-A baseline (+fp16+simd+dotprod+i8mm): "
+        "Apple Silicon, an ARMv8.2+ Android/Linux device, or a 64-bit Raspberry Pi 5.\n"
+        "Detected CMAKE_SYSTEM_PROCESSOR='${CMAKE_SYSTEM_PROCESSOR}', which is unsupported. "
+        "x86/x86_64 (including WSL2) has no ARM NEON path, and ARMv8.0 CPUs such as the "
+        "Raspberry Pi 4 lack the required instructions. See docs/compatibility.md.")
+endif()
+
 add_library(cactus_kernels STATIC
     src/attention.cpp
     src/attention_hybrid.cpp

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -31,6 +31,19 @@ Runtime v1.15 -> new tag v1.15 (changed!) - must update
 3. Find the latest tag that is ≤ your runtime version
 4. If your local weights use an older tag, re-download them
 
+## Platform Support
+
+Cactus kernels are ARM64-only and are compiled for the **ARMv8.2-A** baseline (`-march=armv8.2-a+fp16+simd+dotprod+i8mm`). The build stops early on unsupported targets instead of failing later with a cryptic `bad value '...' for '-march='` compiler error.
+
+| Platform | Supported | Notes |
+|----------|-----------|-------|
+| Apple Silicon (M-series / A-series) | Yes | Primary target; Metal GPU backend available |
+| ARMv8.2+ Android / Linux (`arm64-v8a`) | Yes | Modern phones, Raspberry Pi 5, NVIDIA Jetson |
+| Raspberry Pi 4 and other ARMv8.0 CPUs | No | Lack FP16 / dotprod / i8mm; binaries hit `Illegal instruction` at runtime |
+| x86 / x86_64 (incl. WSL2, Intel/AMD servers) | No | No ARM NEON kernels |
+
+On an unsupported CPU the CMake configure step aborts with a message pointing here.
+
 ## See Also
 
 - [Cactus Engine API](/docs/cactus_engine.md) — Full inference API reference


### PR DESCRIPTION
Closes #655. Also documents the ARMv8.0 / Raspberry Pi 4 case from #561.

## Problem
`cactus-kernels/CMakeLists.txt` passes `-march=armv8.2-a+fp16+simd+dotprod+i8mm` unconditionally, with no architecture guard, and every kernel `#include <arm_neon.h>`. On x86 toolchains this fails deep in the build with the cryptic:

```
cc1plus: error: bad value armv8.2-a+fp16+simd+dotprod+i8mm for -march= switch
```

(reported on WSL2/x86_64 in #655), and on ARMv8.0 CPUs such as the Raspberry Pi 4 the binary compiles but hits `Illegal instruction` at runtime (#561), because the engine is ARM64 v8.2+ by design.

## Change
- **CMake guard** (`cactus-kernels/CMakeLists.txt`): abort at configure time on non-AArch64 targets with an actionable message that names the requirement and points to the docs, instead of failing later with an opaque compiler error. No-op on supported targets.
- **Docs** (`docs/compatibility.md`): add a Platform Support matrix (Apple Silicon / ARMv8.2+ Android-Linux supported; ARMv8.0 e.g. Pi 4 and x86 unsupported).

No behavior change on supported platforms; nothing in the build graph changes there.

## Verified
- `cmake -S cactus-kernels -B build` on Apple Silicon (arm64): configures clean, guard is a no-op.
- `cmake ... -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=x86_64`: aborts at configure with the new message (reproduces #655 turning into a clear error).

## Scope / follow-up
Kept intentionally small and behavior-preserving. Fully resolving #561 (running on ARMv8.0) needs a runtime CPU-feature check to turn the Pi-4 SIGILL into a clean error, or an ARMv8.0 kernel variant — happy to follow up separately; `cactus-kernels/src/threading.h` already has `cpu_has_i8mm()` as a starting point.