### PR TITLE
fix: engine/bpe: map byte 0xAD like GPT-2 byte-level BPE (not identity)

### DIFF
--- a/cactus-engine/src/bpe.cpp
+++ b/cactus-engine/src/bpe.cpp
@@ -267,6 +267,7 @@ void BPETokenizer::init_byte_mappings() const {
 
 
     for (int i = 161; i <= 255; ++i) {
+        if (i == 173) continue;   // U+00AD is not an identity byte in GPT-2 byte-level BPE
         bytes.push_back(i);
     }
 
@@ -274,6 +275,7 @@ void BPETokenizer::init_byte_mappings() const {
     for (int i = 0; i <= 32; ++i) remaining_bytes.push_back(i);
     remaining_bytes.push_back(127);
     for (int i = 128; i <= 160; ++i) remaining_bytes.push_back(i);
+    remaining_bytes.push_back(173);   // -> U+0143, matching GPT-2 bytes_to_unicode()
 
     int unicode_start = 256;
     for (int byte : remaining_bytes) {
@@ -287,7 +289,7 @@ void BPETokenizer::init_byte_mappings() const {
             std::string unicode_char(1, static_cast<char>(byte));
             byte_to_unicode_[byte] = unicode_char;
             unicode_to_byte_[unicode_char] = byte;
-        } else if (byte >= 161 && byte <= 255) {
+        } else if (byte >= 161 && byte <= 255 && byte != 173) {   // 173 -> remaining branch
             std::string unicode_char;
             unicode_char += static_cast<char>(0xC0 | (byte >> 6));
             unicode_char += static_cast<char>(0x80 | (byte & 0x3F));


### PR DESCRIPTION
Fixes #806. (Found alongside #803, whose Python-binding half is #804.)

## What
`BPETokenizer::init_byte_mappings` treats bytes 161..255 as identity code points. GPT-2 byte-level BPE (`bytes_to_unicode()`) excludes 173 (U+00AD, soft hyphen) from that range and assigns it the next free code point after the other non-printables (U+0143). This PR excludes 173 from **both** the identity byte list and the identity branch of the assignment loop — the branch is selected by byte value, so moving the byte between lists alone has no effect (that was my first, ineffective attempt; documented so nobody repeats it).

## Symptom
Any UTF-8 sequence containing byte 0xAD, e.g. `歯` (E6 AD AF), tokenizes to `<byte> <unk> <byte>` instead of the reference token and decodes to U+FFFD. With LiquidAI/LFM2.5-230M:

| input | before | after (= HF reference) |
|---|---|---|
| `歯` | `[672, 0, 617]` | `[33687]` |
| `歯医者` | `[672, 0, 617, 8773, 4046]` | `[33687, 8773, 4046]` |
| `明日の朝9時に歯医者に電話することを思い出させて` | 17 tokens, 1 unk | 15 tokens, identical to HF |

## Verification
- The resulting 256-entry mapping equals HF `GPT2Tokenizer` `bytes_to_unicode()` byte-for-byte (checked against an exact replica of the loop's control flow).
- Built `apple/build.sh` (device, simulator, macOS); `cactus_tokenize` via the macOS framework gives the table above; a React Native app on the iOS simulator round-trips `歯` intact in tool-call arguments where it previously produced `�`.

No other files touched; no performance impact (mapping is built once).
