### PR TITLE
Include <iomanip> directly for std::setw/setfill/setprecision (fixes build on libstdc++/Pi)

### DIFF
--- a/cactus-engine/src/complete.cpp
+++ b/cactus-engine/src/complete.cpp
@@ -13,6 +13,7 @@
 #include <cstdint>
 #include <cstring>
 #include <future>
+#include <iomanip>
 #include <iostream>
 #include <memory>
 #include <sstream>

--- a/cactus-engine/src/telemetry_impl.cpp
+++ b/cactus-engine/src/telemetry_impl.cpp
@@ -8,6 +8,7 @@
 #include <ctime>
 #include <random>
 #include <sstream>
+#include <iomanip>
 #include <string>
 #include <vector>
 #include <deque>

--- a/cactus-engine/tests/test_benchmark.cpp
+++ b/cactus-engine/tests/test_benchmark.cpp
@@ -1,5 +1,6 @@
 #include "test_utils.h"
 #include <cstdlib>
+#include <iomanip>
 #include <iostream>
 #include <numeric>
 #include <string>

--- a/cactus-engine/tests/test_embed.cpp
+++ b/cactus-engine/tests/test_embed.cpp
@@ -1,5 +1,6 @@
 #include "test_utils.h"
 #include <cstdlib>
+#include <iomanip>
 #include <iostream>
 
 using namespace EngineTestUtils;

--- a/cactus-engine/tests/test_llm.cpp
+++ b/cactus-engine/tests/test_llm.cpp
@@ -3,6 +3,7 @@
 #include <fstream>
 #include <cstdlib>
 #include <cstdio>
+#include <iomanip>
 #include <iostream>
 
 #if __has_include(<curl/curl.h>)

--- a/cactus-engine/tests/test_utils.cpp
+++ b/cactus-engine/tests/test_utils.cpp
@@ -2,6 +2,7 @@
 #include <sstream>
 #include <cstdlib>
 #include <cstring>
+#include <iomanip>
 
 namespace TestUtils {
 

--- a/cactus-engine/tests/test_vlm.cpp
+++ b/cactus-engine/tests/test_vlm.cpp
@@ -1,5 +1,6 @@
 #include "test_utils.h"
 #include <cstdlib>
+#include <iomanip>
 #include <iostream>
 
 using namespace EngineTestUtils;

--- a/cactus-graph/tests/test_nn.cpp
+++ b/cactus-graph/tests/test_nn.cpp
@@ -3,6 +3,7 @@
 #include <cmath>
 #include <filesystem>
 #include <fstream>
+#include <iomanip>
 #include <iostream>
 #include <random>
 

--- a/cactus-kernels/tests/test_attention.cpp
+++ b/cactus-kernels/tests/test_attention.cpp
@@ -1,6 +1,7 @@
 #include "test_utils.h"
 #include <vector>
 #include <cmath>
+#include <iomanip>
 
 using namespace TestUtils;
 

--- a/cactus-kernels/tests/test_conv.cpp
+++ b/cactus-kernels/tests/test_conv.cpp
@@ -1,6 +1,7 @@
 #include "test_utils.h"
 #include <vector>
 #include <cmath>
+#include <iomanip>
 
 using namespace TestUtils;
 

--- a/cactus-kernels/tests/test_dsp.cpp
+++ b/cactus-kernels/tests/test_dsp.cpp
@@ -2,6 +2,7 @@
 #include <vector>
 #include <cmath>
 #include <cstring>
+#include <iomanip>
 
 using namespace TestUtils;
 

--- a/cactus-kernels/tests/test_elementwise.cpp
+++ b/cactus-kernels/tests/test_elementwise.cpp
@@ -1,6 +1,7 @@
 #include "test_utils.h"
 #include <vector>
 #include <cmath>
+#include <iomanip>
 
 using namespace TestUtils;
 

--- a/cactus-kernels/tests/test_matmul.cpp
+++ b/cactus-kernels/tests/test_matmul.cpp
@@ -3,6 +3,7 @@
 #include <cmath>
 #include <cstring>
 #include <random>
+#include <iomanip>
 
 using namespace TestUtils;
 

--- a/cactus-kernels/tests/test_quant.cpp
+++ b/cactus-kernels/tests/test_quant.cpp
@@ -1,6 +1,7 @@
 #include "test_utils.h"
 #include <vector>
 #include <cmath>
+#include <iomanip>
 
 using namespace TestUtils;
 

--- a/cactus-kernels/tests/test_reduce.cpp
+++ b/cactus-kernels/tests/test_reduce.cpp
@@ -1,6 +1,7 @@
 #include "test_utils.h"
 #include <vector>
 #include <cmath>
+#include <iomanip>
 
 using namespace TestUtils;
 


### PR DESCRIPTION
Fixes #783 — see the issue for the problem, the full error, root cause, and scope analysis.

## Summary

Adds a direct `#include <iomanip>` to every translation unit that uses `std::setw` / `std::setfill` / `std::setprecision` without one. **Headers only — no behavioral change.** One line per file; diff is +15 / −0.

## Changes

**Production sources** (compiled into `cactus_engine`):
- `cactus-engine/src/telemetry_impl.cpp` ← the actual build failure
- `cactus-engine/src/complete.cpp` (was compiling only via a transitive include through `utils.h`)

**Tests** (were compiling only via their `test_utils.h`):
- `cactus-engine/tests/{test_llm,test_vlm,test_utils,test_embed,test_benchmark}.cpp`
- `cactus-kernels/tests/{test_attention,test_matmul,test_conv,test_elementwise,test_reduce,test_quant,test_dsp}.cpp`
- `cactus-graph/tests/test_nn.cpp`

Files that already include `<iomanip>` directly (`execute.cpp`, the three `test_utils.h`, `utils.h`, …) are untouched.

## Scope choice

The one-line fix to `telemetry_impl.cpp` alone unblocks the build; the other 14 files share the same latent defect (relying on a transitive include from `utils.h` / `test_utils.h`), so this makes each TU directly include what it uses. Happy to trim to just `telemetry_impl.cpp` (or the two production sources) if a tighter scope is preferred.

## Validation

**On the reported environment** — Raspberry Pi (`aarch64`), GCC 12.2.0 / libstdc++ (Debian 12), upstream tree at `c90a1afa` (this PR's base):
- `#include <sstream>` + `std::setw`/`std::setfill` → `g++ -std=c++20` fails with `'setw' is not a member of 'std'` (reproduces #783 on the exact toolchain).
- Adding `#include <iomanip>` → compiles and links clean (exit 0).

**Local (macOS/clang/libc++):** `<iomanip>` resolves `std::setw`/`std::setfill`/`std::hex` under `-std=c++20 -Wall -Werror`; `<sstream>` alone does **not** provide `std::setw` — the gap is real even on libc++, which is why macOS CI never caught it.

**CI:** the `Build` workflow (`cactus-engine/**` trigger) and `DCO Check` run on this PR.

## DCO

This contribution complies with the Developer Certificate of Origin.

Signed-off-by: Nitish Agarwal <1592163+nitishagar@users.noreply.github.com>
