### PR TITLE
fix(graph): deduplicate shared mmap weight files across component graphs

### DIFF
--- a/cactus-graph/cactus_graph.h
+++ b/cactus-graph/cactus_graph.h
@@ -864,7 +864,7 @@ private:
     size_t attach_conv_bias(size_t node, size_t bias, size_t expected_size, const char* op_name);
     static CactusGraph from_serialized(const GraphFile::SerializedGraph& serialized);
     size_t next_node_id_;
-    std::vector<std::unique_ptr<GraphFile::MappedFile>> mapped_files_;
+    std::vector<std::shared_ptr<GraphFile::MappedFile>> mapped_files_;
     std::unordered_map<std::string, size_t> weight_cache_;
     std::unordered_map<size_t, size_t> node_to_mapped_file_;
     std::vector<DebugNodeEntry> debug_nodes_;
@@ -918,6 +918,17 @@ namespace GraphFile {
     SerializedGraph load_graph(const std::string& filename);
     void save_graph(const CactusGraph& graph, const std::string& filename);
     void save_node(CactusGraph& graph, size_t node_id, const std::string& filename);
+
+    class MappedFile;
+
+    class MappedFileRegistry {
+    public:
+        static std::shared_ptr<MappedFile> get_or_load(const std::string& filename);
+        static void clear();
+    private:
+        static std::mutex mutex_;
+        static std::unordered_map<std::string, std::weak_ptr<MappedFile>> cache_;
+    };
 
     class MappedFile {
     public:

--- a/cactus-graph/src/io.cpp
+++ b/cactus-graph/src/io.cpp
@@ -437,7 +437,7 @@ CactusGraph CactusGraph::load(const std::string& path) {
 
 size_t CactusGraph::mmap_embeddings(const std::string& filename) {
     const std::string resolved_filename = resolve_quantized_weight_file(filename);
-    auto mapped_file = std::make_unique<GraphFile::MappedFile>(resolved_filename);
+    auto mapped_file = GraphFile::MappedFileRegistry::get_or_load(resolved_filename);
 
     const auto& shape = mapped_file->shape();
     if (shape.size() != 2) {
@@ -492,9 +492,9 @@ size_t CactusGraph::mmap_embeddings(const std::string& filename) {
     }
 
     size_t file_idx = mapped_files_.size();
-    mapped_files_.push_back(std::move(mapped_file));
+    mapped_files_.push_back(mapped_file);
     node_to_mapped_file_[node_id] = file_idx;
-    weight_cache_[filename] = node_id;
+    weight_cache_[resolved_filename] = node_id;
     return node_id;
 }
 
@@ -505,7 +505,7 @@ size_t CactusGraph::mmap_weights(const std::string& filename) {
         return it->second;
     }
 
-    auto mapped_file = std::make_unique<GraphFile::MappedFile>(resolved_filename);
+    auto mapped_file = GraphFile::MappedFileRegistry::get_or_load(resolved_filename);
 
     const auto& shape = mapped_file->shape();
     Precision precision = mapped_file->precision();
@@ -553,7 +553,7 @@ size_t CactusGraph::mmap_weights(const std::string& filename) {
     }
 
     size_t file_idx = mapped_files_.size();
-    mapped_files_.push_back(std::move(mapped_file));
+    mapped_files_.push_back(mapped_file);
     node_to_mapped_file_[node_id] = file_idx;
     weight_cache_[resolved_filename] = node_id;
     return node_id;
@@ -571,7 +571,7 @@ void CactusGraph::bind_mmap_weights(size_t node_id, const std::string& filename)
         throw std::invalid_argument("Can only bind mmap weights to input nodes");
     }
 
-    auto mapped_file = std::make_unique<GraphFile::MappedFile>(resolved_filename);
+    auto mapped_file = GraphFile::MappedFileRegistry::get_or_load(resolved_filename);
     const auto& shape = mapped_file->shape();
     Precision precision = mapped_file->precision();
     auto& buffer = node.output_buffer;
@@ -640,7 +640,7 @@ void CactusGraph::bind_mmap_weights(size_t node_id, const std::string& filename)
     }
 
     size_t file_idx = mapped_files_.size();
-    mapped_files_.push_back(std::move(mapped_file));
+    mapped_files_.push_back(mapped_file);
     node_to_mapped_file_[node_id] = file_idx;
     weight_cache_[resolved_filename] = node_id;
 }
@@ -666,7 +666,7 @@ void CactusGraph::release_all_weight_pages() {
 }
 
 size_t CactusGraph::embedding(const std::string& filename, size_t indices, ComputeBackend backend) {
-    auto mapped_file = std::make_unique<GraphFile::MappedFile>(filename);
+    auto mapped_file = GraphFile::MappedFileRegistry::get_or_load(filename);
 
     const auto& shape = mapped_file->shape();
     if (shape.size() != 2) {
@@ -677,7 +677,7 @@ size_t CactusGraph::embedding(const std::string& filename, size_t indices, Compu
     size_t embeddings_node = input(shape, precision);
     set_external_input(embeddings_node, const_cast<void*>(mapped_file->data()), precision);
 
-    mapped_files_.push_back(std::move(mapped_file));
+    mapped_files_.push_back(mapped_file);
 
     const auto& idx_shape = get_output_buffer(indices).shape;
     std::vector<size_t> output_shape = idx_shape;
@@ -893,6 +893,45 @@ void save_node(CactusGraph& graph, size_t node_id, const std::string& filename) 
         throw std::runtime_error("Error writing node data to file: " + filename);
     }
 }
+
+// MappedFileRegistry implementation
+
+namespace GraphFile {
+
+std::mutex MappedFileRegistry::mutex_;
+std::unordered_map<std::string, std::weak_ptr<MappedFile>> MappedFileRegistry::cache_;
+
+static std::string canonical_file_key(const std::string& filename) {
+    std::error_code ec;
+    auto abs_path = std::filesystem::absolute(filename, ec);
+    if (!ec) {
+        auto can_path = std::filesystem::canonical(abs_path, ec);
+        if (!ec) return can_path.string();
+        return abs_path.lexically_normal().string();
+    }
+    return filename;
+}
+
+std::shared_ptr<MappedFile> MappedFileRegistry::get_or_load(const std::string& filename) {
+    std::string key = canonical_file_key(filename);
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = cache_.find(key);
+    if (it != cache_.end()) {
+        if (auto sp = it->second.lock()) {
+            return sp;
+        }
+    }
+    auto sp = std::make_shared<MappedFile>(filename);
+    cache_[key] = sp;
+    return sp;
+}
+
+void MappedFileRegistry::clear() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    cache_.clear();
+}
+
+} // namespace GraphFile
 
 // MappedFile implementation
 

--- a/cactus-graph/tests/test_io.cpp
+++ b/cactus-graph/tests/test_io.cpp
@@ -453,6 +453,46 @@ bool test_save_load_preserves_kv_cache_num_slots() {
     }
 }
 
+bool test_shared_mmap_weights_dedup() {
+    try {
+        std::string filename = "test_shared_mmap_dedup.bin";
+        {
+            CactusGraph graph;
+            size_t in_node = graph.input({2, 4}, Precision::FP16);
+            std::vector<__fp16> data = {1, 2, 3, 4, 5, 6, 7, 8};
+            graph.set_input(in_node, data.data(), Precision::FP16);
+            graph.execute();
+            GraphFile::save_node(graph, in_node, filename);
+        }
+
+        void* ptr1 = nullptr;
+        void* ptr2 = nullptr;
+
+        {
+            CactusGraph graph1;
+            size_t id1 = graph1.mmap_weights(filename);
+            graph1.execute();
+            ptr1 = graph1.get_output(id1);
+
+            CactusGraph graph2;
+            size_t id2 = graph2.mmap_weights(filename);
+            graph2.execute();
+            ptr2 = graph2.get_output(id2);
+
+            if (ptr1 == nullptr || ptr2 == nullptr || ptr1 != ptr2) {
+                std::remove(filename.c_str());
+                return false;
+            }
+        }
+
+        std::remove(filename.c_str());
+        return true;
+    } catch (const std::exception& e) {
+        std::cout << "[shared_mmap_weights_dedup] exception: " << e.what() << std::endl;
+        return false;
+    }
+}
+
 bool run_benchmarks() {
     const int ITERS = 100;
     const std::string temp_file = "bench_io_50nodes.cg";
@@ -517,6 +557,7 @@ int main() {
                     test_save_load_preserves_recurrent_cache_persistence());
     runner.run_test("Save/Load Preserves KV Cache Num Slots",
                     test_save_load_preserves_kv_cache_num_slots());
+    runner.run_test("Shared Mmap Weights Deduplication", test_shared_mmap_weights_dedup());
     runner.print_benchmarks_header();
     runner.run_bench("benchmarks", run_benchmarks());
     runner.print_summary();


### PR DESCRIPTION
## Problem
When loading models composed of multiple component graphs (e.g. `lm_encoder`, `lm_encoder_text_chunk`, `lm_encoder_step` for models like `gemma-4-e2b-it`), shared weight files like `embed_tokens_per_layer.weights` are bound by multiple components.

Previously, `weight_cache_` was isolated to each individual `CactusGraph` instance. As a result, each component graph created its own `MappedFile` object and issued an independent `mmap()` system call for shared weights. 

On operating systems with per-process virtual address space / mapped-memory ceilings (such as iOS's ~6.5 GiB limit), repeatedly mapping a 1.13 GiB weight file 3+ times alongside other weights exhausts the process address space budget. This caused `mmap` to fail with `ENOMEM` ("Cannot map file") during `cactus_init`.

## Solution
1. **Process-Wide Thread-Safe Mmap Cache (`MappedFileRegistry`)**:
   - Introduced `GraphFile::MappedFileRegistry` in `cactus_graph.h` / `io.cpp`.
   - Maintains a thread-safe registry mapping canonical absolute file paths (`std::filesystem::canonical`) to `std::weak_ptr<GraphFile::MappedFile>`.
   - If a weight file is already memory-mapped by any component graph in the process, subsequent requests share the active `MappedFile` instance instead of creating duplicate virtual memory mappings.

2. **Refactored `CactusGraph` Storage**:
   - Updated `CactusGraph::mapped_files_` from `std::vector<std::unique_ptr<MappedFile>>` to `std::vector<std::shared_ptr<MappedFile>>`.
   - Updated `mmap_embeddings`, `mmap_weights`, `bind_mmap_weights`, and `embedding` to retrieve shared `MappedFile` pointers via `MappedFileRegistry::get_or_load()`.

3. **Automatic Cleanup (RAII)**:
   - When all component graphs referencing a weight file are destroyed or reset, the `std::shared_ptr` reference count reaches zero, triggering `MappedFile::~MappedFile()` (`munmap`), cleanly unmapping the region.

## Verification
- Added `test_shared_mmap_weights_dedup()` unit test in `cactus-graph/tests/test_io.cpp`.
- Verified that multiple `CactusGraph` instances binding the same weight file receive identical mmap buffer pointers (`ptr1 == ptr2`) and release the mapping safely upon graph teardown.