### PR TITLE
fix(engine): drop cactus_graph.h include so the shipped framework header compiles

### DIFF
--- a/cactus-engine/cactus_engine.h
+++ b/cactus-engine/cactus_engine.h
@@ -1,8 +1,6 @@
 #ifndef CACTUS_FFI_H
 #define CACTUS_FFI_H
 
-#include "cactus_graph.h"
-
 #include <stddef.h>
 #include <stdint.h>
 #include <stdbool.h>


### PR DESCRIPTION
## What

Removes the `#include "cactus_graph.h"` line from `cactus-engine/cactus_engine.h`.

## Why

`apple/build.sh` copies `cactus_engine.h` as the only header inside the iOS/macOS xcframeworks (`cp_headers`, line 37), and the module map exports just that header. Since its first include is `cactus_graph.h`, which is not bundled, `import cactus` fails out of the box:

```
fatal error: 'cactus_graph.h' file not found
could not build module 'cactus'
```

Nothing in the C FFI surface of the header references graph types, so the include is unnecessary for consumers. On the engine side every file that uses graph symbols already includes `cactus_graph.h` directly (`src/engine.h:14`, `src/log.cpp:2`, `src/model.cpp:2`, `tests/test_kv_compress.cpp:4`), so nothing relied on the transitive include.

Closes #771

## Gates

- `./venv/bin/cactus test --component engine` on Apple Silicon (M-series): all tests pass
- Header now compiles standalone: `clang -fsyntax-only -x c -std=c11` and `-x c++ -std=c++20` both clean
- 2-line deletion, no behavior change for in-repo builds