### PR TITLE
fix: bindings/python: keep non-ASCII text as UTF-8 when marshalling JSON to the engine

### DIFF
--- a/python/cactus/bindings/cactus.py
+++ b/python/cactus/bindings/cactus.py
@@ -992,7 +992,7 @@ def _to_json(obj):
     if obj is None:
         return None
     if isinstance(obj, (dict, list)):
-        return json.dumps(obj).encode()
+        return json.dumps(obj, ensure_ascii=False).encode()
     if isinstance(obj, str):
         return obj.encode()
     return obj


### PR DESCRIPTION
Fixes #803.

## What
One-line change in `python/cactus/bindings/cactus.py::_to_json`: `json.dumps(obj, ensure_ascii=False)`.

## Why
`json.dumps` defaults to `ensure_ascii=True`, rewriting every non-ASCII character as `\uXXXX`. The engine's messages/chat-template path does not decode those escapes, so the model literally receives escape text (~3 tokens per character, semantic noise). Accented Latin degrades; Japanese/Korean become unusable. Full evidence in #803.

## Verification (Python-side change only, no C++ touched)
- `usage.prompt_tokens` vs the HF tokenizer for identical messages+tools, before → after:
  en +42 → +42, fr +58 → +42, ko +87 → +42, ja +124 → +44 (the constant +42 is template overhead).
- 808-row multilingual tool-calling eval on a fine-tuned LFM2.5-230M (CQ4): ja/ko false-action rates 88–100% → 0–16% (bf16 reference level); ko `remember` accuracy 17% → 94%; en/de unchanged.
- The bytes handed to C are still valid UTF-8 (`.encode()` unchanged); `ensure_ascii=False` only stops the escaping.

Complementary hardening (not in this PR, kept lean per CONTRIBUTING): have the C++ messages JSON reader decode `\uXXXX` so non-Python bindings that escape are also safe — `utils.h` already has a correct decoder used elsewhere.