### PR TITLE
fix(graph): remove duplicate `GraphFile` namespace declaration

### DIFF
--- a/cactus-graph/src/io.cpp
+++ b/cactus-graph/src/io.cpp
@@ -319,7 +319,7 @@ namespace {
         }
         return node;
     }
-    
+
 
 } // namespace
 
@@ -896,8 +896,6 @@ void save_node(CactusGraph& graph, size_t node_id, const std::string& filename) 
 
 // MappedFileRegistry implementation
 
-namespace GraphFile {
-
 std::mutex MappedFileRegistry::mutex_;
 std::unordered_map<std::string, std::weak_ptr<MappedFile>> MappedFileRegistry::cache_;
 
@@ -930,8 +928,6 @@ void MappedFileRegistry::clear() {
     std::lock_guard<std::mutex> lock(mutex_);
     cache_.clear();
 }
-
-} // namespace GraphFile
 
 // MappedFile implementation
 


### PR DESCRIPTION
`MappedFileRegistry` is already inside `GraphFile`, so the nested namespace caused its definitions to resolve incorrectly and broke the build.