### PR TITLE
Ignore generated mobile archives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@
 
 apple/build-*/
 apple/*.xcframework
+**/jniLibs.zip
+**/*.xcframework.zip
 
 .claude
 .vscode


### PR DESCRIPTION
Closes #786.

This adds narrow ignore rules for generated Android `jniLibs.zip` and Apple `*.xcframework.zip` archives so they are not accidentally committed again.

The existing large blobs remain in Git history and require a separate maintainer-coordinated history rewrite to reduce full clone size.

Testing:
- `git check-ignore -v --no-index` for the previous Flutter and cactus-flutter archive paths
- `git diff --check`